### PR TITLE
feat(edc_list_data): default ordering on BaseListModelMixin

### DIFF
--- a/src/edc_list_data/model_mixins.py
+++ b/src/edc_list_data/model_mixins.py
@@ -66,6 +66,7 @@ class BaseListModelMixin(models.Model):
 
     class Meta:
         abstract = True
+        ordering = ("display_index", "display_name")
         indexes = (models.Index(fields=["display_index", "display_name"]),)
         default_permissions = ("add", "change", "delete", "view", "export", "import")
 


### PR DESCRIPTION
Add ordering = ("display_index", "display_name") so list model querysets (used by list_data-backed FK dropdowns and radio widgets) render in insertion order by default. Previously there was an index on these columns but no Meta.ordering, so downstream admin forms had to override formfield_for_foreignkey to guarantee a stable order.