### PR TITLE
Isolate celery worker and beat per environment in systemd units

### DIFF
--- a/bin/systemd/celery.live.service
+++ b/bin/systemd/celery.live.service
@@ -4,10 +4,10 @@ After=network.target
 
 [Service]
 Type=forking
-User=celery
-Group=celery
+User=live
+Group=live
 EnvironmentFile=/etc/conf.d/celery.live.conf
-WorkingDirectory=/home/live/app/
+WorkingDirectory=/home/live/edc
 ExecStart=/bin/sh -c '${CELERY_BIN} -A ${CELERY_APP} multi start ${CELERYD_NODES} --pidfile=${CELERYD_PID_FILE} --logfile=${CELERYD_LOG_FILE} --loglevel=INFO ${CELERYD_OPTS}'
 Restart=always
 

--- a/bin/systemd/celery.uat.service
+++ b/bin/systemd/celery.uat.service
@@ -1,13 +1,13 @@
 [Unit]
-Description=Celery Service
+Description=Celery Service (UAT)
 After=network.target
 
 [Service]
 Type=forking
-User=celery
-Group=celery
-EnvironmentFile=/etc/conf.d/celery.live.conf
-WorkingDirectory=/home/live/app/
+User=uat
+Group=uat
+EnvironmentFile=/etc/conf.d/celery.uat.conf
+WorkingDirectory=/home/uat/edc
 ExecStart=/bin/sh -c '${CELERY_BIN} -A ${CELERY_APP} multi start ${CELERYD_NODES} --pidfile=${CELERYD_PID_FILE} --logfile=${CELERYD_LOG_FILE} --loglevel=INFO ${CELERYD_OPTS}'
 Restart=always
 

--- a/bin/systemd/celerybeat-uat.service
+++ b/bin/systemd/celerybeat-uat.service
@@ -6,13 +6,15 @@ After=network.target
 
 [Service]
 Type=simple
-User=celery
-Group=celery
-EnvironmentFile=/etc/celery/celery_uat.conf
-WorkingDirectory=/home/celery/working/uat
+User=uat
+Group=uat
+EnvironmentFile=/etc/conf.d/celerybeat.uat.conf
+WorkingDirectory=/home/uat/edc
 ExecStart=/bin/sh -c '${CELERY_BIN} beat  \
   -A ${CELERY_APP} --pidfile=${CELERYBEAT_PID_FILE} \
   --logfile=${CELERYBEAT_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL}'
+Restart=always
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/bin/systemd/celerybeat.service
+++ b/bin/systemd/celerybeat.service
@@ -6,13 +6,15 @@ After=network.target
 
 [Service]
 Type=simple
-User=celery
-Group=celery
-EnvironmentFile=/etc/celery/celery.conf
-WorkingDirectory=/home/celery/working
+User=live
+Group=live
+EnvironmentFile=/etc/conf.d/celerybeat.live.conf
+WorkingDirectory=/home/live/edc
 ExecStart=/bin/sh -c '${CELERY_BIN} beat  \
   -A ${CELERY_APP} --pidfile=${CELERYBEAT_PID_FILE} \
   --logfile=${CELERYBEAT_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL}'
+Restart=always
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/howto/celery.rst
+++ b/docs/howto/celery.rst
@@ -1,13 +1,39 @@
 Celery
 ======
 
-Set up celery to start using systemd
+Set up Celery workers and the Celery beat scheduler to run under systemd,
+with one isolated service instance per environment (``live``, ``uat``,
+``debug``).
 
-See docs at https://docs.celeryq.dev/en/stable/userguide/daemonizing.html#usage-systemd
+See upstream docs:
+https://docs.celeryq.dev/en/stable/userguide/daemonizing.html#usage-systemd
 
-Also, See folder bin for sample systemd service files
+Sample unit files live in ``clinicedc/bin/systemd``:
 
-1. create a celery app per instance (live, uat, debug) in folder ``celery`` under your project edc folder, such as ``meta_edc.celery``.
+- ``celery.live.service`` / ``celery.uat.service`` — workers
+- ``celerybeat.service`` / ``celerybeat-uat.service`` — beat (scheduler)
+
+
+Process isolation
++++++++++++++++++
+
+Each environment runs under its **own** user and group so the UAT worker
+cannot read, write to, or signal live processes (and vice versa).
+
+- ``celery.live.service``     → ``User=live``  / ``Group=live``
+- ``celery.uat.service``      → ``User=uat``   / ``Group=uat``
+- ``celerybeat.service``      → ``User=live``  / ``Group=live``
+- ``celerybeat-uat.service``  → ``User=uat``   / ``Group=uat``
+
+Pid files, log files, and working directories must be owned by the same
+user as the corresponding service, or the unit will fail to start.
+
+
+Celery app module per environment
++++++++++++++++++++++++++++++++++
+
+Create one celery app module per environment under your project's celery
+folder, e.g. ``meta_edc.celery``:
 
 .. code-block:: text
 
@@ -18,26 +44,26 @@ Also, See folder bin for sample systemd service files
                |---uat.py
 
 
