### PR TITLE
perf: skip redundant SELECT/DELETE queries during full metadata regen

### DIFF
--- a/src/edc_metadata/management/commands/update_metadata.py
+++ b/src/edc_metadata/management/commands/update_metadata.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
     help = "Update metadata and re-run metadatarules"
 
     def handle(self, *args, **options) -> None:  # noqa: ARG002
-        metadata_refresher = MetadataRefresher(verbose=True)
+        metadata_refresher = MetadataRefresher(verbose=True, fresh_create=True)
         sys.stdout.write("Deleting all CrfMetadata...     \r")
         CrfMetadata.objects.all().delete()
         sys.stdout.write("Deleting all CrfMetadata...done.                    \n")

--- a/src/edc_metadata/metadata/metadata.py
+++ b/src/edc_metadata/metadata/metadata.py
@@ -174,11 +174,13 @@ class RequisitionCreator(CrfCreator):
         requisition: Requisition,
         update_keyed: bool,
         related_visit: RelatedVisitModel,
+        fresh_create: bool = False,
     ) -> None:
         super().__init__(
             crf=requisition,
             update_keyed=update_keyed,
             related_visit=related_visit,
+            fresh_create=fresh_create,
         )
         self.panel_name: str = f"{self.requisition.model}.{self.requisition.panel.name}"
 

--- a/src/edc_metadata/metadata/metadata.py
+++ b/src/edc_metadata/metadata/metadata.py
@@ -67,11 +67,13 @@ class CrfCreator(SourceModelMetadataMixin):
         related_visit: RelatedVisitModel,
         update_keyed: bool,
         crf: Crf | Requisition,
+        fresh_create: bool = False,
     ) -> None:
         super().__init__(source_model=crf.model, related_visit=related_visit)
         self._metadata_obj = None
         self.update_keyed = update_keyed
         self.crf = crf
