### PR TITLE
Fix --site/--country handling in export_models command

### DIFF
--- a/src/edc_export/management/commands/export_models.py
+++ b/src/edc_export/management/commands/export_models.py
@@ -180,7 +180,18 @@ class Command(BaseCommand):
         # build list of site ids
         site_ids = self.options["site_ids"] or []
         if site_ids:
-            site_ids = [int(x) for x in self.options["site_ids"].split(",")]
+            try:
+                site_ids = [int(x.strip()) for x in site_ids.split(",") if x.strip()]
+            except ValueError as e:
+                raise CommandError(
+                    f"Invalid --site value. Expected comma-separated integers. "
+                    f"Got `{self.options['site_ids']}`."
+                ) from e
+        if not site_ids and not self.countries:
+            raise CommandError(
+                "Nothing to do. Specify either `--site` or `--country`. "
+                "Use `--country all` to export data for all countries."
+            )
         site_ids = get_site_ids_for_export(site_ids=site_ids, countries=self.countries)
 
         # does user have perms to export these sites?
@@ -211,10 +222,15 @@ class Command(BaseCommand):
     @property
     def countries(self):
         if not self._countries:
-            if not self.options["countries"] or self.options["countries"] == ALL_COUNTRIES:
+            raw = self.options["countries"]
+            if not raw:
+                # --country not specified; caller decides whether that's
+                # valid (paired with --site) or an error.
+                self._countries = []
+            elif raw == ALL_COUNTRIES:
                 self._countries = site_sites.countries
             else:
-                self._countries = self.options["countries"].lower().split(",")
+                self._countries = raw.lower().split(",")
                 for country in self._countries:
                     if country not in site_sites.countries:
                         raise CommandError(f"Invalid country. Got {country}.")