-You need to create a systemd EnvironmentFile. Again using ``meta-edc`` project as an example:
+Environment files
++++++++++++++++++
+
+systemd reads environment variables from ``EnvironmentFile=``. Keep
+**worker** and **beat** variables in separate files so the two services
+can be restarted independently and the files can be owned/readable
+separately if needed.
+
+Worker env file — ``/etc/conf.d/celery.live.conf``:
 
 .. code-block:: bash
-
-    # celery.live.conf
 
     # Name of nodes to start
     CELERYD_NODES="w1 w2"
 
-    # Absolute or relative path to the 'celery' command:
-    CELERY_BIN="/home/live/miniconda3/envs/edc/bin/celery"
+    # Absolute path to the 'celery' command inside the project venv
+    CELERY_BIN="/home/live/edc/.venv/bin/celery"
 
     # App instance to use
     CELERY_APP="meta_edc.celery.live:app"
-
-    # Where to chdir at start.
-    CELERYD_CHDIR="/home/live/app/"
-
-    # How to call manage.py
-    CELERYD_MULTI="multi"
 
     # Extra command-line arguments to the worker
     CELERYD_OPTS="--time-limit=300 --concurrency=8"
@@ -45,34 +71,145 @@ You need to create a systemd EnvironmentFile. Again using ``meta-edc`` project a
     # - %n will be replaced with the first part of the nodename.
     # - %I will be replaced with the current child process index
     #   and is important when using the prefork pool to avoid race conditions.
-    CELERYD_PID_FILE="/opt/celery/%n.live.pid"
+    CELERYD_PID_FILE="/var/run/celery/%n.live.pid"
     CELERYD_LOG_FILE="/var/log/celery/%n%I.live.log"
     CELERYD_LOG_LEVEL="INFO"
 
-    CELERYD_USER="celery"
-    CELERYD_GROUP="celery"
+.. note::
 
-The user account celery.
+   ``CELERYD_USER``, ``CELERYD_GROUP``, and ``CELERYD_CHDIR`` are
+   init-script conventions. Under systemd the equivalents are the
+   ``User=``, ``Group=``, and ``WorkingDirectory=`` directives inside
+   the ``.service`` file — do **not** set them in the environment file.
 
-1. Add ``celery`` account to "live" and "uat" groups
-2. for logging or workers, create ``/var/log/celery`` (0755 celery celery)
-3. for the PID file, create ``/opts/celery`` (0755 celery celery)
-
-In settings or your .env file, set ``CELERY_ENABLED=True``.
-
-Install ``celery`` into your env.
+Beat env file — ``/etc/conf.d/celerybeat.live.conf``:
 
 .. code-block:: bash
 
-    pip install -U celery[redis]
+    CELERY_BIN="/home/live/edc/.venv/bin/celery"
+    CELERY_APP="meta_edc.celery.live:app"
 
-Load services
-+++++++++++++
+    CELERYBEAT_PID_FILE="/var/run/celery/celerybeat.live.pid"
+    CELERYBEAT_LOG_FILE="/var/log/celery/celerybeat.live.log"
+    CELERYD_LOG_LEVEL="INFO"
+
+Repeat for UAT with ``uat`` substituted throughout
+(``/etc/conf.d/celery.uat.conf``, ``/etc/conf.d/celerybeat.uat.conf``,
+``CELERY_APP="meta_edc.celery.uat:app"``, etc.).
+
+
+User accounts and file ownership
+++++++++++++++++++++++++++++++++
+
+Each environment has a dedicated system user that owns the venv, code
+checkout, pid files, and log files for that environment:
 
 .. code-block:: bash
 
