### PR TITLE
Tighten make_forms_reference CLI and make stdout injectable

### DIFF
--- a/src/edc_form_describer/management/commands/make_forms_reference.py
+++ b/src/edc_form_describer/management/commands/make_forms_reference.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import sys
-from importlib import import_module
 from importlib.metadata import version
 from pathlib import Path
+from typing import IO
 
+from django.apps import apps
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from django.core.management.color import color_style
 from django.utils.translation import gettext as _
 
@@ -23,14 +24,16 @@ def update_forms_reference(
     title: str | None = None,
     filename: str | None = None,
     doc_folder: str | Path | None = None,
+    stdout: IO[str] | None = None,
 ):
-    module = import_module(app_label)
+    stdout = stdout or sys.stdout
+    module = apps.get_app_config(app_label).module
     default_doc_folder = Path(settings.BASE_DIR) / "docs"
     filename = filename or f"forms_reference_{app_label}.md"
     admin_site = getattr(module.admin_site, admin_site_name)
     visit_schedule = site_visit_schedules.get_visit_schedule(visit_schedule_name)
     title = title or _("%(title_app)s Forms Reference") % dict(title_app=app_label.upper())
-    sys.stdout.write(
+    stdout.write(
         style.MIGRATE_HEADING(f"Refreshing CRF reference document for {app_label}\n")
     )
     doc_folder = Path(doc_folder).expanduser() if doc_folder else default_doc_folder
@@ -46,8 +49,8 @@ def update_forms_reference(
     path = doc_folder / filename
     forms.to_file(path=path, overwrite=True)
 
-    sys.stdout.write(f"{path}\n")
-    sys.stdout.write("Done\n")
+    stdout.write(f"{path}\n")
+    stdout.write("Done\n")
 
 
 class Command(BaseCommand):
@@ -57,47 +60,50 @@ class Command(BaseCommand):
         parser.add_argument(
             "--app-label",
             dest="app_label",
-            default=None,
+            required=True,
+            help="Django app label of the module that provides admin_site.",
         )
-
         parser.add_argument(
             "--admin-site",
             dest="admin_site_name",
-            default=None,
+            required=True,
+            help="Attribute name of the admin_site on <app>.admin_site.",
         )
-
         parser.add_argument(
             "--visit-schedule",
             dest="visit_schedule_name",
-            default=None,
+            required=True,
+            help="Registered visit-schedule name.",
         )
-
         parser.add_argument(
             "--title",
             dest="title",
             default=None,
+            help="Optional document title. Defaults to '<APP_LABEL> Forms Reference'.",
         )
-
         parser.add_argument(
-            "--doc_folder",
+            "--filename",
+            dest="filename",
+            default=None,
+            help="Output filename. Defaults to 'forms_reference_<app_label>.md'.",
+        )
+        parser.add_argument(
+            "--doc-folder",
             dest="doc_folder",
             default=None,
+            help=(
+                "Output folder. Defaults to $BASE_DIR/docs. "
+                "Created if it does not exist."
+            ),
         )
 
     def handle(self, *args, **options):  # noqa: ARG002
-        app_label = options["app_label"]
-        admin_site_name = options["admin_site_name"]
-        visit_schedule_name = options["visit_schedule_name"]
-        title = options["title"]
-        doc_folder = options["doc_folder"]
-
-        if not app_label or not admin_site_name or not visit_schedule_name:
-            raise CommandError(f"parameter missing. got {options}")
-
         update_forms_reference(
-            app_label=app_label,
-            admin_site_name=admin_site_name,
-            visit_schedule_name=visit_schedule_name,
-            title=title,
-            doc_folder=doc_folder,
+            app_label=options["app_label"],
+            admin_site_name=options["admin_site_name"],
+            visit_schedule_name=options["visit_schedule_name"],
+            title=options["title"],
+            filename=options["filename"],
+            doc_folder=options["doc_folder"],
+            stdout=self.stdout,
         )


### PR DESCRIPTION
## Summary
- Mark `--app-label`, `--admin-site`, `--visit-schedule` as `required=True` so argparse produces a proper usage error; drop the manual `CommandError` check.
- Rename `--doc_folder` → `--doc-folder` for consistency with other flags; add `--filename`; add `help=` text on every argument.
- Replace `importlib.import_module(app_label)` with `apps.get_app_config(app_label).module` for a clearer error when the app isn't installed.
- Accept an optional `stdout` writer in `update_forms_reference` and pass `self.stdout` from `Command.handle` so output honours `--no-color` and is capturable in tests.

## Test plan
- [ ] Run `manage.py make_forms_reference` with a valid app/admin-site/visit-schedule and confirm the `.md` file is written to `$BASE_DIR/docs/`.
- [ ] Omit a required flag and confirm argparse prints a usage error (not a generic `CommandError`).
- [ ] Pass `--doc-folder` with `~` in the path and confirm it expands.
- [ ] Pass `--filename foo.md` and confirm the output file respects it.
- [ ] Pass an unknown `--app-label` and confirm the Django "app not installed" error is clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)