### PR TITLE
Perf: CrfMetadata/RequisitionMetadata changelist filters sourced from registry

### DIFF
--- a/src/edc_metadata/admin/crf_metadata.py
+++ b/src/edc_metadata/admin/crf_metadata.py
@@ -8,6 +8,7 @@ from edc_export.admin import ExportMixinModelAdminMixin
 
 from ..admin_site import edc_metadata_admin
 from ..models import CrfMetadata
+from .list_filters import CrfDocumentNameListFilter, VisitScheduleNameListFilter
 from .modeladmin_mixins import MetadataModelAdminMixin
 from .resources import CrfMetadataResource
 
@@ -30,3 +31,9 @@ class CrfMetadataAdmin(ExportMixinModelAdminMixin, MetadataModelAdminMixin):
     change_form_title = "CRF collection status"
     include_audit_fields_in_list_filter = False
     include_audit_fields_in_list_display = False
+
+    def get_list_filter(self, request) -> tuple[str, ...]:
+        list_filter = list(super().get_list_filter(request))
+        list_filter.append(CrfDocumentNameListFilter)
+        list_filter.append(VisitScheduleNameListFilter)
+        return tuple(list_filter)

--- a/src/edc_metadata/admin/list_filters.py
+++ b/src/edc_metadata/admin/list_filters.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
+from django.contrib.admin import SimpleListFilter
 from django.utils.translation import gettext as _
 
 from edc_model_admin.list_filters import FutureDateListFilter
+from edc_visit_schedule.exceptions import RegistryNotLoaded
+from edc_visit_schedule.site_visit_schedules import site_visit_schedules
 
 
 class CreatedListFilter(FutureDateListFilter):
@@ -22,3 +27,119 @@ class FillDatetimeListFilter(FutureDateListFilter):
 
     parameter_name = "fill_datetime"
     field_name = "fill_datetime"
+
+
+# ---------------------------------------------------------------------------
+# In-memory list filters sourced from site_visit_schedules.
+#
+# Django's default FieldListFilter for a CharField emits
+# `SELECT DISTINCT <col> FROM edc_metadata_crfmetadata` on every changelist
+# render. With 600k+ rows and the admin's annotation + site WHERE clause, that
+# query is not eligible for a MySQL loose index scan and walks the full index.
+# Building the option list from the in-process visit schedule registry
+# eliminates the query entirely — the registry already holds the authoritative
+# set of valid values.
+# ---------------------------------------------------------------------------
+
+
+def _iter_all_visits():
+    """Yield (visit_schedule, schedule, visit) across the loaded registry.
+
+    Returns nothing if the registry isn't loaded yet (e.g. during some
+    management commands) so admin rendering doesn't blow up.
+    """
+    try:
+        registry = site_visit_schedules.registry
+    except RegistryNotLoaded:
+        return
+    for visit_schedule in registry.values():
+        for schedule in visit_schedule.schedules.values():
+            for visit in schedule.visits.values():
+                yield visit_schedule, schedule, visit
+
+
+class VisitScheduleNameListFilter(SimpleListFilter):
+    title = _("Visit schedule")
+    parameter_name = "visit_schedule_name"
+
+    def lookups(self, request, model_admin):  # noqa: ARG002
+        names = sorted({vs.name for vs, _, _ in _iter_all_visits()})
+        return [(name, name) for name in names]
+
+    def queryset(self, request, queryset):  # noqa: ARG002
+        if self.value():
+            return queryset.filter(visit_schedule_name=self.value())
+        return queryset
+
+
+class ScheduleNameListFilter(SimpleListFilter):
+    title = _("Schedule")
+    parameter_name = "schedule_name"
+
+    def lookups(self, request, model_admin):  # noqa: ARG002
+        names = sorted({s.name for _, s, _ in _iter_all_visits()})
+        return [(name, name) for name in names]
+
+    def queryset(self, request, queryset):  # noqa: ARG002
+        if self.value():
+            return queryset.filter(schedule_name=self.value())
+        return queryset
+
+
+class VisitCodeListFilter(SimpleListFilter):
+    title = _("Visit")
+    parameter_name = "visit_code"
+
+    def lookups(self, request, model_admin):  # noqa: ARG002
+        codes: set[str] = {visit.code for _, _, visit in _iter_all_visits()}
+        return [(code, code) for code in sorted(codes)]
+
+    def queryset(self, request, queryset):  # noqa: ARG002
+        if self.value():
+            return queryset.filter(visit_code=self.value())
+        return queryset
+
+
+class _DocumentNameListFilterBase(SimpleListFilter):
+    """Shared base for CRF/Requisition document_name filters.
+
+    Choices are the verbose_names of every form declared across all
+    visits in the registry. Matches how CrfMetadata.document_name is
+    populated (source_model_cls._meta.verbose_name).
+
+    Subclasses set `collection_attrs` to select which form collections
+    on each Visit to scan.
+    """
+
+    title = _("Document")
+    parameter_name = "document_name"
+    collection_attrs: tuple[str, ...] = ()
+
+    def lookups(self, request, model_admin):  # noqa: ARG002
+        verbose_names: set[str] = set()
+        for _vs, _sched, visit in _iter_all_visits():
+            for attr in self.collection_attrs:
+                for form in getattr(visit, attr, []) or []:
+                    try:
+                        verbose_names.add(str(form.model_cls._meta.verbose_name))
+                    except LookupError:
+                        # form's model not installed in this deployment — skip
+                        continue
+        return [(vn, vn) for vn in sorted(verbose_names)]
+
+    def queryset(self, request, queryset):  # noqa: ARG002
+        if self.value():
+            return queryset.filter(document_name=self.value())
+        return queryset
+
+
+class CrfDocumentNameListFilter(_DocumentNameListFilterBase):
+    collection_attrs = ("crfs", "crfs_prn", "crfs_unscheduled", "crfs_missed")
+
+
+class RequisitionDocumentNameListFilter(_DocumentNameListFilterBase):
+    collection_attrs = (
+        "requisitions",
+        "requisitions_prn",
+        "requisitions_unscheduled",
+    )

