### PR TITLE
Resolve AE app label dynamically in tmg_death_listboard template

### DIFF
--- a/src/edc_adverse_event/templates/edc_adverse_event/tmg/tmg_death_listboard.html
+++ b/src/edc_adverse_event/templates/edc_adverse_event/tmg/tmg_death_listboard.html
@@ -1,6 +1,7 @@
 {% extends edc_listboard_template %}
 
 {% load edc_dashboard_extras %}
+{% load edc_adverse_event_extras %}
 {% load tz %}
 {% load static %}
 {% load l10n %}
@@ -57,16 +58,17 @@
                 <BR></small>
         {% endfor %}
     <td>
+        {% has_ae_perm "change_deathreport" as can_change_death_report %}
         <a title="View Death Report"
            href="{% if SITE_ID != result.object.site.id %}#{% else %}{{ result.href }}{% endif %}"
            role="button"
-           class="btn btn-sm btn-{% if  perms.ambition_ae.change_deathreport %}success{% else %}info{% endif %}"
+           class="btn btn-sm btn-{% if can_change_death_report %}success{% else %}info{% endif %}"
            {% if SITE_ID != result.object.site.id %}disabled{% endif %}>
-            {% if  perms.ambition_ae.change_deathreport %}
+            {% if can_change_death_report %}
                 <i class="fas fa-pencil-alt fa-fw"></i>
             {% else %}
                 <i class="fas fa-eye fa-fw"></i>
-            {% endif %}&nbsp;<tt>{{ result.object.identifier }}</tt></span>
+            {% endif %}&nbsp;<tt>{{ result.object.identifier }}</tt>
         </a>
         <small>
             <BR>Died: {{ result.object.death_datetime|date:"SHORT_DATE_FORMAT" }}

--- a/src/edc_adverse_event/templatetags/edc_adverse_event_extras.py
+++ b/src/edc_adverse_event/templatetags/edc_adverse_event_extras.py
@@ -288,6 +288,17 @@ def render_tmg_panel(
 
 
 @register.simple_tag(takes_context=True)
+def has_ae_perm(context, codename: str) -> bool:
+    """Return True if user has ``<ae_app_label>.<codename>``.
+
+    The AE app label is resolved dynamically so downstream apps
+    (effect_ae, meta_ae, ...) don't need to patch this template.
+    """
+    user = context["request"].user
+    return user.has_perm(f"{get_adverse_event_app_label()}.{codename}")
+
+
+@register.simple_tag(takes_context=True)
 def has_perms_for_tmg_role(context):
     has_perms = False
     try:


### PR DESCRIPTION
The tmg_death_listboard.html template hardcoded
`perms.ambition_ae.change_deathreport`, which meant the "change" vs "view" affordance silently broke for any downstream app whose AE app label isn't `ambition_ae` (effect_ae, meta_ae, ...).

Add a `has_ae_perm` simple_tag that resolves the permission using `get_adverse_event_app_label()` at render time, and use it in the template. Also fixes a stray `</span>` with no opening tag.