### PR TITLE
update comparison list of codenames, expect syscolumns from model_to_dataframe

### DIFF
--- a/src/edc_model_to_dataframe/tests/tests/test_to_df.py
+++ b/src/edc_model_to_dataframe/tests/tests/test_to_df.py
@@ -71,14 +71,14 @@ class TestExport(TestCase):
         m = ModelToDataframe(queryset=CrfFour.objects.all())
         self.assertEqual(len(m.dataframe.index), 4)
 
+    @tag("22")
     def test_columns(self):
         model = "clinicedc_tests.crffour"
 
         fields = [f.attname for f in django_apps.get_model(model)._meta.get_fields()]
         fields.sort()
 
-        # class drops system columns by default
-        m = ModelToDataframe(model=model)
+        m = ModelToDataframe(model=model, drop_sys_columns=True)
         for f in SYSTEM_COLUMNS:
             self.assertNotIn(f, m.dataframe.columns)
 

--- a/src/edc_qareports/tests/tests/test_qa.py
+++ b/src/edc_qareports/tests/tests/test_qa.py
@@ -47,22 +47,26 @@ class TestQA(TestCase):
         )
         self.subject_identifier = consent.subject_identifier
 
+    @tag("22")
     def test_codenames(self):
         """Assert default codenames"""
-        codenames = get_app_codenames("edc_qareports")
+        codenames = [
+            x for x in get_app_codenames("edc_qareports") if "edcpermissions" not in x
+        ]
         codenames.sort()
         expected_codenames = [
-            "edc_qareports.add_edcpermissions",
             "edc_qareports.add_note",
-            "edc_qareports.change_edcpermissions",
             "edc_qareports.change_note",
-            "edc_qareports.delete_edcpermissions",
             "edc_qareports.delete_note",
-            "edc_qareports.view_edcpermissions",
             "edc_qareports.view_note",
+            "edc_qareports.view_historicalnote",
+            # "edc_qareports.viewallsites_note",
             "edc_qareports.view_qareportlog",
+            # "edc_qareports.viewallsites_qareportlog",
             "edc_qareports.view_qareportlogsummary",
+            # "edc_qareports.viewallsites_qareportlogsummary",
         ]
+        expected_codenames.sort()
         self.assertEqual(codenames, expected_codenames)
 
     def test_crfcase_invalid(self):


### PR DESCRIPTION
* update comparison list of codenames returned by get_app_codenames
* fix test - model_to_dataframe now includes SYSCOLUMNS by default