-	sudo systemctl daemon-reload
-	sudo systemctl enable celery.uat.service
-	sudo systemctl enable celery.live.service
-	sudo systemctl start celery.uat.service
-	sudo systemctl start celery.live.service
+    # pid + log directories
+    sudo install -d -m 0755 -o live -g live /var/run/celery
+    sudo install -d -m 0755 -o live -g live /var/log/celery
+
+    # UAT gets its own paths or a shared directory that both users can
+    # write into (prefer the former for stronger isolation):
+    sudo install -d -m 0755 -o uat -g uat /var/run/celery-uat
+    sudo install -d -m 0755 -o uat -g uat /var/log/celery-uat
+
+Adjust the ``CELERYD_PID_FILE`` / ``CELERYD_LOG_FILE`` /
+``CELERYBEAT_PID_FILE`` / ``CELERYBEAT_LOG_FILE`` paths in the env files
+to match.
+
+.. warning::
+
+   Do **not** grant the ``celery`` user membership in the ``live`` or
+   ``uat`` groups. Each environment runs as its own user; a shared
+   ``celery`` account defeats the isolation described above.
+
+
+Install Celery
+++++++++++++++
+
+Install into the project venv (as the environment's user):
+
+.. code-block:: bash
+
+    uv pip install -U "celery[redis]"
+
+Or (non-uv hosts):
+
+.. code-block:: bash
+
+    pip install -U "celery[redis]"
+
+
+Settings
+++++++++
+
+Enable Celery in settings or the project ``.env`` file:
+
+.. code-block:: bash
+
+    CELERY_ENABLED=True
+
+
+Load and start services
++++++++++++++++++++++++
+
+After copying the ``.service`` files from ``clinicedc/bin/systemd`` into
+``/etc/systemd/system/`` (or symlinking them):
+
+.. code-block:: bash
+
+    sudo systemctl daemon-reload
+
+    sudo systemctl enable celery.live.service celerybeat.service
+    sudo systemctl enable celery.uat.service celerybeat-uat.service
+
+    sudo systemctl start celery.live.service celerybeat.service
+    sudo systemctl start celery.uat.service celerybeat-uat.service
+
+
+Verify
+++++++
+
+.. code-block:: bash
+
+    sudo systemctl status celery.live.service
+    sudo systemctl status celery.uat.service
+    sudo systemctl status celerybeat.service
+    sudo systemctl status celerybeat-uat.service
+
+Tail the logs:
+
+.. code-block:: bash
+
+    sudo journalctl -u celery.uat.service -f
+    sudo tail -f /var/log/celery/w1.uat.log
+    sudo tail -f /var/log/celery/celerybeat.uat.log
+
+
+Restarting after a code deploy
+++++++++++++++++++++++++++++++
+
+After pulling new code or updating dependencies, restart the worker
+(and beat, if periodic tasks changed):
+
+.. code-block:: bash
+
+    sudo systemctl restart celery.uat.service celerybeat-uat.service
+    sudo systemctl restart celery.live.service celerybeat.service
+
+All four units use ``Restart=always`` so systemd will bring them back up
+if they crash. ``celerybeat*.service`` additionally sets ``RestartSec=5s``
+to avoid a tight restart loop if beat is mis-configured.
+
+
+Future: Django Tasks framework
+++++++++++++++++++++++++++++++
+
+Django 6.0 shipped the Tasks framework (DEP 14) but only with inline
+(``immediate``) and ``dummy`` backends — no persistent backend in core.
+Once a persistent/database backend ships in core Django (expected 7.x),
+Celery in clinicedc will be replaced with Django Tasks and these systemd
+units will be retired in favour of a ``manage.py`` worker command. No
+action required until then.


### PR DESCRIPTION
## Summary

- **Fix silent prod risk:** `celery.uat.service` was byte-identical to `celery.live.service` (same `EnvironmentFile=/etc/conf.d/celery.live.conf`, same `WorkingDirectory=/home/live/app/`). The UAT worker was reading live configuration. Now differentiated.
- **Process isolation:** each environment runs as its own system user — `live`/`live` for the live worker + beat, `uat`/`uat` for the UAT worker + beat. The two cannot read, write to, or signal each other's processes.
- **Beat resilience:** `celerybeat.service` and `celerybeat-uat.service` gain `Restart=always` / `RestartSec=5s`. Previously a beat crash would silently halt the scheduler with no restart.
- **Docs rewrite:** `docs/howto/celery.rst` updated to match the new layout — adds a process-isolation section, beat env-file example, verify/log-tail section, restart-after-deploy section. Drops stale `CELERYD_USER`/`CELERYD_GROUP`/`CELERYD_CHDIR` init-script references in favour of the systemd directives.

## Final state of the four units

| Unit | User/Group | WorkingDirectory | EnvironmentFile |
|---|---|---|---|
| `celery.live.service` | `live` | `/home/live/edc` | `/etc/conf.d/celery.live.conf` |
| `celery.uat.service` | `uat` | `/home/uat/edc` | `/etc/conf.d/celery.uat.conf` |
| `celerybeat.service` | `live` | `/home/live/edc` | `/etc/conf.d/celerybeat.live.conf` |
| `celerybeat-uat.service` | `uat` | `/home/uat/edc` | `/etc/conf.d/celerybeat.uat.conf` |

## Host-side prep required before restart

These units reference env files and users that may not yet exist on existing hosts. Before `systemctl daemon-reload` + restart:

- [ ] `live` and `uat` system users + groups exist
- [ ] `/etc/conf.d/celery.live.conf`, `/etc/conf.d/celery.uat.conf`, `/etc/conf.d/celerybeat.live.conf`, `/etc/conf.d/celerybeat.uat.conf` all exist and are readable by the matching user
- [ ] pid/log directories referenced in those env files are writable by the matching user (see `docs/howto/celery.rst` for a worked example)
- [ ] Old `/etc/celery/celery.conf` and `/etc/celery/celery_uat.conf` can be retired once the new units are live and stable

## Test plan

- [ ] On a UAT host: `sudo systemctl daemon-reload && sudo systemctl restart celery.uat.service celerybeat-uat.service`
- [ ] `sudo systemctl status celery.uat.service celerybeat-uat.service` — both active, running as `uat:uat`
- [ ] `ps -u uat | grep celery` — worker + beat both appear
- [ ] `sudo journalctl -u celery.uat.service -n 50` — no permission/file-not-found errors
- [ ] Enqueue a pharmacy repack task from the admin; verify it processes
- [ ] Repeat the same checks on a live host after UAT soak

🤖 Generated with [Claude Code](https://claude.com/claude-code)