### PR TITLE
Add flat render mode and split required/optional CRFs

### DIFF
--- a/src/edc_form_describer/forms_reference.py
+++ b/src/edc_form_describer/forms_reference.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from importlib.metadata import version
 from pathlib import Path
 
@@ -7,6 +9,10 @@ from django.utils import timezone
 
 from .form_describer import FormDescriber
 from .markdown_writer import MarkdownWriter
+
+
+class FormsReferenceError(Exception):
+    pass
 
 
 class FormsReference:
@@ -26,11 +32,13 @@ class FormsReference:
         title=None,
         add_per_form_timestamp: bool | None = None,
     ):
+        if admin_site is None:
+            raise FormsReferenceError("admin_site is required")
         self.toc = []
         self.title = title or "Forms Reference"
         self._anchors: set[str] = set()
         self._markdown = []
-        self.visit_schedules = visit_schedules
+        self.visit_schedules = visit_schedules or []
         self.admin_site = admin_site
         self.include_hidden_fields = include_hidden_fields
         self.plans = {}
@@ -38,15 +46,17 @@ class FormsReference:
             True if add_per_form_timestamp is None else add_per_form_timestamp
         )
         self.timestamp = timezone.now().strftime("%Y-%m-%d %H:%M")
+        self.flat = not self.visit_schedules
         for visit_schedule in self.visit_schedules:
-            self.plans.update({visit_schedule.name: {}})
+            self.plans[visit_schedule.name] = {}
             for schedule in visit_schedule.schedules.values():
                 for visit_code, visit in schedule.visits.items():
-                    crfs = [c.model for c in visit.crfs]
+                    crfs = [(c.model, bool(c.required)) for c in visit.crfs]
                     requisitions = [r.panel.name for r in visit.requisitions]