+        self.fresh_create = fresh_create
 
     @property
     def metadata_model_cls(
@@ -100,31 +102,34 @@ class CrfCreator(SourceModelMetadataMixin):
         if not self._metadata_obj:
             metadata_obj = None
             registered = model_cls_registered_with_admin_site(self.source_model_cls)
-            try:
-                metadata_obj = self.metadata_model_cls.objects.get(**self.query_options)
-            except ObjectDoesNotExist:
-                if registered:
-                    opts = dict(
-                        entry_status=(REQUIRED if self.crf.required else NOT_REQUIRED),
-                        show_order=self.crf.show_order,
-                        site=self.related_visit.site,
-                        due_datetime=self.due_datetime,
-                        fill_datetime=self.fill_datetime,
-                        document_user=self.document_user,
-                        document_name=self.document_name,
+            if not self.fresh_create:
+                # normal path: check if record already exists
+                try:
+                    metadata_obj = self.metadata_model_cls.objects.get(**self.query_options)
+                except ObjectDoesNotExist:
+                    pass
+                else:
+                    if not registered:
+                        metadata_obj.delete()
+                        metadata_obj = None
+            if metadata_obj is None and registered:
+                opts = dict(
+                    entry_status=(REQUIRED if self.crf.required else NOT_REQUIRED),
+                    show_order=self.crf.show_order,
+                    site=self.related_visit.site,
+                    due_datetime=self.due_datetime,
+                    fill_datetime=self.fill_datetime,
+                    document_user=self.document_user,
+                    document_name=self.document_name,
+                )
+                opts.update(**self.query_options)
+                try:
+                    with transaction.atomic():
+                        metadata_obj = self.metadata_model_cls.objects.create(**opts)
+                except IntegrityError:
+                    metadata_obj = self.metadata_model_cls.objects.get(
+                        **self.query_options
                     )
-                    opts.update(**self.query_options)
-                    try:
-                        with transaction.atomic():
-                            metadata_obj = self.metadata_model_cls.objects.create(**opts)
-                    except IntegrityError:
-                        metadata_obj = self.metadata_model_cls.objects.get(
-                            **self.query_options
-                        )
-            else:
-                if not registered:
-                    metadata_obj.delete()
-                    metadata_obj = None
             if metadata_obj:
                 metadata_obj = self.update_entry_status_to_default_or_keyed(metadata_obj)
             self._metadata_obj = metadata_obj
@@ -258,27 +263,29 @@ class Creator:
             )
         return RequisitionCollection(*requisitions, name="requisitions")
 
-    def create(self) -> None:
+    def create(self, fresh_create: bool = False) -> None:
         """Creates metadata for all CRFs and requisitions for
         the scheduled or unscheduled visit instance.
         """
         for crf in self.crfs:
-            self.create_crf(crf)
+            self.create_crf(crf, fresh_create=fresh_create)
         for requisition in self.requisitions:
-            self.create_requisition(requisition)
+            self.create_requisition(requisition, fresh_create=fresh_create)
 
-    def create_crf(self, crf) -> CrfMetadata:
+    def create_crf(self, crf, fresh_create: bool = False) -> CrfMetadata:
         return self.crf_creator_cls(
             crf=crf,
             update_keyed=self.update_keyed,
             related_visit=self.related_visit,
+            fresh_create=fresh_create,
         ).create()
 
-    def create_requisition(self, requisition) -> RequisitionMetadata:
+    def create_requisition(self, requisition, fresh_create: bool = False) -> RequisitionMetadata:
         return self.requisition_creator_cls(
             requisition=requisition,
             update_keyed=self.update_keyed,
             related_visit=self.related_visit,
+            fresh_create=fresh_create,
         ).create()
 
 
@@ -331,19 +338,24 @@ class Metadata:
         self.creator = self.creator_cls(related_visit=related_visit, update_keyed=update_keyed)
         self.destroyer = self.destroyer_cls(related_visit=related_visit)
 
-    def prepare(self) -> bool:
+    def prepare(self, fresh_create: bool = False) -> bool:
         """Creates and deletes, or just deletes, metadata, depending
         on the related_visit `reason`.
+
+        Set fresh_create=True when all metadata has already been deleted
+        externally (e.g. during a full regeneration). This skips the
+        Destroyer queries that would otherwise find nothing to delete.
         """
         metadata_exists = False
         if self.reason in self.related_visit.visit_schedule.delete_metadata_on_reasons:
             self.destroyer.delete()
         elif self.reason in self.related_visit.visit_schedule.create_metadata_on_reasons:
-            if self.reason == MISSED_VISIT:
-                self.destroyer.delete(entry_status_not_in=[KEYED])
-            else:
-                self.destroyer.delete(entry_status_not_in=[KEYED, NOT_REQUIRED])
-            self.creator.create()
+            if not fresh_create:
+                if self.reason == MISSED_VISIT:
+                    self.destroyer.delete(entry_status_not_in=[KEYED])
+                else:
+                    self.destroyer.delete(entry_status_not_in=[KEYED, NOT_REQUIRED])
+            self.creator.create(fresh_create=fresh_create)
             metadata_exists = True
         else:
             raise CreatesMetadataError(

--- a/src/edc_metadata/metadata_refresher.py
+++ b/src/edc_metadata/metadata_refresher.py
@@ -150,7 +150,7 @@ class MetadataRefresher:
             f"   - {model_count} post-consent models found for {total} visits ... \n"
         )
         for related_visit in tqdm(related_visits, total=total):
-            related_visit.metadata_create()
+            related_visit.metadata_create(fresh_create=True)
         self._message("    Done.\n")
 
     def validate_metadata_for_all(self):

--- a/src/edc_metadata/metadata_refresher.py
+++ b/src/edc_metadata/metadata_refresher.py
@@ -24,10 +24,11 @@ class MetadataRefresher:
     metadata rules or manual changes to data.
     """
 
-    def __init__(self, verbose: bool | None = None):
+    def __init__(self, verbose: bool | None = None, fresh_create: bool = False):
         self._source_models = []
         self._admin_models = []
         self.verbose = verbose
+        self.fresh_create = fresh_create
 
     def run(self) -> None:
         self._message("Updating metadata ...     \n")
@@ -150,7 +151,7 @@ class MetadataRefresher:
             f"   - {model_count} post-consent models found for {total} visits ... \n"
         )
         for related_visit in tqdm(related_visits, total=total):
-            related_visit.metadata_create(fresh_create=True)
+            related_visit.metadata_create(fresh_create=self.fresh_create)
         self._message("    Done.\n")
 
     def validate_metadata_for_all(self):

--- a/src/edc_metadata/model_mixins/creates/creates_metadata_model_mixin.py
+++ b/src/edc_metadata/model_mixins/creates/creates_metadata_model_mixin.py
@@ -31,10 +31,16 @@ class CreatesMetadataModelMixin(RelatedVisitProtocol, models.Model):
     metadata_destroyer_cls: type[Destroyer] = Destroyer
     metadata_rule_evaluator_cls: type[MetadataRuleEvaluator] = MetadataRuleEvaluator
 
-    def metadata_create(self) -> None:
-        """Creates metadata, called by post_save signal."""
+    def metadata_create(self, fresh_create: bool = False) -> None:
+        """Creates metadata, called by post_save signal.
+
+        Set fresh_create=True when all metadata has already been deleted
+        (e.g. during a full regeneration via update_metadata). This skips
+        the per-CRF SELECT and per-visit DELETE queries that would otherwise
+        always find nothing.
+        """
         metadata = self.metadata_cls(related_visit=self, update_keyed=True)
-        metadata.prepare()
+        metadata.prepare(fresh_create=fresh_create)
 
     def run_metadata_rules(self, allow_create: bool | None = None) -> None:
         """Runs all the metadata rules.


### PR DESCRIPTION
Add a fresh_create=True flag to metadata_create(), Metadata.prepare(), Creator.create(), and CrfCreator so that MetadataRefresher can signal that all metadata has already been deleted externally.

When fresh_create=True:
- Destroyer.delete() is skipped — no metadata exists to delete
- CrfCreator.metadata_obj skips the objects.get() and goes straight to objects.create(), eliminating one wasted SELECT per CRF per visit

For a typical dataset (5,000 visits × 20 CRFs) this removes ~100,000 wasted SELECT queries and ~10,000 wasted DELETE queries during update_metadata runs. All normal (non-regeneration) call sites use the default fresh_create=False and are unaffected.