### PR TITLE
fix receive_item signal, stock creation, and pharmacy tests

### DIFF
--- a/src/edc_pharmacy/models/signals.py
+++ b/src/edc_pharmacy/models/signals.py
@@ -123,7 +123,11 @@ def receive_on_post_save(sender, instance, raw, created, update_fields, **kwargs
 
 @receiver(post_save, sender=ReceiveItem, dispatch_uid="receive_item_on_post_save")
 def receive_item_on_post_save(sender, instance, raw, created, update_fields, **kwargs):
-    if not raw and update_fields in (["added_to_stock"], ["container_unit_qty"]):
+    if not raw and (
+        created
+        or not update_fields
+        or update_fields in (["added_to_stock"], ["container_unit_qty"])
+    ):
         # update receive item_count after receive_item
         receive_items = ReceiveItem.objects.filter(receive=instance.receive)
         instance.receive.item_count = receive_items.count()
@@ -135,8 +139,14 @@ def receive_item_on_post_save(sender, instance, raw, created, update_fields, **k
                 unit_qty=Sum("unit_qty_received")
             )["unit_qty"]
         ) or Decimal("0.0")
+        instance.order_item.unit_qty_pending = (
+            instance.order_item.unit_qty_ordered
+            - instance.order_item.unit_qty_received
+        )
 
-        instance.order_item.save(update_fields=["unit_qty_received"])
+        instance.order_item.save(
+            update_fields=["unit_qty_received", "unit_qty_pending"]
+        )
 
         update_orderitem_status(order_item=instance.order_item)
 

--- a/src/edc_pharmacy/tests/tests/test_order_and_receive_stock.py
+++ b/src/edc_pharmacy/tests/tests/test_order_and_receive_stock.py
@@ -15,15 +15,10 @@ from django.contrib.sites.models import Site
 from django.db.models import Sum
 from django.test import TestCase, override_settings, tag
 from django.utils import timezone
-from edc_consent import site_consents
-from edc_facility.import_holidays import import_holidays
-from edc_randomization.constants import ACTIVE, PLACEBO
-from edc_randomization.models import RandomizationList
-from edc_sites.site import sites
-from edc_sites.utils import add_or_update_django_sites
-from edc_visit_schedule.site_visit_schedules import site_visit_schedules
 from sequences import get_next_value
 
+from edc_consent import site_consents
+from edc_facility.import_holidays import import_holidays
 from edc_pharmacy.analytics import get_next_scheduled_visit_for_subjects_df
 from edc_pharmacy.exceptions import RepackRequestError
 from edc_pharmacy.models import (
@@ -55,6 +50,11 @@ from edc_pharmacy.utils import (
     get_instock_and_nostock_data,
     process_repack_request,
 )
+from edc_randomization.constants import ACTIVE, PLACEBO
+from edc_randomization.models import RandomizationList
+from edc_sites.site import sites
+from edc_sites.utils import add_or_update_django_sites
+from edc_visit_schedule.site_visit_schedules import site_visit_schedules
 
 utc_tz = ZoneInfo("UTC")
 
@@ -173,6 +173,7 @@ class TestOrderReceive(TestCase):
         self.assertEqual(OrderItem.objects.all().count(), 20)
         self.assertEqual(order.item_count, 20)
 
+    @tag("20")
     def test_receive_ordered_items(self):
         container_units, _ = ContainerUnits.objects.get_or_create(
             name="tablet", plural_name="tablets"
@@ -237,6 +238,7 @@ class TestOrderReceive(TestCase):
             2000,
         )
 
+    @tag("20")
     def test_receive_ordered_items2(self):
         """Test receive where order product unit (e.g. Tablet) is not
         the same as received product unit (Bottle of 100 tablets).
@@ -374,6 +376,7 @@ class TestOrderReceive(TestCase):
         receive.save()
         return receive
 
+    @tag("20")
     def test_delete_receive_item(self):
         # confirm deleting stock, resave received items recreates
         self.order_and_receive()
@@ -430,6 +433,7 @@ class TestOrderReceive(TestCase):
         )
         return container_128
 
+    @tag("20")
     def test_repack(self):
         """Test repackage two bottles of 50000 into bottles of 128."""
         # create order of 50000 for each arm

--- a/src/edc_pharmacy/utils/create_new_stock_on_receive.py
+++ b/src/edc_pharmacy/utils/create_new_stock_on_receive.py
@@ -7,19 +7,19 @@ def create_new_stock_on_receive(receive_item_pk: UUID = None):
     receive_item_model_cls = django_apps.get_model("edc_pharmacy.receiveitem")
     stock_model_cls = django_apps.get_model("edc_pharmacy.stock")
     receive_item = receive_item_model_cls.objects.get(pk=receive_item_pk)
-    if (
-        create_count := (
-            receive_item.item_qty_received
-            - stock_model_cls.objects.filter(receive_item_id=receive_item.id).count()
-        )
-        > 0
-    ):
+    create_count = (
+        receive_item.item_qty_received
+        - stock_model_cls.objects.filter(receive_item_id=receive_item.id).count()
+    )
+    if create_count > 0:
         for _ in range(0, create_count):
             stock_model_cls.objects.create(
                 receive_item_id=receive_item.id,
                 qty_in=1,
                 qty_out=0,
                 qty=1,
+                container_unit_qty=receive_item.container_unit_qty,
+                unit_qty_in=receive_item.container_unit_qty,
                 product_id=receive_item.order_item.product.id,
                 container_id=receive_item.container.id,
                 location_id=receive_item.receive.location.id,


### PR DESCRIPTION
Three bugs fixed:

1. receive_item_on_post_save signal condition was too restrictive, only firing on update_fields=["added_to_stock"] or ["container_unit_qty"]. Now also fires on created and on regular save (not update_fields).

2. create_new_stock_on_receive had a walrus operator precedence bug: create_count was assigned True/False instead of the integer difference, so only 1 stock entry was created per ReceiveItem regardless of item_qty_received.

3. create_new_stock_on_receive was not setting container_unit_qty or unit_qty_in on Stock entries.

Also recalculate unit_qty_pending in receive_item signal alongside unit_qty_received.