--- a/src/edc_export/tests/tests/test_get_site_ids_for_export.py
+++ b/src/edc_export/tests/tests/test_get_site_ids_for_export.py
@@ -1,0 +1,62 @@
+from clinicedc_tests.sites import all_sites
+from django.core.management import CommandError
+from django.test import TestCase
+from django.test.utils import tag
+
+from edc_export.utils import get_site_ids_for_export
+from edc_sites.site import sites as site_sites
+from edc_sites.utils import add_or_update_django_sites
+
+
+@tag("export")
+class TestGetSiteIdsForExport(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        site_sites._registry = {}
+        site_sites.loaded = False
+        site_sites.register(*all_sites)
+        add_or_update_django_sites()
+
+    def test_site_ids_only_returns_validated_ids(self):
+        """Passing `site_ids` only returns those ids after validating
+        each against sites.Site."""
+        result = get_site_ids_for_export(site_ids=[10, 20, 30], countries=None)
+        self.assertEqual(sorted(result), [10, 20, 30])
+
+    def test_site_ids_does_not_duplicate_on_multiple_ids(self):
+        """Regression: the previous implementation appended to the
+        list being iterated, producing duplicates / infinite loop on
+        multi-id input."""
+        result = get_site_ids_for_export(site_ids=[10, 20, 30, 40, 50], countries=None)
+        self.assertEqual(sorted(result), [10, 20, 30, 40, 50])
+        self.assertEqual(len(result), len(set(result)))
+
+    def test_invalid_site_id_raises(self):
+        with self.assertRaises(CommandError) as ctx:
+            get_site_ids_for_export(site_ids=[99999], countries=None)
+        self.assertIn("Invalid site_id", str(ctx.exception))
+
+    def test_countries_only_returns_sites_in_countries(self):
+        """Passing `countries` only returns all site ids for those
+        countries."""
+        result = get_site_ids_for_export(site_ids=None, countries=["botswana"])
+        # Botswana sites in clinicedc_tests.sites.all_sites are 10, 20, 30, 40, 50.
+        self.assertEqual(sorted(result), [10, 20, 30, 40, 50])
+
+    def test_multiple_countries_unions_site_ids(self):
+        result = get_site_ids_for_export(
+            site_ids=None, countries=["namibia", "uganda"]
+        )
+        # namibia=60, uganda=70
+        self.assertEqual(sorted(result), [60, 70])
+
+    def test_both_specified_raises(self):
+        with self.assertRaises(CommandError) as ctx:
+            get_site_ids_for_export(site_ids=[10], countries=["botswana"])
+        self.assertIn("not both", str(ctx.exception))
+
+    def test_neither_specified_returns_empty(self):
+        """With both inputs empty, returns []. The management command
+        is expected to reject this case before calling the helper."""
+        self.assertEqual(get_site_ids_for_export(site_ids=None, countries=None), [])
+        self.assertEqual(get_site_ids_for_export(site_ids=[], countries=[]), [])

--- a/src/edc_export/utils.py
+++ b/src/edc_export/utils.py
@@ -196,16 +196,31 @@ def get_site_ids_for_export(
     site_ids: list[int] | None,
     countries: list[str] | None,
 ) -> list[int]:
-    """Returns a list of site ids"""
+    """Return a list of site ids based on explicit `site_ids` or `countries`.
+
+    `site_ids` and `countries` are mutually exclusive. The caller must
+    pass exactly one (non-empty). An empty result from both inputs is
+    treated as a programming error here; the management command is
+    expected to reject "neither specified" before calling this function.
+    """
+    site_ids = list(site_ids or [])
+    countries = list(countries or [])
+
     if countries and site_ids:
         raise CommandError("Invalid. Specify `site_ids` or `countries`, not both.")
-    for site_id in site_ids or []:
-        try:
-            obj = django_apps.get_model("sites.site").objects.get(id=int(site_id))
-        except ObjectDoesNotExist as e:
-            raise CommandError(f"Invalid site_id. Got `{site_id}`.") from e
-        else:
-            site_ids.append(obj.id)
-    for country in countries or []:
-        site_ids.extend(list(site_sites.get_by_country(country)))
-    return site_ids
+
+    if site_ids:
+        site_model_cls = django_apps.get_model("sites.site")
+        validated: list[int] = []
+        for site_id in site_ids:
+            try:
+                obj = site_model_cls.objects.get(id=int(site_id))
+            except ObjectDoesNotExist as e:
+                raise CommandError(f"Invalid site_id. Got `{site_id}`.") from e
+            validated.append(obj.id)
+        return validated
+
+    resolved: list[int] = []
+    for country in countries:
+        resolved.extend(list(site_sites.get_by_country(country)))
+    return resolved


### PR DESCRIPTION
## Summary

The `--site` option in the `export_models` management command has been unreachable in all code paths since it was added. `self.countries` defaulted to `site_sites.countries` (all countries) whenever `--country` was not explicitly passed, and `get_site_ids_for_export` raises when both inputs are non-empty — so any invocation of `--site` triggered the mutex error.

Even if that had been reachable, `get_site_ids_for_export` had a second bug: it appended to the `site_ids` list while iterating over it, which would have produced duplicates or an infinite loop on multi-id input.

This PR fixes both.

## New behaviour

| `--site` | `--country` | behavior |
|---|---|---|
| — | — | **CommandError** (be explicit) |
| — | `all` | all sites in all countries |
| — | `tz,ug` | all sites in TZ + UG |
| `1,2,3` | — | validated `[1,2,3]` |
| `1,2,3` | anything | CommandError (mutually exclusive) |

## Changes

- **`countries` property:** "--country not specified" now returns `[]` (was: all countries). `--country all` still returns all countries.
- **`handle()`:** parse `--site` defensively (strip whitespace, skip empty segments, `CommandError` on non-integer rather than unhandled `ValueError` traceback). Raise `CommandError` up front if neither flag is specified.
- **`get_site_ids_for_export()`:** rewritten as two clear branches. Drops the list-mutation-during-iteration bug.

## Tests

- New `test_get_site_ids_for_export.py` covering site-only, country-only, multiple countries, both-specified, invalid id, and a regression test for the infinite-loop bug.
- Full clinicedc test suite (1576 tests) passes.

## Breaking change

Invocations of `export_models` that pass **neither** `--site` nor `--country` (relying on the old "default to all countries" behaviour) now raise `CommandError`. Callers should add `--country all`.

Shell scripts affected:
- `meta-edcx/get_data.sh` (10 invocations)
- `intecomm-edc/get_data.sh` (9 invocations)

The author of this change will update those scripts manually.

## Out of scope

During review we spotted several other issues in `export_models` / `edc_export.utils` that deserve follow-up PRs — including a `EXPORT_PII` group check that uses a string literal instead of the imported constant, silent acceptance of unknown model names, and the lack of audit logging for PII exports. Those are intentionally not addressed here to keep the diff reviewable.

## Test plan

- [x] `test_get_site_ids_for_export.py` (new) passes
- [x] Full clinicedc test suite passes (1576 tests)
- [ ] Manually verify `manage.py export_models --country all -a some_app -p /tmp/x` works
- [ ] Manually verify `manage.py export_models --site 10,20 -a some_app -p /tmp/x` works
- [ ] Manually verify `manage.py export_models -a some_app -p /tmp/x` (neither flag) errors cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)