### PR TITLE
feat: return views — request/dispatch, receive, and disposition

### DIFF
--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_disposition.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_disposition.html
@@ -1,0 +1,123 @@
+{% extends edc_base_template %}
+{% load static %}
+
+{% block main %}
+    {{ block.super }}
+    <div class="container">
+        <div class="col-sm-2"></div>
+        <div class="col-sm-8">
+            <div style="padding:10px">
+                <a href="{% url "edc_pharmacy_admin:index" %}">Edc Pharmacy</a> &rsaquo;
+                <a href="{{ changelist_url }}">Return Requests</a>
+                {% if return_request %}&rsaquo; {{ return_request.return_identifier }}{% endif %}
+            </div>
+
+            {% if messages %}
+            {% for message in messages %}
+            <div class="alert alert-{{ message.tags }}">{{ message }}</div>
+            {% endfor %}
+            {% endif %}
+
+            {% if not return_request %}
+            {# ─── Phase 1: Select a return request to disposition ─────── #}
+            <div class="panel panel-default">
+                <div class="panel-heading">Set Disposition for Returned Stock</div>
+                <div class="panel-body">
+                    {% if pending_disposition %}
+                    <table class="table table-condensed">
+                        <thead>
+                            <tr>
+                                <th>Reference</th>
+                                <th>From</th>
+                                <th>Date</th>
+                                <th>Pending Disposition</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for rr in pending_disposition %}
+                            <tr>
+                                <td>{{ rr.return_identifier }}</td>
+                                <td>{{ rr.from_location.display_name }}</td>
+                                <td>{{ rr.return_datetime|date:"d-M-Y" }}</td>
+                                <td>{{ rr.returnitem_set.all|length }}</td>
+                                <td>
+                                    <a href="{% url "edc_pharmacy:return_disposition_url" return_request=rr.pk %}"
+                                       class="btn btn-xs btn-default">Disposition</a>
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    {% else %}
+                    <p class="text-muted">No returned stock awaiting disposition.</p>
+                    {% endif %}
+                </div>
+            </div>
+
+            {% else %}
+            {# ─── Phase 2: Set disposition on received items ──────────── #}
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    Disposition: {{ return_request.return_identifier }}
+                    &mdash; {{ return_request.from_location.display_name }}
+                </div>
+                <div class="panel-body">
+                    <p>
+                        Pending disposition: <strong>{{ pending_count }}</strong>
+                        {% if pending_count == 0 %}
+                            &mdash; <span class="text-success">Complete</span>
+                        {% endif %}
+                    </p>
+
+                    {% if pending_count > 0 %}
+                    <form class="form-horizontal" method="post"
+                          onSubmit="document.getElementById('submit_disposition').disabled=true;">
+                        {% csrf_token %}
+                        <div class="form-group">
+                            <label class="control-label col-sm-4">Disposition</label>
+                            <div class="col-sm-8">
+                                {% for value, label in disposition_choices %}
+                                <div class="radio">
+                                    <label>
+                                        <input type="radio" name="disposition" value="{{ value }}"
+                                               {% if forloop.first %}checked{% endif %}>
+                                        {{ label }}
+                                    </label>
+                                </div>
+                                {% endfor %}
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            {% for i in item_count %}
+                                <label class="control-label col-sm-3" for="codes_{{ forloop.counter }}">
+                                    {{ forloop.counter }}.
+                                </label>
+                                <div class="col-sm-9">
+                                    <input type="text" class="form-control" name="codes"
+                                           id="codes_{{ forloop.counter }}"
+                                           placeholder="stock code {{ forloop.counter }}"
+                                           pattern="[A-Z0-9]{6}"
+                                           {% if forloop.first %}autofocus{% endif %}>
+                                </div>
+                            {% endfor %}
+                        </div>
+                        <div class="col-sm-12">
+                            <button type="submit" class="btn btn-primary"
+                                    id="submit_disposition">Apply Disposition</button>
+                        </div>
+                    </form>
+                    {% else %}
+                    <p class="text-success">All items have been dispositioned.</p>
+                    {% endif %}
+
+                    <button class="btn btn-default" style="margin-top:10px"
+                            onclick="window.location.href='{{ changelist_url }}'">Done</button>
+                </div>
+            </div>
+            {% endif %}
+
+        </div>
+        <div class="col-sm-2"></div>
+    </div>
+{% endblock main %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_receive.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_receive.html
@@ -1,0 +1,115 @@
+{% extends edc_base_template %}
+{% load static %}
+
+{% block main %}
+    {{ block.super }}
+    <div class="container">
+        <div class="col-sm-2"></div>
+        <div class="col-sm-8">
+            <div style="padding:10px">
+                <a href="{% url "edc_pharmacy_admin:index" %}">Edc Pharmacy</a> &rsaquo;
+                <a href="{{ changelist_url }}">Return Requests</a>
+                {% if return_request %}&rsaquo; {{ return_request.return_identifier }}{% endif %}
+            </div>
+
+            {% if messages %}
+            {% for message in messages %}
+            <div class="alert alert-{{ message.tags }}">{{ message }}</div>
+            {% endfor %}
+            {% endif %}
+
+            {% if not return_request %}
+            {# ─── Phase 1: Select a return request to receive ─────────── #}
+            <div class="panel panel-default">
+                <div class="panel-heading">Receive Returned Stock</div>
+                <div class="panel-body">
+                    {% if pending_receipts %}
+                    <table class="table table-condensed">
+                        <thead>
+                            <tr>
+                                <th>Reference</th>
+                                <th>From</th>
+                                <th>Date</th>
+                                <th>Items in Transit</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for rr in pending_receipts %}
+                            <tr>
+                                <td>{{ rr.return_identifier }}</td>
+                                <td>{{ rr.from_location.display_name }}</td>
+                                <td>{{ rr.return_datetime|date:"d-M-Y" }}</td>
+                                <td>
+                                    {{ rr.returnitem_set.all|length }}
+                                </td>
+                                <td>
+                                    <a href="{% url "edc_pharmacy:return_receive_url" return_request=rr.pk %}"
+                                       class="btn btn-xs btn-default">Receive</a>
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    {% else %}
+                    <p class="text-muted">No returns currently in transit.</p>
+                    {% endif %}
+                </div>
+            </div>
+
+            {% else %}
+            {# ─── Phase 2: Confirm receipt of items ───────────────────── #}
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    Receive: {{ return_request.return_identifier }}
+                    &mdash; {{ return_request.from_location.display_name }}
+                    &rarr; {{ return_request.to_location.display_name }}
+                </div>
+                <div class="panel-body">
+                    <p>
+                        Received: <strong>{{ received_count }}</strong> /
+                        In transit: <strong>{{ pending_count }}</strong>
+                        {% if pending_count > 0 %}
+                            &mdash; <span class="text-warning">{{ pending_count }} remaining</span>
+                        {% else %}
+                            &mdash; <span class="text-success">All received</span>
+                        {% endif %}
+                    </p>
+
+                    {% if pending_count > 0 %}
+                    <form class="form-horizontal" method="post"
+                          onSubmit="document.getElementById('submit_receive').disabled=true;">
+                        {% csrf_token %}
+                        <div class="form-group">
+                            {% for i in item_count %}
+                                <label class="control-label col-sm-3" for="codes_{{ forloop.counter }}">
+                                    {{ forloop.counter }}.
+                                </label>
+                                <div class="col-sm-9">
+                                    <input type="text" class="form-control" name="codes"
+                                           id="codes_{{ forloop.counter }}"
+                                           placeholder="stock code {{ forloop.counter }}"
+                                           pattern="[A-Z0-9]{6}"
+                                           {% if forloop.first %}autofocus{% endif %}>
+                                </div>
+                            {% endfor %}
+                        </div>
+                        <div class="col-sm-12">
+                            <button type="submit" class="btn btn-primary"
+                                    id="submit_receive">Confirm Receipt</button>
+                        </div>
+                    </form>
+                    {% else %}
+                    <p class="text-success">All items received.</p>
+                    {% endif %}
+
+                    <button class="btn btn-default" style="margin-top:10px"
+                            onclick="window.location.href='{{ changelist_url }}'">Done</button>
+                </div>
+            </div>
+            {% endif %}
+
+        </div>
+        <div class="col-sm-2"></div>
+    </div>
+{% endblock main %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
@@ -1,0 +1,146 @@
+{% extends edc_base_template %}
+{% load static %}
+
+{% block main %}
+    {{ block.super }}
+    <div class="container">
+        <div class="col-sm-2"></div>
+        <div class="col-sm-8">
+            <div style="padding:10px">
+                <a href="{% url "edc_pharmacy_admin:index" %}">Edc Pharmacy</a> &rsaquo;
+                <a href="{{ changelist_url }}">Return Requests</a>
+                {% if return_request %}&rsaquo; {{ return_request.return_identifier }}{% endif %}
+            </div>
+
+            {% if not return_request %}
+            {# ─── Phase 1: Create a new return request ─────────────────── #}
+            <div class="panel panel-default">
+                <div class="panel-heading">New Return Request</div>
+                <div class="panel-body">
+                    <form class="form-horizontal" method="post"
+                          onSubmit="document.getElementById('submit_new').disabled=true;">
+                        {% csrf_token %}
+                        <div class="form-group">
+                            <label class="control-label col-sm-4" for="from_location_id">Site location</label>
+                            <div class="col-sm-8">
+                                <select class="form-control" id="from_location_id" name="from_location_id" required autofocus>
+                                    <option value="">---------</option>
+                                    {% for loc in from_locations %}
+                                        <option value="{{ loc.id }}">{{ loc.display_name }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-4" for="item_count">Number of items</label>
+                            <div class="col-sm-8">
+                                <input type="number" class="form-control" id="item_count"
+                                       name="item_count" min="1" max="500" required>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-4" for="comment">Comment</label>
+                            <div class="col-sm-8">
+                                <textarea class="form-control" id="comment" name="comment" rows="2"></textarea>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <div class="col-sm-offset-4 col-sm-8">
+                                <button type="submit" class="btn btn-primary" id="submit_new">
+                                    Create Return Request
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            {% if pending_returns %}
+            <div class="panel panel-default">
+                <div class="panel-heading">Open Return Requests</div>
+                <div class="panel-body">
+                    <table class="table table-condensed">
+                        <thead>
+                            <tr>
+                                <th>Reference</th>
+                                <th>From</th>
+                                <th>Date</th>
+                                <th>Items</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for rr in pending_returns %}
+                            <tr>
+                                <td>{{ rr.return_identifier }}</td>
+                                <td>{{ rr.from_location.display_name }}</td>
+                                <td>{{ rr.return_datetime|date:"d-M-Y" }}</td>
+                                <td>{{ rr.received_item_count }} / {{ rr.item_count }}</td>
+                                <td>
+                                    <a href="{% url "edc_pharmacy:return_request_url" return_request=rr.pk %}"
+                                       class="btn btn-xs btn-default">Dispatch</a>
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            {% endif %}
+
+            {% else %}
+            {# ─── Phase 2: Dispatch items on an existing ReturnRequest ──── #}
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    Dispatch: {{ return_request.return_identifier }}
+                    &mdash; {{ return_request.from_location.display_name }}
+                    &rarr; {{ return_request.to_location.display_name }}
+                </div>
+                <div class="panel-body">
+                    <p>
+                        Dispatched: <strong>{{ dispatched_count }}</strong> /
+                        Expected: <strong>{{ return_request.item_count }}</strong>
+                        {% if remaining_count > 0 %}
+                            &mdash; <span class="text-warning">{{ remaining_count }} remaining</span>
+                        {% else %}
+                            &mdash; <span class="text-success">Complete</span>
+                        {% endif %}
+                    </p>
+
+                    {% if remaining_count > 0 %}
+                    <form class="form-horizontal" method="post"
+                          onSubmit="document.getElementById('submit_dispatch').disabled=true;">
+                        {% csrf_token %}
+                        <div class="form-group">
+                            {% for i in item_count %}
+                                <label class="control-label col-sm-3" for="codes_{{ forloop.counter }}">
+                                    {{ forloop.counter }}.
+                                </label>
+                                <div class="col-sm-9">
+                                    <input type="text" class="form-control" name="codes"
+                                           id="codes_{{ forloop.counter }}"
+                                           placeholder="stock code {{ forloop.counter }}"
+                                           pattern="[A-Z0-9]{6}"
+                                           {% if forloop.first %}autofocus{% endif %}>
+                                </div>
+                            {% endfor %}
+                        </div>
+                        <div class="col-sm-12">
+                            <button type="submit" class="btn btn-primary"
+                                    id="submit_dispatch">Dispatch</button>
+                        </div>
+                    </form>
+                    {% else %}
+                    <p class="text-success">All items dispatched.</p>
+                    {% endif %}
+
+                    <button class="btn btn-default" style="margin-top:10px"
+                            onclick="window.location.href='{{ changelist_url }}'">Done</button>
+                </div>
+            </div>
+            {% endif %}
+
+        </div>
+        <div class="col-sm-2"></div>
+    </div>
+{% endblock main %}

--- a/src/edc_pharmacy/urls.py
+++ b/src/edc_pharmacy/urls.py
@@ -12,6 +12,9 @@ from .views import (
     MoveToStorageBinView,
     PrepareAndReviewStockRequestView,
     PrintLabelsView,
+    ReturnDispositionView,
+    ReturnReceiveView,
+    ReturnRequestView,
     TransferStockView,
     get_stock_transfers_view,
     print_stock_transfer_manifest_view,
@@ -142,6 +145,38 @@ urlpatterns = [
         DispenseView.as_view(),
         name="dispense_url",
     ),
+    # ── Return workflow ────────────────────────────────────────────────────
+    path(
+        "return-request/<uuid:return_request>/",
+        ReturnRequestView.as_view(),
+        name="return_request_url",
+    ),
+    path(
+        "return-request/",
+        ReturnRequestView.as_view(),
+        name="return_request_url",
+    ),
+    path(
+        "return-receive/<uuid:return_request>/",
+        ReturnReceiveView.as_view(),
+        name="return_receive_url",
+    ),
+    path(
+        "return-receive/",
+        ReturnReceiveView.as_view(),
+        name="return_receive_url",
+    ),
+    path(
+        "return-disposition/<uuid:return_request>/",
+        ReturnDispositionView.as_view(),
+        name="return_disposition_url",
+    ),
+    path(
+        "return-disposition/",
+        ReturnDispositionView.as_view(),
+        name="return_disposition_url",
+    ),
+    # ───────────────────────────────────────────────────────────────────────
     path("admin/", edc_pharmacy_admin.urls),
     # path("admin/history/", edc_pharmacy_history_admin.urls),
     path("", HomeView.as_view(), name="home_url"),

--- a/src/edc_pharmacy/views/__init__.py
+++ b/src/edc_pharmacy/views/__init__.py
@@ -11,4 +11,7 @@ from .prepare_and_review_stock_request_view import PrepareAndReviewStockRequestV
 from .print_labels_view import PrintLabelsView
 from .print_stock_transfer_manifest_view import print_stock_transfer_manifest_view
 from .print_stock_view import print_stock_view
+from .return_disposition_view import ReturnDispositionView
+from .return_receive_view import ReturnReceiveView
+from .return_request_view import ReturnRequestView
 from .transfer_stock_view import TransferStockView

--- a/src/edc_pharmacy/views/return_disposition_view.py
+++ b/src/edc_pharmacy/views/return_disposition_view.py
@@ -1,0 +1,143 @@
+"""Return disposition view (central pharmacist).
+
+After stock has been received back at central, this view lets the
+central pharmacist choose a final disposition for each item:
+  - repooled    → re-enters general supply
+  - quarantined → set aside for investigation
+  - destroyed   → removed from supply
+"""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.core.exceptions import ObjectDoesNotExist
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView
+
+from edc_dashboard.view_mixins import EdcViewMixin
+from edc_navbar import NavbarViewMixin
+from edc_protocol.view_mixins import EdcProtocolViewMixin
+
+from ..exceptions import ReturnError
+from ..models import ReturnRequest
+from ..utils.process_return_request import disposition_return
+
+DISPOSITION_CHOICES = [
+    ("repooled", "Repooled — return to general supply"),
+    ("quarantined", "Quarantined — set aside for investigation"),
+    ("destroyed", "Destroyed — remove from supply"),
+]
+
+
+@method_decorator(login_required, name="dispatch")
+class ReturnDispositionView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateView):
+    """Central pharmacist: set final disposition on returned stock."""
+
+    template_name = "edc_pharmacy/stock/return_disposition.html"
+    navbar_name = settings.APP_NAME
+    navbar_selected_item = "pharmacy"
+
+    def get_context_data(self, **kwargs):
+        return_request = self._get_return_request()
+        # Returns that have received items needing disposition.
+        pending_disposition = ReturnRequest.objects.filter(
+            returnitem__stock__in_transit=False,
+            returnitem__stock__dispensed=False,
+            returnitem__stock__quarantined=False,
+            returnitem__stock__destroyed=False,
+            cancel__in=["", "N/A"],
+        ).distinct().order_by("-return_datetime")
+
+        pending_count = 0
+        if return_request:
+            pending_count = return_request.returnitem_set.filter(
+                stock__in_transit=False,
+                stock__dispensed=False,
+                stock__quarantined=False,
+                stock__destroyed=False,
+            ).count()
+            items_to_scan = min(pending_count, 12)
+        else:
+            items_to_scan = 0
+
+        kwargs.update(
+            return_request=return_request,
+            pending_disposition=pending_disposition,
+            pending_count=pending_count,
+            item_count=list(range(1, items_to_scan + 1)),
+            disposition_choices=DISPOSITION_CHOICES,
+            changelist_url=reverse(
+                "edc_pharmacy_admin:edc_pharmacy_returnrequest_changelist"
+            ),
+        )
+        return super().get_context_data(**kwargs)
+
+    def _get_return_request(self) -> ReturnRequest | None:
+        pk = self.kwargs.get("return_request")
+        if pk:
+            try:
+                return ReturnRequest.objects.get(pk=pk)
+            except ObjectDoesNotExist:
+                messages.add_message(
+                    self.request, messages.ERROR, "Return request not found."
+                )
+        return None
+
+    def post(self, request, *args, **kwargs):  # noqa: ARG002
+        return_request = self._get_return_request()
+        if not return_request:
+            return HttpResponseRedirect(reverse("edc_pharmacy:return_disposition_url"))
+
+        disposition = request.POST.get("disposition", "").strip()
+        stock_codes = [c.strip().upper() for c in request.POST.getlist("codes") if c.strip()]
+
+        if not disposition:
+            messages.add_message(request, messages.ERROR, "Please select a disposition.")
+            return HttpResponseRedirect(
+                reverse(
+                    "edc_pharmacy:return_disposition_url",
+                    kwargs={"return_request": return_request.pk},
+                )
+            )
+
+        if stock_codes:
+            try:
+                processed, skipped = disposition_return(
+                    stock_codes, request.user, disposition=disposition
+                )
+            except ReturnError as e:
+                messages.add_message(request, messages.ERROR, str(e))
+            else:
+                if processed:
+                    messages.add_message(
+                        request,
+                        messages.SUCCESS,
+                        f"Applied '{disposition}' to {len(processed)} item(s).",
+                    )
+                if skipped:
+                    messages.add_message(
+                        request,
+                        messages.WARNING,
+                        f"Skipped {len(skipped)} item(s): {', '.join(skipped)}",
+                    )
+
+        pending_count = return_request.returnitem_set.filter(
+            stock__in_transit=False,
+            stock__dispensed=False,
+            stock__quarantined=False,
+            stock__destroyed=False,
+        ).count()
+        if pending_count > 0:
+            return HttpResponseRedirect(
+                reverse(
+                    "edc_pharmacy:return_disposition_url",
+                    kwargs={"return_request": return_request.pk},
+                )
+            )
+        return HttpResponseRedirect(
+            reverse("edc_pharmacy_admin:edc_pharmacy_returnrequest_changelist")
+        )

--- a/src/edc_pharmacy/views/return_receive_view.py
+++ b/src/edc_pharmacy/views/return_receive_view.py
@@ -1,0 +1,118 @@
+"""Return receive view (central pharmacist).
+
+Central confirms receipt of stock returned from a site.
+Scans codes and calls receive_return() for each.
+"""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.core.exceptions import ObjectDoesNotExist
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView
+
+from edc_dashboard.view_mixins import EdcViewMixin
+from edc_navbar import NavbarViewMixin
+from edc_protocol.view_mixins import EdcProtocolViewMixin
+
+from ..exceptions import ReturnError
+from ..models import ReturnRequest
+from ..utils.process_return_request import receive_return
+
+
+@method_decorator(login_required, name="dispatch")
+class ReturnReceiveView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateView):
+    """Central pharmacist: confirm receipt of returned stock."""
+
+    template_name = "edc_pharmacy/stock/return_receive.html"
+    navbar_name = settings.APP_NAME
+    navbar_selected_item = "pharmacy"
+
+    def get_context_data(self, **kwargs):
+        return_request = self._get_return_request()
+        pending_receipts = ReturnRequest.objects.filter(
+            returnitem__stock__in_transit=True,
+            cancel__in=["", "N/A"],
+        ).distinct().order_by("-return_datetime")
+
+        received_count = 0
+        pending_count = 0
+        if return_request:
+            received_count = return_request.returnitem_set.filter(
+                stock__in_transit=False,
+                stock__confirmed_at_location=False,
+            ).count()
+            pending_count = return_request.returnitem_set.filter(
+                stock__in_transit=True,
+            ).count()
+            items_to_scan = min(pending_count, 12)
+        else:
+            items_to_scan = 0
+
+        kwargs.update(
+            return_request=return_request,
+            pending_receipts=pending_receipts,
+            received_count=received_count,
+            pending_count=pending_count,
+            item_count=list(range(1, items_to_scan + 1)),
+            changelist_url=reverse(
+                "edc_pharmacy_admin:edc_pharmacy_returnrequest_changelist"
+            ),
+        )
+        return super().get_context_data(**kwargs)
+
+    def _get_return_request(self) -> ReturnRequest | None:
+        pk = self.kwargs.get("return_request")
+        if pk:
+            try:
+                return ReturnRequest.objects.get(pk=pk)
+            except ObjectDoesNotExist:
+                messages.add_message(
+                    self.request, messages.ERROR, "Return request not found."
+                )
+        return None
+
+    def post(self, request, *args, **kwargs):  # noqa: ARG002
+        return_request = self._get_return_request()
+        if not return_request:
+            return HttpResponseRedirect(reverse("edc_pharmacy:return_receive_url"))
+
+        stock_codes = [c.strip().upper() for c in request.POST.getlist("codes") if c.strip()]
+        if stock_codes:
+            try:
+                received, skipped = receive_return(
+                    return_request, stock_codes, request.user
+                )
+            except ReturnError as e:
+                messages.add_message(request, messages.ERROR, str(e))
+            else:
+                if received:
+                    messages.add_message(
+                        request,
+                        messages.SUCCESS,
+                        f"Received {len(received)} item(s).",
+                    )
+                if skipped:
+                    messages.add_message(
+                        request,
+                        messages.WARNING,
+                        f"Skipped {len(skipped)} item(s): {', '.join(skipped)}",
+                    )
+
+        pending_count = return_request.returnitem_set.filter(
+            stock__in_transit=True
+        ).count()
+        if pending_count > 0:
+            return HttpResponseRedirect(
+                reverse(
+                    "edc_pharmacy:return_receive_url",
+                    kwargs={"return_request": return_request.pk},
+                )
+            )
+        return HttpResponseRedirect(
+            reverse("edc_pharmacy_admin:edc_pharmacy_returnrequest_changelist")
+        )

--- a/src/edc_pharmacy/views/return_request_view.py
+++ b/src/edc_pharmacy/views/return_request_view.py
@@ -1,0 +1,170 @@
+"""Return request / dispatch view (site pharmacist).
+
+Two phases on the same URL:
+
+  Phase 1 — no return_request kwarg:
+    POST with stock_codes → calls request_stock_return() to flag each code
+    as return_requested, then redirects back with the return_request pk
+    that was created (or a fresh one is created).
+
+  Phase 2 — return_request kwarg present:
+    POST with codes → calls dispatch_return() to mark each code as
+    in_transit to central and creates ReturnItem rows.
+"""
+
+from __future__ import annotations
+
+from django.apps import apps as django_apps
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.utils import timezone
+from django.views.generic import TemplateView
+
+from edc_dashboard.view_mixins import EdcViewMixin
+from edc_navbar import NavbarViewMixin
+from edc_protocol.view_mixins import EdcProtocolViewMixin
+
+from ..constants import CENTRAL_LOCATION
+from ..exceptions import ReturnError
+from ..models import Location, ReturnRequest
+from ..utils.process_return_request import dispatch_return, request_stock_return
+
+
+@method_decorator(login_required, name="dispatch")
+class ReturnRequestView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateView):
+    """Site pharmacist: request and dispatch stock returns to central."""
+
+    template_name = "edc_pharmacy/stock/return_request.html"
+    navbar_name = settings.APP_NAME
+    navbar_selected_item = "pharmacy"
+
+    def get_context_data(self, **kwargs):
+        return_request = self._get_return_request()
+        pending_returns = ReturnRequest.objects.filter(
+            from_location__site=self.request.site,
+            cancel__in=["", "N/A"],
+        ).order_by("-return_datetime")
+
+        dispatched_count = 0
+        remaining_count = 0
+        if return_request:
+            dispatched_count = return_request.returnitem_set.count()
+            remaining_count = max(
+                0, (return_request.item_count or 0) - dispatched_count
+            )
+            items_to_scan = min(remaining_count, 12)
+        else:
+            items_to_scan = 0
+
+        try:
+            central_location = Location.objects.get(name=CENTRAL_LOCATION)
+        except Location.DoesNotExist:
+            central_location = None
+
+        from_locations = Location.objects.filter(
+            site__in=self.request.user.userprofile.sites.all()
+        )
+
+        kwargs.update(
+            return_request=return_request,
+            pending_returns=pending_returns,
+            dispatched_count=dispatched_count,
+            remaining_count=remaining_count,
+            item_count=list(range(1, items_to_scan + 1)),
+            central_location=central_location,
+            from_locations=from_locations,
+            changelist_url=reverse(
+                "edc_pharmacy_admin:edc_pharmacy_returnrequest_changelist"
+            ),
+        )
+        return super().get_context_data(**kwargs)
+
+    def _get_return_request(self) -> ReturnRequest | None:
+        pk = self.kwargs.get("return_request")
+        if pk:
+            try:
+                return ReturnRequest.objects.get(pk=pk)
+            except ReturnRequest.DoesNotExist:
+                messages.add_message(
+                    self.request, messages.ERROR, "Return request not found."
+                )
+        return None
+
+    def post(self, request, *args, **kwargs):  # noqa: ARG002
+        return_request = self._get_return_request()
+
+        # --- Phase 1: create a new ReturnRequest and flag codes ---
+        if not return_request:
+            from_location_id = request.POST.get("from_location_id")
+            item_count = request.POST.get("item_count")
+            comment = request.POST.get("comment", "")
+            try:
+                from_location = Location.objects.get(pk=from_location_id)
+                central_location = Location.objects.get(name=CENTRAL_LOCATION)
+            except Location.DoesNotExist as e:
+                messages.add_message(request, messages.ERROR, str(e))
+                return HttpResponseRedirect(reverse("edc_pharmacy:return_request_url"))
+
+            try:
+                return_request = ReturnRequest.objects.create(
+                    from_location=from_location,
+                    to_location=central_location,
+                    item_count=int(item_count or 0),
+                    comment=comment,
+                    return_datetime=timezone.now(),
+                    user_created=request.user.username,
+                )
+            except (ReturnError, ValueError) as e:
+                messages.add_message(request, messages.ERROR, str(e))
+                return HttpResponseRedirect(reverse("edc_pharmacy:return_request_url"))
+
+            messages.add_message(
+                request,
+                messages.SUCCESS,
+                f"Return request {return_request.return_identifier} created.",
+            )
+            return HttpResponseRedirect(
+                reverse(
+                    "edc_pharmacy:return_request_url",
+                    kwargs={"return_request": return_request.pk},
+                )
+            )
+
+        # --- Phase 2: dispatch stock codes on an existing ReturnRequest ---
+        stock_codes = [c.strip().upper() for c in request.POST.getlist("codes") if c.strip()]
+        if stock_codes:
+            try:
+                dispatched, skipped = dispatch_return(
+                    return_request, stock_codes, request.user
+                )
+            except ReturnError as e:
+                messages.add_message(request, messages.ERROR, str(e))
+            else:
+                if dispatched:
+                    messages.add_message(
+                        request,
+                        messages.SUCCESS,
+                        f"Dispatched {len(dispatched)} item(s).",
+                    )
+                if skipped:
+                    messages.add_message(
+                        request,
+                        messages.WARNING,
+                        f"Skipped {len(skipped)} item(s): {', '.join(skipped)}",
+                    )
+
+        dispatched_count = return_request.returnitem_set.count()
+        if dispatched_count < (return_request.item_count or 0):
+            return HttpResponseRedirect(
+                reverse(
+                    "edc_pharmacy:return_request_url",
+                    kwargs={"return_request": return_request.pk},
+                )
+            )
+        return HttpResponseRedirect(
+            reverse("edc_pharmacy_admin:edc_pharmacy_returnrequest_changelist")
+        )


### PR DESCRIPTION
## Summary

- **ReturnRequestView** — site pharmacist creates a `ReturnRequest` (phase 1: form with location, item count, comment) then dispatches stock codes one batch at a time (phase 2: scan form), calling `dispatch_return()` to mark each item in-transit.
- **ReturnReceiveView** — central pharmacist sees all in-transit returns, selects one, and scans codes to confirm receipt via `receive_return()`.
- **ReturnDispositionView** — central pharmacist sees all received-but-undispositioned returns, selects one, chooses a disposition (repooled / quarantined / destroyed), and scans codes via `disposition_return()`.

Each view pair (list phase / action phase) follows the same URL pattern as existing transfer/confirm views: `<base>/` and `<base>/<uuid:return_request>/`.

Stacked on top of PR #50 (Allocation OneToOne → FK refactor).

## Test plan

- [ ] 12 `pharmacy_return`-tagged tests pass: `uv run runtests.py --tag=pharmacy_return`
- [ ] Manually create a return request as site pharmacist, dispatch items, receive as central, set disposition

🤖 Generated with [Claude Code](https://claude.com/claude-code)