### PR TITLE
Use EXPORT_PII constant instead of string literal in edc_export.utils

### DIFF
--- a/src/edc_export/utils.py
+++ b/src/edc_export/utils.py
@@ -76,7 +76,7 @@ def raise_if_prohibited_from_export_pii_group(username: str, groups: Iterable) -
                 "groups": format_html(
                     "This user is not allowed to export PII data. You may not add "
                     "this user to the <U>{text}</U> group.",
-                    text="EXPORT_PII",
+                    text=EXPORT_PII,
                 )
             }
         )
@@ -143,7 +143,7 @@ def get_export_user() -> User | AbstractBaseUser:
 def validate_user_perms_or_raise(user: User, decrypt: bool | None) -> None:
     if not user.groups.filter(name=EXPORT).exists():
         raise CommandError("You are not authorized to export data.")
-    if decrypt and not user.groups.filter(name="EXPORT_PII").exists():
+    if decrypt and not user.groups.filter(name=EXPORT_PII).exists():
         raise CommandError("You are not authorized to export sensitive data.")
 
 


### PR DESCRIPTION
## Summary

Two spots in `edc_export.utils` referenced the `EXPORT_PII` group name as a bare string `"EXPORT_PII"` rather than the already-imported constant.

- **`validate_user_perms_or_raise()`** — the auth gate for `--decrypt` exports filtered groups by `name="EXPORT_PII"`. Today this works because the constant happens to equal the string, but a future rename of the constant would silently bypass the PII-decryption permission check. This is the single most important one to fix.
- **`raise_if_prohibited_from_export_pii_group()`** — the form-validation error shown to admins hard-coded `"EXPORT_PII"` in the user-facing display text. If the group name ever changes, the message would no longer match the actual group.

Both now reference the imported `EXPORT_PII` constant.

## Test plan

- [x] clinicedc full test suite run before change: all green (1576 tests, 37 skipped)
- [ ] No functional change — the constant's current value equals the string, so existing behaviour is unchanged. The change is a robustness fix against future renames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)