### PR TITLE
Harden export_models input validation

### DIFF
--- a/src/edc_export/management/commands/export_models.py
+++ b/src/edc_export/management/commands/export_models.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import grp
+import os
+import pwd
 import sys
 from pathlib import Path
 
@@ -20,6 +23,69 @@ from edc_sites.site import sites as site_sites
 ALL_COUNTRIES = "all"
 
 style = color_style()
+
+
+def _split_csv(value: str | None) -> list[str]:
+    """Split a comma-separated CLI value, stripping whitespace and
+    dropping empty tokens. Handles trailing commas and stray spaces.
+    """
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _validate_export_path_or_raise(path: Path, decrypt: bool) -> list[str]:
+    """Validate the export directory. Returns a list of warnings
+    (non-fatal). Raises CommandError on any hard-error condition.
+
+    Hard errors:
+      - path does not exist, is not a directory, or is not writable
+      - with decrypt, directory is world-readable (o+r)
+
+    Warnings:
+      - with decrypt, directory is group-readable and the group is
+        not "private" (has members besides the owner)
+    """
+    if not path.exists():
+        raise CommandError(f"Path does not exist. Got `{path}`.")
+    if not path.is_dir():
+        raise CommandError(f"Path is not a directory. Got `{path}`.")
+    if not os.access(path, os.W_OK):
+        raise CommandError(f"Path is not writable. Got `{path}`.")
+
+    warnings: list[str] = []
+    if decrypt:
+        st = path.stat()
+        mode = st.st_mode
+        if mode & 0o004:
+            raise CommandError(
+                "Refusing to write decrypted data to a world-readable "
+                f"directory. Got `{path}` (mode {oct(mode & 0o777)}). "
+                "Remove world-read (chmod o-r) and retry."
+            )
+        if mode & 0o040:
+            # group-readable; warn only if group is non-private
+            try:
+                group_info = grp.getgrgid(st.st_gid)
+                owner_name = pwd.getpwuid(st.st_uid).pw_name
+                primary_members = {
+                    p.pw_name for p in pwd.getpwall() if p.pw_gid == st.st_gid
+                }
+                all_members = set(group_info.gr_mem) | primary_members
+                if not all_members <= {owner_name}:
+                    warnings.append(
+                        f"Export directory `{path}` is group-readable by "
+                        f"group `{group_info.gr_name}` which has members "
+                        f"beyond the owner `{owner_name}`. Decrypted data "
+                        "will be readable by those users."
+                    )
+            except KeyError:
+                # unknown uid/gid — can't verify; warn conservatively
+                warnings.append(
+                    f"Export directory `{path}` is group-readable and "
+                    "group membership could not be verified."
+                )
+    return warnings
 
 
 class Command(BaseCommand):
@@ -125,7 +191,7 @@ class Command(BaseCommand):
             help="only export data for site id. Separate by comma if more than one.",
         )
 
-    def handle(self, *args, **options):  # noqa: ARG002
+    def handle(self, *args, **options):  # noqa: ARG002, C901, PLR0912
         user = get_export_user()
         validate_user_perms_or_raise(user, options["decrypt"])
 
@@ -137,40 +203,48 @@ class Command(BaseCommand):
             else int(self.options["stata_dta_version"] or STATA_14)
         )
 
-        if not self.options["path"] or not Path(self.options["path"]).expanduser().exists():
-            raise CommandError(f"Path does not exist. Got `{self.options['path']}`")
+        if not self.options["path"]:
+            raise CommandError("Path is required. Use --path to specify the export directory.")
         export_path = Path(self.options["path"]).expanduser().resolve()
+        warnings = _validate_export_path_or_raise(export_path, decrypt=bool(self.decrypt))
 
         use_simple_filename = self.options["use_simple_filename"]
 
         sys.stdout.write("Export models.\n")
         sys.stdout.write(f"* export base path: {export_path}\n")
+        for warning in warnings:
+            sys.stderr.write(style.WARNING(f"WARNING: {warning}\n"))
+
+        app_labels = _split_csv(self.options["app_labels"])
+        cli_model_names = _split_csv(self.options["model_names"])
 
         if self.options["trial_prefix"]:
+            if app_labels or cli_model_names:
+                raise CommandError(
+                    "`--trial-prefix` is mutually exclusive with `--app` and `--model`."
+                )
             model_names = get_default_models_for_export(self.options["trial_prefix"])
         else:
-            app_labels = []
-            if self.options["app_labels"]:
-                app_labels = self.options["app_labels"].split(",")
+            if app_labels:
                 sys.stdout.write(
                     f"* preparing to export models from apps: {', '.join(app_labels)}\n"
                 )
-            model_names = []
-            if self.options["model_names"]:
-                model_names = self.options["model_names"].split(",")
-                sys.stdout.write(f"* preparing to export models: {', '.join(model_names)}\n")
-            if not app_labels and not model_names:
+            if cli_model_names:
+                sys.stdout.write(
+                    f"* preparing to export models: {', '.join(cli_model_names)}\n"
+                )
+            if not app_labels and not cli_model_names:
                 raise CommandError(
                     "Nothing to do. No models to export. "
                     "Specify `app_labels` or `model_names`."
                 )
             model_names = get_model_names_for_export(
                 app_labels=app_labels,
-                model_names=model_names,
+                model_names=cli_model_names,
             )
 
