### PR TITLE
Audit-log CLI-initiated exports via DataRequest/DataRequestHistory

### DIFF
--- a/src/edc_export/management/commands/export_models.py
+++ b/src/edc_export/management/commands/export_models.py
@@ -16,6 +16,7 @@ from edc_export.utils import (
     get_export_user,
     get_model_names_for_export,
     get_site_ids_for_export,
+    record_cli_export_audit,
     validate_user_perms_or_raise,
 )
 from edc_sites.site import sites as site_sites
@@ -289,6 +290,29 @@ class Command(BaseCommand):
             use_simple_filename=use_simple_filename,
             export_folder=export_path,
         )
+
+        # audit log
+        try:
+            data_request, _ = record_cli_export_audit(
+                user=user,
+                models_to_file=models_to_file,
+                decrypt=bool(self.decrypt),
+                export_format=export_format,
+                site_ids=site_ids,
+                countries=self.countries,
+                trial_prefix=self.options.get("trial_prefix") or None,
+                include_historical=bool(self.options.get("include_historical")),
+                export_path=export_path,
+            )
+            sys.stdout.write(f"* audit: recorded as `{data_request.name}`\n")
+        except Exception as e:
+            # audit failure must never break a completed export; surface it.
+            sys.stderr.write(
+                style.WARNING(
+                    f"WARNING: failed to record export audit log: {e!r}\n"
+                )
+            )
+
         sys.stdout.write(
             style.SUCCESS(f"\nDone.\nExported to {models_to_file.archive_filename}\n")
         )