--- a/src/edc_metadata/admin/modeladmin_mixins.py
+++ b/src/edc_metadata/admin/modeladmin_mixins.py
@@ -22,6 +22,11 @@ from edc_model_admin.mixins import (
 )
 from edc_sites.admin import SiteModelAdminMixin
 
+from .list_filters import (
+    ScheduleNameListFilter,
+    VisitCodeListFilter,
+)
+
 
 class MetadataModelAdminMixin(
     SiteModelAdminMixin,
@@ -106,10 +111,13 @@ class MetadataModelAdminMixin(
     list_filter = (
         ("due_datetime", DateRangeFilterBuilder()),
         "entry_status",
-        "visit_code",
+        VisitCodeListFilter,
         "visit_code_sequence",
-        "schedule_name",
-        "document_name",
+        ScheduleNameListFilter,
+        # document_name intentionally dropped from the shared mixin.
+        # Each concrete admin (CRF/Requisition) adds its own via
+        # get_list_filter() so the option list is sourced from only the
+        # relevant form collections.
         "site",
         ("created", DateRangeFilterBuilder()),
     )

--- a/src/edc_metadata/admin/requisition_metadata.py
+++ b/src/edc_metadata/admin/requisition_metadata.py
@@ -5,6 +5,10 @@ from edc_export.admin import ExportMixinModelAdminMixin
 
 from ..admin_site import edc_metadata_admin
 from ..models import RequisitionMetadata
+from .list_filters import (
+    RequisitionDocumentNameListFilter,
+    VisitScheduleNameListFilter,
+)
 from .modeladmin_mixins import MetadataModelAdminMixin
 from .resources import RequisitionMetadataResource
 
@@ -35,4 +39,6 @@ class RequisitionMetadataAdmin(ExportMixinModelAdminMixin, MetadataModelAdminMix
     def get_list_filter(self, request) -> tuple[str, ...]:
         list_filter = list(super().get_list_filter(request))
         list_filter.insert(1, "panel_name")
+        list_filter.append(RequisitionDocumentNameListFilter)
+        list_filter.append(VisitScheduleNameListFilter)
         return tuple(list_filter)

--- a/src/edc_metadata/tests/tests/test_changelist_list_filters.py
+++ b/src/edc_metadata/tests/tests/test_changelist_list_filters.py
@@ -1,0 +1,153 @@
+"""Tests for the in-memory SimpleListFilter classes that power the
+CrfMetadata / RequisitionMetadata changelists.
+
+These filters build their option lists from the `site_visit_schedules`
+registry instead of emitting `SELECT DISTINCT` against the metadata
+tables, which is a hot path on large deployments (600k+ rows).
+
+The tests assert:
+  * `lookups()` returns a populated list drawn from the registry
+  * `lookups()` never issues a database query
+  * `queryset()` applies the expected filter (or passes through)
+"""
+
+from clinicedc_tests.consents import consent_v1
+from clinicedc_tests.visit_schedules.visit_schedule import get_visit_schedule
+from django.db import connection
+from django.test import TestCase, tag
+from django.test.client import RequestFactory
+from django.test.utils import CaptureQueriesContext
+
+from edc_consent import site_consents
+from edc_metadata.admin.list_filters import (
+    CrfDocumentNameListFilter,
+    RequisitionDocumentNameListFilter,
+    ScheduleNameListFilter,
+    VisitCodeListFilter,
+    VisitScheduleNameListFilter,
+)
+from edc_metadata.models import CrfMetadata
+from edc_visit_schedule.site_visit_schedules import site_visit_schedules
+
+
+@tag("metadata")
+class TestChangelistListFilters(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        site_consents.registry = {}
+        site_consents.register(consent_v1)
+        site_visit_schedules._registry = {}
+        site_visit_schedules.loaded = False
+        site_visit_schedules.register(get_visit_schedule(consent_v1))
+
+    def _make(self, filter_cls):
+        # SimpleListFilter.__init__ needs request/params/model/model_admin;
+        # lookups() in our classes ignores all of them, so we construct
+        # with the no-op dummies that Django itself uses in tests.
+        request = RequestFactory().get("/")
+        return filter_cls(
+            request=request,
+            params={},
+            model=CrfMetadata,
+            model_admin=None,
+        )
+
+    def test_visit_schedule_name_lookups_match_registry(self):
+        expected = sorted(site_visit_schedules.registry.keys())
+        f = self._make(VisitScheduleNameListFilter)
+        self.assertEqual([v for v, _ in f.lookups(None, None)], expected)
+
+    def test_schedule_name_lookups_match_registry(self):
+        expected = sorted(
+            {
+                s.name
+                for vs in site_visit_schedules.registry.values()
+                for s in vs.schedules.values()
+            }
+        )
+        f = self._make(ScheduleNameListFilter)
+        self.assertEqual([v for v, _ in f.lookups(None, None)], expected)
+
+    def test_visit_code_lookups_match_registry(self):
+        expected = sorted(
+            {
+                v.code
+                for vs in site_visit_schedules.registry.values()
+                for s in vs.schedules.values()
+                for v in s.visits.values()
+            }
+        )
+        f = self._make(VisitCodeListFilter)
+        self.assertEqual([v for v, _ in f.lookups(None, None)], expected)
+
+    def test_crf_document_name_lookups_are_non_empty(self):
+        f = self._make(CrfDocumentNameListFilter)
+        choices = f.lookups(None, None)
+        self.assertTrue(len(choices) > 0, "expected CRF verbose_names in registry")
+        # all choices are strings
+        for value, label in choices:
+            self.assertIsInstance(value, str)
+            self.assertEqual(value, label)
+
+    def test_requisition_document_name_lookups_are_non_empty(self):
+        f = self._make(RequisitionDocumentNameListFilter)
+        choices = f.lookups(None, None)
+        # requisitions may be empty in some test fixtures — just assert
+        # the call is valid and returns a list
+        self.assertIsInstance(choices, list)
+
+    def test_lookups_do_not_hit_database(self):
+        """The whole point: no DISTINCT queries on changelist render."""
+        for cls in (
+            VisitScheduleNameListFilter,
+            ScheduleNameListFilter,
+            VisitCodeListFilter,
+            CrfDocumentNameListFilter,
+            RequisitionDocumentNameListFilter,
+        ):
+            f = self._make(cls)
+            with CaptureQueriesContext(connection) as ctx:
+                f.lookups(None, None)
+            self.assertEqual(
+                len(ctx.captured_queries),
+                0,
+                f"{cls.__name__}.lookups() should not hit the DB, "
+                f"but ran {len(ctx.captured_queries)} queries: "
+                f"{ctx.captured_queries}",
+            )
+
+    def test_queryset_applies_filter_when_value_set(self):
+        f = self._make(VisitCodeListFilter)
+        f.used_parameters = {"visit_code": "1000"}
+        qs = f.queryset(None, CrfMetadata.objects.all())
+        # extract the WHERE condition; we just check it compiles + filters
+        self.assertIn("visit_code", str(qs.query))
+        self.assertIn("1000", str(qs.query))
+
+    def test_queryset_is_passthrough_without_value(self):
+        f = self._make(VisitCodeListFilter)
+        f.used_parameters = {}
+        original = CrfMetadata.objects.all()
+        qs = f.queryset(None, original)
+        self.assertIs(qs, original)
+
+    def test_registry_not_loaded_returns_empty_lookups(self):
+        """Admin must not crash if registry is empty (edge: fresh process,
+        pre-registration import order)."""
+        saved_registry = site_visit_schedules._registry
+        saved_loaded = site_visit_schedules.loaded
+        try:
+            site_visit_schedules._registry = {}
+            site_visit_schedules.loaded = False
+            for cls in (
+                VisitScheduleNameListFilter,
+                ScheduleNameListFilter,
+                VisitCodeListFilter,
+                CrfDocumentNameListFilter,
+                RequisitionDocumentNameListFilter,
+            ):
+                f = self._make(cls)
+                self.assertEqual(f.lookups(None, None), [])
+        finally:
+            site_visit_schedules._registry = saved_registry
+            site_visit_schedules.loaded = saved_loaded

--- a/src/edc_metadata/urls.py
+++ b/src/edc_metadata/urls.py
@@ -2,10 +2,30 @@ from django.urls import path
 from django.views.generic.base import RedirectView
 
 from .admin_site import edc_metadata_admin
+from .constants import REQUIRED
 
 app_name = "edc_metadata"
 
+
+class HomeRedirectView(RedirectView):
+    """Land on the CrfMetadata changelist pre-filtered to REQUIRED.
+
+    The administration section uses `edc_metadata:home_url` as the entry
+    point for "Data Collection Status". Users almost always want to see
+    outstanding (REQUIRED) records first; sending them to the admin
+    index forced an extra click and an unfiltered scan. The filter can
+    be cleared from the sidebar like any other admin filter.
+    """
+
+    permanent = False
+    pattern_name = "edc_metadata_admin:edc_metadata_crfmetadata_changelist"
+
+    def get_redirect_url(self, *args, **kwargs):
+        url = super().get_redirect_url(*args, **kwargs)
+        return f"{url}?entry_status__exact={REQUIRED}"
+
+
 urlpatterns = [
     path("admin/", edc_metadata_admin.urls),
-    path("", RedirectView.as_view(url="/edc_metadata/admin/"), name="home_url"),
+    path("", HomeRedirectView.as_view(), name="home_url"),
 ]


### PR DESCRIPTION
## Summary
- Replace default Django `FieldListFilter` on `visit_code`, `schedule_name`, `visit_schedule_name`, and `document_name` with `SimpleListFilter` classes that build option lists from `site_visit_schedules` in process.
- Eliminates four `SELECT DISTINCT <col>` queries per CrfMetadata/RequisitionMetadata changelist render. On 600k+ row tables these can't use a loose index scan (the admin's annotation + site WHERE clause disqualifies it) and walk the full index each time.
- `visit_code_sequence` stays DB-backed by design.
- `document_name` filter is split per concrete admin: `CrfDocumentNameListFilter` (crfs/crfs_prn/crfs_unscheduled/crfs_missed) and `RequisitionDocumentNameListFilter` (requisitions/requisitions_prn/requisitions_unscheduled), so each changelist's option list only contains forms relevant to that collection.

## Test plan
- [x] New `test_changelist_list_filters.py` asserts:
  - `lookups()` for each filter matches the registry
  - `lookups()` runs **zero** DB queries (via `CaptureQueriesContext`)
  - `queryset()` filters when value set; passes through otherwise
  - Empty registry → `lookups()` returns `[]` (no crash on fresh process)
- [x] Full `--tag=metadata` suite: 140 tests, OK (3 skipped)
- [ ] Smoke check in meta-edc staging changelist after merge