-        if self.options["skip_model_names"]:
-            skip_model_names = self.options["skip_model_names"].split(",")
+        skip_model_names = _split_csv(self.options["skip_model_names"])
+        if skip_model_names:
             sys.stdout.write(f"* skipping models: {', '.join(skip_model_names)}\n")
             model_names = [m for m in model_names if m not in skip_model_names]
 
@@ -178,9 +252,13 @@ class Command(BaseCommand):
             model_names = [m for m in model_names if "historical" not in m]
 
         # build list of site ids
-        site_ids = self.options["site_ids"] or []
-        if site_ids:
-            site_ids = [int(x) for x in self.options["site_ids"].split(",")]
+        site_ids_raw = _split_csv(self.options["site_ids"])
+        try:
+            site_ids = [int(x) for x in site_ids_raw]
+        except ValueError as e:
+            raise CommandError(
+                f"Invalid --site value, must be integers. Got `{self.options['site_ids']}`."
+            ) from e
         site_ids = get_site_ids_for_export(site_ids=site_ids, countries=self.countries)
 
         # does user have perms to export these sites?
@@ -211,10 +289,13 @@ class Command(BaseCommand):
     @property
     def countries(self):
         if not self._countries:
-            if not self.options["countries"] or self.options["countries"] == ALL_COUNTRIES:
-                self._countries = site_sites.countries
+            raw = (self.options["countries"] or "").strip().lower()
+            if not raw:
+                self._countries = []
+            elif raw == ALL_COUNTRIES:
+                self._countries = list(site_sites.countries)
             else:
-                self._countries = self.options["countries"].lower().split(",")
+                self._countries = [c.lower() for c in _split_csv(raw)]
                 for country in self._countries:
                     if country not in site_sites.countries:
                         raise CommandError(f"Invalid country. Got {country}.")

--- a/src/edc_export/tests/tests/test_export_utils.py
+++ b/src/edc_export/tests/tests/test_export_utils.py
@@ -1,0 +1,103 @@
+from django.core.management import CommandError
+from django.test import SimpleTestCase, tag
+
+from edc_export.utils import (
+    get_default_models_for_export,
+    get_model_names_for_export,
+)
+
+
+@tag("export")
+class TestGetDefaultModelsForExport(SimpleTestCase):
+    def test_unknown_trial_prefix_raises(self):
+        """A typo in trial_prefix should raise CommandError, not
+        silently return only the six generic framework models.
+        """
+        with self.assertRaises(CommandError) as cm:
+            get_default_models_for_export("no_such_trial_prefix_xyz")
+        msg = str(cm.exception)
+        self.assertIn("no_such_trial_prefix_xyz", msg)
+        self.assertIn("No installed app matched", msg)
+        # error lists all expected app suffixes so operator can see
+        # which patterns were attempted
+        for suffix in (
+            "_consent",
+            "_lists",
+            "_subject",
+            "_ae",
+            "_prn",
+            "_screening",
+        ):
+            self.assertIn(suffix, msg)
+
+
+@tag("export")
+class TestGetModelNamesForExport(SimpleTestCase):
+    def test_unknown_app_label_raises(self):
+        with self.assertRaises(CommandError) as cm:
+            get_model_names_for_export(
+                app_labels=["no_such_app_xyz"], model_names=None
+            )
+        self.assertIn("no_such_app_xyz", str(cm.exception))
+        self.assertIn("unknown app_label", str(cm.exception))
+
+    def test_unknown_model_name_raises(self):
+        with self.assertRaises(CommandError) as cm:
+            get_model_names_for_export(
+                app_labels=None, model_names=["edc_export.no_such_model"]
+            )
+        self.assertIn("edc_export.no_such_model", str(cm.exception))
+        self.assertIn("unknown model", str(cm.exception))
+
+    def test_collects_all_errors_in_single_raise(self):
+        """All invalid labels and model names should be reported
+        together, not one per re-run.
+        """
+        with self.assertRaises(CommandError) as cm:
+            get_model_names_for_export(
+                app_labels=["bogus_app_1", "bogus_app_2"],
+                model_names=["bogus.one", "bogus.two"],
+            )
+        msg = str(cm.exception)
+        self.assertIn("bogus_app_1", msg)
+        self.assertIn("bogus_app_2", msg)
+        self.assertIn("bogus.one", msg)
+        self.assertIn("bogus.two", msg)
+
+    def test_malformed_model_name_raises(self):
+        """Values that can't be parsed as `app_label.ModelName` raise
+        ValueError inside get_model(); we coerce that to CommandError.
+        """
+        with self.assertRaises(CommandError) as cm:
+            get_model_names_for_export(
+                app_labels=None, model_names=["not_a_valid_label"]
+            )
+        self.assertIn("not_a_valid_label", str(cm.exception))
+
+    def test_valid_app_label_returns_models(self):
+        result = get_model_names_for_export(
+            app_labels=["edc_export"], model_names=None
+        )
+        self.assertTrue(len(result) > 0)
+        # every entry is label_lower format
+        for name in result:
+            self.assertIn(".", name)
+
+    def test_valid_model_name_passthrough(self):
+        result = get_model_names_for_export(
+            app_labels=None, model_names=["edc_export.datarequest"]
+        )
+        self.assertIn("edc_export.datarequest", result)
+
+    def test_none_inputs_return_empty(self):
+        self.assertEqual(
+            get_model_names_for_export(app_labels=None, model_names=None), []
+        )
+
+    def test_deduplicates(self):
+        """Same model specified twice -> returned once."""
+        result = get_model_names_for_export(
+            app_labels=None,
+            model_names=["edc_export.datarequest", "edc_export.datarequest"],
+        )
+        self.assertEqual(result.count("edc_export.datarequest"), 1)

