### PR TITLE
fix: prevent metadata_create() during negative visit_code_sequence re…

### DIFF
--- a/src/edc_appointment/management/commands/fix_negative_visit_code_sequences.py
+++ b/src/edc_appointment/management/commands/fix_negative_visit_code_sequences.py
@@ -1,0 +1,44 @@
+import sys
+
+from django.core.management.base import BaseCommand
+from django.db.models import QuerySet
+
+from edc_metadata.models import CrfMetadata, RequisitionMetadata
+
+
+class Command(BaseCommand):
+    help = (
+        "Delete CrfMetadata and RequisitionMetadata records with negative "
+        "visit_code_sequence values. These are corrupt records created by a bug in "
+        "reset_visit_code_sequence_or_pass() where metadata_create() was called "
+        "while visit_code_sequence was temporarily set to a negative value during "
+        "renumbering. After running this command, run update_metadata to regenerate "
+        "correct metadata for affected subjects."
+    )
+
+    def handle(self, *args, **options):  # noqa: ARG002
+        crf_qs: QuerySet = CrfMetadata.objects.filter(visit_code_sequence__lt=0)
+        req_qs: QuerySet = RequisitionMetadata.objects.filter(visit_code_sequence__lt=0)
+
+        crf_count = crf_qs.count()
+        req_count = req_qs.count()
+
+        if crf_count == 0 and req_count == 0:
+            sys.stdout.write("No corrupt metadata records found. Nothing to do.\n")
+            return
+
+        sys.stdout.write(
+            f"Found {crf_count} CrfMetadata and {req_count} RequisitionMetadata "
+            "records with negative visit_code_sequence.\n"
+        )
+
+        crf_qs.delete()
+        sys.stdout.write(f"Deleted {crf_count} CrfMetadata records.\n")
+
+        req_qs.delete()
+        sys.stdout.write(f"Deleted {req_count} RequisitionMetadata records.\n")
+
+        sys.stdout.write(
+            "Done. Run `update_metadata` to regenerate correct metadata for "
+            "affected subjects.\n"
+        )

--- a/src/edc_appointment/utils.py
+++ b/src/edc_appointment/utils.py
@@ -314,7 +314,8 @@ def reset_visit_code_sequence_or_pass(
 
         with transaction.atomic():
             # set appt and related visit visit_code_sequences to the
-            # negative of the current value
+            # negative of the current value (temporary, to avoid unique
+            # constraint violations while renumbering)
             for obj in get_appointment_model_cls().objects.filter(
                 visit_code_sequence__gt=0, **opts
             ):
@@ -323,7 +324,8 @@ def reset_visit_code_sequence_or_pass(
                 if getattr(obj, "related_visit", None):
                     obj.related_visit.visit_code_sequence = obj.visit_code_sequence
                     obj.related_visit.save_base(update_fields=["visit_code_sequence"])
-                    obj.related_visit.metadata_create()
+                # do NOT call metadata_create() here — visit_code_sequence is
+                # temporarily negative and would create corrupt metadata records
 
             # reset sequence order by appt_datetime
             for index, obj in enumerate(


### PR DESCRIPTION
…numbering

In reset_visit_code_sequence_or_pass(), appointment visit_code_sequence values are temporarily set to negative integers to avoid unique constraint violations while renumbering. Calling metadata_create() during this intermediate step created CrfMetadata and RequisitionMetadata records with negative visit_code_sequence values, which should never occur.

Moved metadata_create() calls out of the negation loop and into the final renumbering loop, where visit_code_sequence values are correct.

Adds fix_negative_visit_code_sequences management command to delete any existing corrupt records. After running it, run update_metadata to regenerate correct metadata for affected subjects.