### PR TITLE
Fix crash and correctness bugs in edc_form_describer

### DIFF
--- a/src/edc_form_describer/form_describer.py
+++ b/src/edc_form_describer/form_describer.py
@@ -129,15 +129,19 @@ class FormDescriber:
         """Appends all form features to a list `lines`."""
         number = 0.0
         self.markdown.append(f"{self.level} {self.verbose_name}")
-        docstring = self.model_cls.__doc__.strip()
-        if docstring.lower().startswith(self.model_cls._meta.label_lower.split(".")[1]):
+        docstring = (self.model_cls.__doc__ or "").strip()
+        model_name_lower = self.model_cls._meta.label_lower.split(".")[1]
+        if not docstring or docstring.lower().startswith(model_name_lower):
             self.markdown.append("*[missing model class docstring]*\n")
         else:
             self.markdown.append(f"{docstring}\n")
-        self.markdown.append(f"*Instructions*: {self.admin_cls.instructions}\n")
-        if self.admin_cls.additional_instructions:
+        instructions = getattr(self.admin_cls, "instructions", "")
+        if instructions:
+            self.markdown.append(f"*Instructions*: {instructions}\n")
+        additional_instructions = getattr(self.admin_cls, "additional_instructions", "")
+        if additional_instructions:
             self.markdown.append(
-                f"*Additional instructions*: {self.admin_cls.additional_instructions}\n"
+                f"*Additional instructions*: {additional_instructions}\n"
             )
 
         for fieldset_name, fieldset in self.fieldsets:
@@ -161,14 +165,12 @@ class FormDescriber:
     def add_hidden_fields(self):
         self.markdown.append("\n**Hidden fields:**")
         self.add_field(fname="report_datetime")
-        base_fields = DEFAULT_BASE_FIELDS
-        base_fields.append("revision")
-        base_fields.sort()
+        base_fields = sorted([*DEFAULT_BASE_FIELDS, "revision"])
         for fname in base_fields:
             self.add_field(fname=fname)
 
     def add_field(self, fname: str | None = None, number: float | None = None) -> None:
-        number = number or "@"
+        number = "@" if number is None else number
         field_cls = self.models_fields.get(fname)
         if not field_cls:
             raise FormDescriberError(f"Unknown field {fname}")
@@ -202,8 +204,13 @@ class FormDescriber:
                 self.markdown.append("- responses: *free text*")
         elif field_cls.get_internal_type() == "ManyToManyField":
             self.markdown.append("- responses: *Select all that apply*")
-            for obj in field_cls.related_model.objects.all().order_by("display_index"):
-                self.markdown.append(f"  - `{obj.name}`: *{obj.display_name}*")
+            qs = field_cls.related_model.objects.all()
+            if any(f.name == "display_index" for f in field_cls.related_model._meta.get_fields()):
+                qs = qs.order_by("display_index")
+            for obj in qs:
+                name = getattr(obj, "name", str(obj))
+                display_name = getattr(obj, "display_name", name)
+                self.markdown.append(f"  - `{name}`: *{display_name}*")
 
     @staticmethod
     def get_next_number(number: float | None = None, fname: str | None = None) -> float:

--- a/src/edc_form_describer/management/commands/make_forms_reference.py
+++ b/src/edc_form_describer/management/commands/make_forms_reference.py
@@ -22,10 +22,10 @@ def update_forms_reference(
     visit_schedule_name: str,
     title: str | None = None,
     filename: str | None = None,
-    doc_folder: str | None = None,
+    doc_folder: str | Path | None = None,
 ):
     module = import_module(app_label)
-    default_doc_folder = Path(settings.BASE_DIR / "docs")
+    default_doc_folder = Path(settings.BASE_DIR) / "docs"
     filename = filename or f"forms_reference_{app_label}.md"
     admin_site = getattr(module.admin_site, admin_site_name)
     visit_schedule = site_visit_schedules.get_visit_schedule(visit_schedule_name)
@@ -33,9 +33,8 @@ def update_forms_reference(
     sys.stdout.write(
         style.MIGRATE_HEADING(f"Refreshing CRF reference document for {app_label}\n")
     )
-    doc_folder = doc_folder or default_doc_folder
-    if doc_folder == default_doc_folder and not default_doc_folder.exists():
-        doc_folder.mkdir(parents=False, exist_ok=False)
+    doc_folder = Path(doc_folder).expanduser() if doc_folder else default_doc_folder
+    doc_folder.mkdir(parents=True, exist_ok=True)
 
     forms = FormsReference(
         visit_schedules=[visit_schedule],


### PR DESCRIPTION
- form_describer.py: stop mutating the imported DEFAULT_BASE_FIELDS
  constant in add_hidden_fields(); every call was appending another
  "revision" entry to the shared list, poisoning other describers in
  the same process. Copy the list first.
- form_describer.py: guard against model classes with no docstring
  (__doc__ is None); describe() was calling .strip() on None.
- form_describer.py: fix numbering when number is 0.0 — the `number or
  "@"` idiom substituted "@" for a legitimate 0.0 value; use an explicit
  None check.
- form_describer.py: guard missing `instructions` / `additional_
  instructions` on admin classes that don't inherit the clinicedc
  admin mixin, instead of raising AttributeError.
- form_describer.py: don't require a `display_index` field on every
  ManyToManyField target; fall back to unordered, and use getattr for
  `name` / `display_name` accessors so non-list-model M2M targets don't
  crash.
- make_forms_reference.py: coerce `--doc-folder` to Path before use.
  Previously a str from argparse was compared to a Path with `==`
  (always False) and later used with `/` operator and `.mkdir()`,
  silently skipping folder creation for non-default paths and failing
  deeper in the write. Also always ensure the folder exists
  (parents=True, exist_ok=True) rather than only for the default case.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