--- a/src/edc_export/utils.py
+++ b/src/edc_export/utils.py
@@ -148,7 +148,13 @@ def validate_user_perms_or_raise(user: User, decrypt: bool | None) -> None:
 
 
 def get_default_models_for_export(trial_prefix: str) -> list[str]:
-    apps = [
+    """Return default model list for a trial identified by `trial_prefix`.
+
+    Raises CommandError if no installed apps match the trial_prefix —
+    likely a typo, otherwise the caller would silently get only the six
+    generic framework models below and think they exported the trial.
+    """
+    expected_apps = [
         f"{trial_prefix}_consent",
         f"{trial_prefix}_lists",
         f"{trial_prefix}_subject",
@@ -166,8 +172,10 @@ def get_default_models_for_export(trial_prefix: str) -> list[str]:
     ]
 
     # prepare a list of model names in label lower format
+    matched: list[str] = []
     for app_config in django_apps.get_app_configs():
-        if app_config.name.startswith(trial_prefix) and app_config.name in apps:
+        if app_config.name.startswith(trial_prefix) and app_config.name in expected_apps:
+            matched.append(app_config.name)
             model_names.extend(
                 [
                     model_cls._meta.label_lower
@@ -176,6 +184,12 @@ def get_default_models_for_export(trial_prefix: str) -> list[str]:
                     and not model_cls._meta.proxy
                 ]
             )
+
+    if not matched:
+        raise CommandError(
+            f"Unknown trial_prefix `{trial_prefix}`. No installed app matched. "
+            f"Expected at least one of: {', '.join(expected_apps)}."
+        )
     return model_names
 
 
@@ -183,12 +197,35 @@ def get_model_names_for_export(
     app_labels: list[str] | None,
     model_names: list[str] | None,
 ) -> list[str]:
-    """Returns a unique list of label_lower"""
-    model_names = model_names or []
-    if app_labels:
-        for app_label in app_labels:
-            app_config = django_apps.get_app_config(app_label)
-            model_names.extend([cls._meta.label_lower for cls in app_config.get_models()])
+    """Return a unique list of label_lower.
+
+    Both app_labels and model_names are validated. Collects all errors
+    and raises a single CommandError listing every unknown label/name
+    so the operator can fix them all in one pass rather than one per
+    re-run.
+    """
+    app_labels = list(app_labels or [])
+    model_names = list(model_names or [])
+    errors: list[str] = []
+
+    for app_label in app_labels:
+        try:
+            django_apps.get_app_config(app_label)
+        except LookupError:
+            errors.append(f"unknown app_label `{app_label}`")
+
+    for model_name in model_names:
+        try:
+            django_apps.get_model(model_name)
+        except (LookupError, ValueError):
+            errors.append(f"unknown model `{model_name}`")
+
+    if errors:
+        raise CommandError("Invalid --app / --model input: " + "; ".join(errors) + ".")
+
+    for app_label in app_labels:
+        app_config = django_apps.get_app_config(app_label)
+        model_names.extend([cls._meta.label_lower for cls in app_config.get_models()])
     return list(set(model_names))
 
 


### PR DESCRIPTION
## Summary
- Validate unknown app_labels/model_names (collect-all) and trial_prefix typos — both raise `CommandError` instead of silently returning an incomplete model list.
- Normalize CSV parsing across `--app`, `--model`, `--skip_model`, `--country`, `--site` via a shared `_split_csv` helper (strip whitespace, drop empty tokens). `--site` now rejects non-integers with a clear error.
- `--path` validation hardened: must exist, be a directory, and be writable. With `--decrypt`, refuse world-readable target dirs (hard error) and warn on group-readable dirs whose group is not user-private.
- `--path` is now required; `--trial-prefix` is mutually exclusive with `--app`/`--model` (still compatible with `--skip-model`).
- Added unit tests for `get_default_models_for_export` and `get_model_names_for_export`.

## Test plan
- [x] Full suite: `Ran 1578 tests in 993.575s — OK (skipped=37)`
- [x] Ruff clean on changed files
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)