### PR TITLE
fix system check to detect users with empty name or email

### DIFF
--- a/src/edc_notification/system_checks.py
+++ b/src/edc_notification/system_checks.py
@@ -22,8 +22,11 @@ def edc_notification_check(app_configs, **kwargs):
             users = get_user_model().objects.filter(
                 (
                     Q(first_name__isnull=True)
+                    | Q(first_name="")
                     | Q(last_name__isnull=True)
+                    | Q(last_name="")
                     | Q(email__isnull=True)
+                    | Q(email="")
                 ),
                 is_active=True,
                 is_staff=True,


### PR DESCRIPTION
Django User model CharField fields store "" not NULL, so the __isnull=True checks never matched. Added Q(field="") conditions to properly detect incomplete user accounts.