--- a/src/edc_export/tests/tests/test_record_cli_export_audit.py
+++ b/src/edc_export/tests/tests/test_record_cli_export_audit.py
@@ -1,0 +1,113 @@
+from tempfile import mkdtemp
+from types import SimpleNamespace
+
+from clinicedc_tests.sites import all_sites
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings, tag
+
+from edc_export.utils import record_cli_export_audit
+from edc_sites.site import sites as site_sites
+from edc_sites.utils import add_or_update_django_sites
+
+ARCHIVE_PATH = "/exports/archive.zip"
+
+
+def _fake_models_to_file(**overrides) -> SimpleNamespace:
+    """Minimal stand-in for ModelsToFile — we only touch the attributes
+    that record_cli_export_audit reads.
+    """
+    defaults = dict(
+        models=["edc_export.datarequest", "edc_export.datarequesthistory"],
+        exported_filenames=["a.csv", "b.csv"],
+        archive_filename=ARCHIVE_PATH,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@tag("export")
+@override_settings(
+    EDC_EXPORT_EXPORT_FOLDER=mkdtemp(),
+    EDC_AUTH_SKIP_AUTH_UPDATER=True,
+    EDC_AUTH_SKIP_SITE_AUTHS=True,
+    SITE_ID=10,
+)
+class TestRecordCliExportAudit(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        site_sites._registry = {}
+        site_sites.loaded = False
+        site_sites.register(*all_sites)
+        add_or_update_django_sites()
+
+    def setUp(self):
+        self.user = User.objects.create(username="alice")
+
+    def test_creates_data_request_and_history(self):
+        data_request, history = record_cli_export_audit(
+            user=self.user,
+            models_to_file=_fake_models_to_file(),
+            decrypt=False,
+            export_format="csv",
+            export_path="/var/exports",
+        )
+        self.assertEqual(data_request.user_created, "alice")
+        self.assertIn("edc_export.datarequest", data_request.models)
+        self.assertIn("edc_export.datarequesthistory", data_request.models)
+        self.assertFalse(data_request.decrypt)
+        self.assertEqual(history.data_request_id, data_request.id)
+        self.assertEqual(history.archive_filename, ARCHIVE_PATH)
+        self.assertIn("a.csv", history.summary)
+        self.assertIn("b.csv", history.summary)
+
+    def test_summary_is_sorted(self):
+        _, history = record_cli_export_audit(
+            user=self.user,
+            models_to_file=_fake_models_to_file(
+                exported_filenames=["z.csv", "a.csv", "m.csv"]
+            ),
+            decrypt=False,
+            export_format="csv",
+        )
+        self.assertEqual(history.summary.splitlines(), ["a.csv", "m.csv", "z.csv"])
+
+    def test_description_records_filters(self):
+        data_request, _ = record_cli_export_audit(
+            user=self.user,
+            models_to_file=_fake_models_to_file(),
+            decrypt=True,
+            export_format=118,
+            site_ids=[10, 20],
+            countries=["uganda"],
+            trial_prefix="effect",
+            include_historical=True,
+            export_path="/exports",
+        )
+        desc = data_request.description
+        self.assertIn("export_models", desc)
+        self.assertIn("decrypt=True", desc)
+        self.assertIn("include_historical=True", desc)
+        self.assertIn("trial_prefix=effect", desc)
+        self.assertIn("site_ids=10,20", desc)
+        self.assertIn("countries=uganda", desc)
+        self.assertIn("export_path=/exports", desc)
+        self.assertIn("export_format=118", desc)
+
+    def test_empty_exported_filenames_is_handled(self):
+        """Defensive: should not crash if the exporter produced no files."""
+        _, history = record_cli_export_audit(
+            user=self.user,
+            models_to_file=_fake_models_to_file(exported_filenames=[]),
+            decrypt=False,
+            export_format="csv",
+        )
+        self.assertEqual(history.summary, "")
+
+    def test_name_has_timestamp_prefix(self):
+        data_request, _ = record_cli_export_audit(
+            user=self.user,
+            models_to_file=_fake_models_to_file(),
+            decrypt=False,
+            export_format="csv",
+        )
+        self.assertTrue(data_request.name.startswith("CLI export "))

--- a/src/edc_export/utils.py
+++ b/src/edc_export/utils.py
@@ -126,6 +126,70 @@ def update_data_request_history(request, models_to_file: ModelsToFile):
     )
 
 
+def record_cli_export_audit(
+    user: User | AbstractBaseUser,
+    models_to_file: ModelsToFile,
+    *,
+    decrypt: bool,
+    export_format: str | int,
+    site_ids: list[int] | None = None,
+    countries: list[str] | None = None,
+    trial_prefix: str | None = None,
+    include_historical: bool = False,
+    export_path: Path | str | None = None,
+) -> tuple:
+    """Record a CLI-initiated export to DataRequest / DataRequestHistory.
+
+    Web-initiated exports record history via `update_data_request_history`.
+    CLI exports have no `request` object, so the management command calls
+    this helper to leave an equivalent audit trail: who ran the export,
+    what models, with what filters, decrypted or not, where it landed.
+
+    The `site` FK is left null; `SiteModelMixin.get_site_on_create` will
+    assign from `settings.SITE_ID` at save-time, matching how other
+    CLI-created rows behave.
+
+    Returns the (data_request, data_request_history) instances (primarily
+    for tests).
+    """
+    summary = sorted(str(x) for x in (models_to_file.exported_filenames or []))
+    data_request_model_cls = django_apps.get_model("edc_export.datarequest")
+    data_request_history_model_cls = django_apps.get_model("edc_export.datarequesthistory")
+
+    description_lines = [
+        "Initiated via `export_models` management command.",
+        f"export_format={export_format}",
+        f"decrypt={bool(decrypt)}",
+        f"include_historical={bool(include_historical)}",
+    ]
+    if trial_prefix:
+        description_lines.append(f"trial_prefix={trial_prefix}")
+    if site_ids:
+        description_lines.append(f"site_ids={','.join(str(s) for s in site_ids)}")
+    if countries:
+        description_lines.append(f"countries={','.join(countries)}")
+    if export_path is not None:
+        description_lines.append(f"export_path={export_path}")
+
+    data_request = data_request_model_cls.objects.create(
+        name=f"CLI export {timezone.now().strftime('%Y%m%d%H%M')}",
+        description="\n".join(description_lines),
+        decrypt=bool(decrypt),
+        export_format=str(export_format),
+        models="\n".join(models_to_file.models or []),
+        user_created=user.username,
+    )
+    data_request_history = data_request_history_model_cls.objects.create(
+        data_request=data_request,
+        exported_datetime=timezone.now(),
+        summary="\n".join(summary),
+        user_created=user.username,
+        user_modified=user.username,
+        archive_filename=models_to_file.archive_filename or "",
+    )
+    return data_request, data_request_history
+
+
 def get_export_user() -> User | AbstractBaseUser:
     username = input("Username:")
     passwd = getpass.getpass("Password for " + username + ":")


### PR DESCRIPTION
## Summary
- Web exports have always recorded an audit trail through `update_data_request_history`. CLI-initiated exports via `export_models` left no record — a gap for sensitive (decrypted) data requests.
- Adds `record_cli_export_audit` helper that creates matching `DataRequest` + `DataRequestHistory` rows from CLI context (no `request` object). Captures user, models, archive filename, `decrypt`, `export_format`, site/country filters, `trial_prefix`, `include_historical`, and `export_path`.
- Wired into `export_models.handle()` after a successful export. Audit failures surface as a stderr warning and never break a completed export.

## Test plan
- [x] Unit tests for the helper (happy path, filter serialization, sorted summary, empty-filenames edge, name prefix)
- [x] `--tag=export` suite: 13 tests pass
- [x] Ruff clean on changed files
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)