-                    self.plans[visit_schedule.name].update(
-                        {visit_code: {"crfs": crfs, "requisitions": requisitions}}
-                    )
+                    self.plans[visit_schedule.name][visit_code] = {
+                        "crfs": crfs,
+                        "requisitions": requisitions,
+                    }
 
     def to_file(
         self,
@@ -80,44 +90,120 @@ class FormsReference:
     @property
     def markdown(self):
         if not self._markdown:
-            markdown = []
-            toc = []
-            for plan in self.plans.values():
-                for visit_code, documents in plan.items():
-                    markdown.append(f"{self.h3} {visit_code}\n")
-                    toc.append(
-                        f'\n<a href="#{self.anchor_prefix}-{visit_code.lower()}">'
-                        f"**{visit_code}.**</a>"
-                    )
-                    for index, model in enumerate(documents.get("crfs")):
-                        model_cls = django_apps.get_model(model)
-                        admin_cls = self.admin_site._registry.get(model_cls)
-                        if admin_cls:
-                            describer = self.describer_cls(
-                                admin_cls=admin_cls,
-                                include_hidden_fields=self.include_hidden_fields,
-                                visit_code=visit_code,
-                                level=self.h4,
-                                anchor_prefix=self.anchor_prefix,
-                                add_timestamp=self.add_per_form_timestamp,
-                            )
-                            describer.markdown.append("\n")
-                            anchor = f"{self.get_anchor(describer.anchor)}"
-                            toc.append(
-                                f'{index + 1}. <a href="#{anchor}">{describer.verbose_name}</a>'
-                            )
-                            markdown.extend(describer.markdown)
-                    requisitions = documents.get("requisitions") or []
-                    if requisitions:
-                        markdown.append(f"{self.h4} Requisitions\n")
-                        markdown.extend(
-                            [f"* {panel_name}\n" for panel_name in requisitions]
-                        )
-            markdown = self.insert_toc(toc, markdown)
-            markdown.insert(0, f"{self.h1} {self.title}")
-            markdown.append(
-                f"\n\n*Version v{version(settings.APP_NAME)}* "
-                f"*Rendered on {self.timestamp}*\n"
-            )
-            self._markdown = markdown
+            if self.flat:
+                self._markdown = self._build_flat_markdown()
+            else:
+                self._markdown = self._build_scheduled_markdown()
         return self._markdown
+
+    # --- scheduled mode ---------------------------------------------------
+
+    def _build_scheduled_markdown(self) -> list[str]:
+        markdown: list[str] = []
+        toc: list[str] = []
+        for plan in self.plans.values():
+            for visit_code, documents in plan.items():
+                markdown.append(f"{self.h3} {visit_code}\n")
+                toc.append(
+                    f'\n<a href="#{self.anchor_prefix}-{visit_code.lower()}">'
+                    f"**{visit_code}.**</a>"
+                )
+                crfs = documents.get("crfs") or []
+                required_models = [m for m, req in crfs if req]
+                optional_models = [m for m, req in crfs if not req]
+                index = 0
+                for model in required_models:
+                    index = self._render_scheduled_crf(
+                        model=model,
+                        visit_code=visit_code,
+                        index=index,
+                        markdown=markdown,
+                        toc=toc,
+                    )
+                if optional_models:
+                    markdown.append(f"{self.h4} Optional forms\n")
+                    for model in optional_models:
+                        index = self._render_scheduled_crf(
+                            model=model,
+                            visit_code=visit_code,
+                            index=index,
+                            markdown=markdown,
+                            toc=toc,
+                        )
+                requisitions = documents.get("requisitions") or []
+                if requisitions:
+                    markdown.append(f"{self.h4} Requisitions\n")
+                    markdown.extend(
+                        [f"* {panel_name}\n" for panel_name in requisitions]
+                    )
+        return self._finalize(markdown=markdown, toc=toc)
+
+    def _render_scheduled_crf(
+        self,
+        model: str,
+        visit_code: str,
+        index: int,
+        markdown: list[str],
+        toc: list[str],
+    ) -> int:
+        model_cls = django_apps.get_model(model)
+        admin_cls = self.admin_site._registry.get(model_cls)
+        if not admin_cls:
+            return index
+        describer = self.describer_cls(
+            admin_cls=admin_cls,
+            include_hidden_fields=self.include_hidden_fields,
+            visit_code=visit_code,
+            level=self.h4,
+            anchor_prefix=self.anchor_prefix,
+            add_timestamp=self.add_per_form_timestamp,
+        )
+        if not describer.markdown:
+            return index
+        describer.markdown.append("\n")
+        anchor = self.get_anchor(describer.anchor)
+        toc.append(
+            f'{index + 1}. <a href="#{anchor}">{describer.verbose_name}</a>'
+        )
+        markdown.extend(describer.markdown)
+        return index + 1
+
+    # --- flat mode --------------------------------------------------------
+
+    def _build_flat_markdown(self) -> list[str]:
+        markdown: list[str] = []
+        toc: list[str] = []
+        registry = sorted(
+            self.admin_site._registry.items(),
+            key=lambda kv: kv[0]._meta.verbose_name.lower(),
+        )
+        index = 0
+        for model_cls, admin_cls in registry:
+            describer = self.describer_cls(
+                admin_cls=admin_cls,
+                include_hidden_fields=self.include_hidden_fields,
+                level=self.h3,
+                anchor_prefix=self.anchor_prefix,
+                add_timestamp=self.add_per_form_timestamp,
+            )
+            if not describer.markdown:
+                continue
+            describer.markdown.append("\n")
+            anchor = self.get_anchor(describer.anchor)
+            toc.append(
+                f'{index + 1}. <a href="#{anchor}">{describer.verbose_name}</a>'
+            )
+            markdown.extend(describer.markdown)
+            index += 1
+        return self._finalize(markdown=markdown, toc=toc)
+
+    # --- shared footer ----------------------------------------------------
+
+    def _finalize(self, markdown: list[str], toc: list[str]) -> list[str]:
+        markdown = self.insert_toc(toc, markdown)
+        markdown.insert(0, f"{self.h1} {self.title}")
+        markdown.append(
+            f"\n\n*Version v{version(settings.APP_NAME)}* "
+            f"*Rendered on {self.timestamp}*\n"
+        )
+        return markdown

--- a/src/edc_form_describer/management/commands/make_forms_reference.py
+++ b/src/edc_form_describer/management/commands/make_forms_reference.py
@@ -20,7 +20,7 @@ style = color_style()
 def update_forms_reference(
     app_label: str,
     admin_site_name: str,
-    visit_schedule_name: str,
+    visit_schedule_name: str | None = None,
     title: str | None = None,
     filename: str | None = None,
     doc_folder: str | Path | None = None,
@@ -31,7 +31,10 @@ def update_forms_reference(
     default_doc_folder = Path(settings.BASE_DIR) / "docs"
     filename = filename or f"forms_reference_{app_label}.md"
     admin_site = getattr(module.admin_site, admin_site_name)
-    visit_schedule = site_visit_schedules.get_visit_schedule(visit_schedule_name)
+    if visit_schedule_name:
+        visit_schedules = [site_visit_schedules.get_visit_schedule(visit_schedule_name)]
+    else:
+        visit_schedules = None
     title = title or _("%(title_app)s Forms Reference") % dict(title_app=app_label.upper())
     stdout.write(
         style.MIGRATE_HEADING(f"Refreshing CRF reference document for {app_label}\n")
@@ -40,7 +43,7 @@ def update_forms_reference(
     doc_folder.mkdir(parents=True, exist_ok=True)
 
     forms = FormsReference(
-        visit_schedules=[visit_schedule],
+        visit_schedules=visit_schedules,
         admin_site=admin_site,
         title=f"{title} v{version(settings.APP_NAME)}",
         add_per_form_timestamp=False,
@@ -72,8 +75,12 @@ class Command(BaseCommand):
         parser.add_argument(
             "--visit-schedule",
             dest="visit_schedule_name",
-            required=True,
-            help="Registered visit-schedule name.",
+            default=None,
+            help=(
+                "Registered visit-schedule name. Omit to render all forms "
+                "registered on the admin site in a single flat section "
+                "(e.g. for AE modules with no visit schedule)."
+            ),
         )
         parser.add_argument(
             "--title",


### PR DESCRIPTION
## Summary
- `FormsReference`: when no `visit_schedules` are passed, render every model registered on the admin site in a single flat section sorted by `verbose_name`. Intended for modules like `meta_ae` / `effect_ae` that have an admin site but no visit schedule.
- Within a visit, split CRFs into required and optional. Required CRFs render as before; optional CRFs render under a new `#### Optional forms` sub-section. Requisitions keep their current flat listing.
- `FormsReference.plans` now stores each CRF as `(model, required)` so the required flag is available at render time.
- `make_forms_reference`: `--visit-schedule` becomes optional. Omit it to trigger flat mode.
- Raise a `FormsReferenceError` if `admin_site` is not provided.

## Test plan
- [x] Full clinicedc test suite passes (1601 OK, 37 skipped).
- [ ] Run `make_forms_reference --app-label meta_ae --admin-site meta_ae_admin` (no `--visit-schedule`) and confirm all registered forms render, alphabetised.
- [ ] Run with `--visit-schedule` pointing at a schedule with mixed `required=True/False` CRFs and confirm an `#### Optional forms` sub-section appears below the required ones.
- [ ] Confirm requisitions render unchanged.
- [ ] Confirm TOC numbering counts both required and optional forms for each visit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)