### PR TITLE
Make MarkdownWriter construction side-effect free

### DIFF
--- a/src/edc_form_describer/markdown_writer.py
+++ b/src/edc_form_describer/markdown_writer.py
@@ -6,55 +6,43 @@ from django.utils import timezone
 
 
 class MarkdownWriter:
-    def __init__(self, path: str | None = None, overwrite: bool | None = None):
-        self.path = self.get_path(path=path, overwrite=overwrite)
+    """Render a list of markdown lines to a string or a file.
 
-    @staticmethod
-    def get_path(path: str | None = None, overwrite: bool | None = None) -> str:
-        if not path:
-            timestamp = timezone.now().strftime("%Y%m%d%H%M")
-            path = f"forms_{timestamp}.md"
-        if Path(path).exists():
-            if overwrite:
-                Path(path).unlink()
-            else:
-                raise FileExistsError(f"File exists. Got '{path}'")
-        return path
+    The constructor is side-effect free: it stores the target `path` and the
+    `overwrite` flag but does not touch the filesystem. Path resolution and
+    the existence check happen in `to_file`, so callers that only need
+    `to_markdown()` never risk a `FileExistsError`.
+    """
+
+    def __init__(
+        self,
+        path: str | Path | None = None,
+        overwrite: bool | None = None,
+    ):
+        self.path = path
+        self.overwrite = bool(overwrite)
+
+    def _resolve_path(self) -> Path:
+        if self.path:
+            return Path(self.path)
+        timestamp = timezone.now().strftime("%Y%m%d%H%M")
+        return Path(f"forms_{timestamp}.md")
 
     @staticmethod
     def to_markdown(markdown: list[str]) -> str:
-        """Returns the markdown as a text string."""
+        """Return the markdown as a single text string."""
         return "\n".join(markdown)
 
-    def to_file(
-        self,
-        markdown: list[str],
-        pad: int | None = None,
-        append: bool | None = None,
-        prepend: bool | None = None,
-    ) -> None:
-        markdown = self.to_markdown(markdown=markdown)
+    def to_file(self, markdown: list[str], pad: int | None = None) -> Path:
+        """Write `markdown` to the resolved path and return that path.
+
+        Raises FileExistsError if the target exists and `overwrite` is falsy.
+        """
+        path = self._resolve_path()
+        if path.exists() and not self.overwrite:
+            raise FileExistsError(f"File exists. Got '{path}'")
+        text = self.to_markdown(markdown=markdown)
         if pad:
-            markdown = markdown + ("\n" * pad)
-        if append:
-            self._append(markdown)
-        elif prepend:
-            self._prepend(markdown)
-        else:
-            self._write(markdown)
-
-    def _write(self, markdown: str, mode: str | None = None) -> None:
-        mode = mode or "w"
-        with Path(self.path).open(mode) as f:
-            f.write(markdown)
-
-    def _append(self, markdown) -> None:
-        mode = "a"
-        self._write(markdown=markdown, mode=mode)
-
-    def _prepend(self, markdown=None) -> None:
-        mode = "r+"
-        with Path(self.path).open(mode) as f:
-            content = f.read()
-            f.seek(0, 0)
-            f.write(markdown + "\n" + content)
+            text += "\n" * pad
+        path.write_text(text)
+        return path


### PR DESCRIPTION
## Summary
- `__init__` now stores only `path` and `overwrite`; no filesystem I/O, no `FileExistsError` at construction time. Callers that only need `to_markdown()` never risk a write-path error.
- Move path default (`forms_<timestamp>.md`) and the existence check into `to_file()`, where the write actually happens. Drop the redundant `Path(path).unlink()` call — mode `"w"` already truncates.
- Drop unused `append` / `prepend` parameters on `to_file()` and the matching `_append` / `_prepend` helpers. No caller in the workspace used them.
- `to_file()` now returns the resolved `Path` for convenience; existing callers ignore the return value, so nothing breaks.

## Test plan
- [x] Full clinicedc test suite passes (1601 OK, 37 skipped).
- [ ] Overwrite-true run rewrites an existing file without pre-unlink.
- [ ] Overwrite-false run on an existing file raises `FileExistsError` from `to_file`, not from the constructor.
- [ ] `to_markdown(...)` on a writer with a colliding existing path no longer raises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)