### PR TITLE
feat: export button on Stock Transaction ledger admin

### DIFF
--- a/src/edc_pharmacy/DESIGN_transaction_log.md
+++ b/src/edc_pharmacy/DESIGN_transaction_log.md
@@ -789,28 +789,33 @@ existing code working.
 
 Run these commands in order when deploying with all PRs merged into develop.
 
+`fix_historical_stock_state` must run **before** `bootstrap_stock_transactions`
+because it creates `TXN_REPACK_CONSUMED` rows (with a `repack_request` FK) for
+repacked bulk stock.  Bootstrap then detects those stocks as already having
+transactions and only backfills the missing `TXN_RECEIVED` row.  Running
+`fix_historical_stock_state` a **second time** after bootstrap applies the
+`repack_consumed_qty_delta` fix (patch `qty_delta=0 → -1` for containers whose
+`qty_out=1`); the command is fully idempotent for both runs.
+
 ```bash
-# 1. Run all migrations (0139–0145 plus any others)
+# 1. Run all migrations
 uv run --dev manage.py migrate
 
-# 2. Fix known pre-refactor stock inconsistencies before bootstrapping:
-#    - in_transit stuck True (old signal never cleared it)
-#    - allocation not nulled after dispense
-#    - invalid qty_delta=0 on bootstrapped TXN_RECEIVED rows
+# 2. Fix known pre-refactor Stock column inconsistencies and create
+#    TXN_REPACK_CONSUMED rows for repacked bulk stock (must run before bootstrap).
 uv run --dev manage.py fix_historical_stock_state
 
-# 3. Mark the three irreconcilable pre-refactor stocks as invalid_state=True
-#    so bootstrap and ledger-check skip them.
-#    (UGNXMR, 4992XB, 94UQKG — dispensed with no DispenseItem and no allocation)
-uv run --dev manage.py shell -c \
-  "from edc_pharmacy.models import Stock; Stock.objects.filter(code__in=['UGNXMR','4992XB','94UQKG']).update(invalid_state=True)"
-
-# 4. Back-fill StockTransaction rows for all pre-refactor stock.
+# 3. Back-fill StockTransaction rows for all pre-refactor stock.
 #    Idempotent — safe to re-run. Shows a tqdm progress bar.
 uv run --dev manage.py bootstrap_stock_transactions
 
+# 4. Second pass — patches TXN_REPACK_CONSUMED qty_delta on containers
+#    whose qty_out=1 (set by old repack workflow). All other fixes are
+#    idempotent no-ops at this point.
+uv run --dev manage.py fix_historical_stock_state
+
 # 5. Verify ledger replay matches Stock cache columns.
-#    Expected result: N OK, 0 discrepancies, small number of no-transactions, 3 skipped.
+#    Expected result: N OK, 0 discrepancies, small number with no transactions.
 uv run --dev manage.py check_stock_ledger
 ```
 

--- a/src/edc_pharmacy/DESIGN_transaction_log.md
+++ b/src/edc_pharmacy/DESIGN_transaction_log.md
@@ -1,0 +1,826 @@
+# edc_pharmacy transaction-log refactor — design sketch
+
+**Status:** Draft. Not implemented. Open for review.
+**Audience:** edc_pharmacy maintainers.
+**Author:** Erik van Widenfelt
+**Related:** returns workflow, allocation history, dormant `StockTransaction` model.
+
+---
+
+## 1. Why
+
+`Stock` today carries current state as boolean flags (`confirmed`,
+`confirmed_at_location`, `stored_at_location`, `dispensed`, `destroyed`,
+`in_transit`) plus the presence/absence of OneToOne child rows
+(`StorageBinItem`, `ConfirmationAtLocationItem`, `DispenseItem`,
+`Confirmation`, `Allocation`). Writes are driven by a dozen `post_save` /
+`post_delete` signal handlers — each flipping one flag from a different
+sender model.
+
+That design is optimised for the forward monotonic path
+(receive → repack → allocate → transfer → confirm → store → dispense). It
+does not accommodate:
+
+- **Returns** — bottle goes back from site to central, then is re-pooled,
+  quarantined, or destroyed. Reversing booleans overloads their meaning.
+- **Reallocation** — `Stock.allocation` is OneToOne, so a returned bottle
+  cannot be allocated to a second subject while preserving history.
+- **History** — only `HistoricalRecords` captures prior states, which is
+  fine for audit trails but useless for answering "when was this bottle
+  dispensed?" or "how long between receipt at site and storage?"
+
+The dormant `StockTransaction` model already exists in the schema,
+suggesting the original author anticipated this.
+
+---
+
+## 2. Target architecture — hybrid CQRS-lite
+
+Keep the cache columns on `Stock` as a denormalised **state projection**
+(balance sheet). Add the ledger rows (`StockTransaction`) as the **source
+of truth for history** (general ledger). One write path enforces
+consistency.
+
+```
+                ┌──────────────────────┐
+   business ──> │  apply_transaction() │ ──> writes ledger row
+   action       │   (choke point)      │ ──> writes cache columns
+                └──────────────────────┘         (Stock + children)
+```
+
+**Rule:** never edit the cache without writing to the ledger.
+Enforced by deleting all existing mutation signal handlers and routing
+every write through `apply_transaction`. A debug-only `post_save`
+tripwire on Stock can log any mutation whose call stack doesn't include
+`apply_transaction`.
+
+---
+
+## 3. The three pieces — `StateDelta`, `compute_delta`, `apply_transaction`
+
+The core contract splits **pure computation** from **imperative apply**,
+so V2's replay engine (needed for reversals) is mechanical.
+
+### 3.1 `StateDelta` — value object
+
+Pure, immutable, no DB. Encodes everything `apply_transaction` must do
+after writing the ledger row.
+
+```python
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+ChildAction = Literal["create", "delete", "unchanged"]
+AllocationAction = Literal["create", "end", "unchanged"]
+
+@dataclass(frozen=True)
+class StateDelta:
+    # Stock cache column updates. Keys are Stock field names.
+    # Values are the new values (not deltas). Empty dict = no change.
+    stock_fields: dict[str, Any] = field(default_factory=dict)
+
+    # OneToOne child rows. "create" means apply_delta materialises the
+    # row using kwargs; "delete" removes the existing row; "unchanged"
+    # leaves it alone. A transaction can touch multiple children (e.g.
+    # DISPENSED also deletes StorageBinItem).
+    storage_bin_item: ChildAction = "unchanged"
+    confirmation_at_location_item: ChildAction = "unchanged"
+    confirmation: ChildAction = "unchanged"
+    dispense_item: ChildAction = "unchanged"
+
+    # Allocation lifecycle. "create" opens a new Allocation;
+    # "end" sets ended_datetime + ended_reason on the active one.
+    allocation_action: AllocationAction = "unchanged"
+    allocation_end_reason: str | None = None
+
+    # Location change (None = no change). Writes Stock.location plus
+    # the ledger from_location/to_location.
+    new_location_id: int | None = None
+
+    # Qty changes (signed). None = no change.
+    qty_delta: "Decimal | None" = None
+    unit_qty_delta: "Decimal | None" = None
+
+    # Guards. Non-empty = refuse to apply.
+    preconditions_failed: tuple[str, ...] = ()
+```
+
+Notes:
+- `stock_fields` is **absolute values**, not deltas, because boolean
+  flips and FKs are not naturally delta-able. `qty_delta` /
+  `unit_qty_delta` *are* signed deltas because they compose over a
+  lifetime (received 60, dispensed 30, adjusted -5, balance 25).
+- `preconditions_failed` means `compute_delta` noticed the state is
+  illegal for this transaction type (e.g. DISPENSED on a bottle that
+  isn't stored). `apply_transaction` raises before touching the DB.
+
+### 3.2 `compute_delta` — pure
+
+Signature:
+
+```python
+def compute_delta(
+    txn_type: str,
+    current: CurrentState,
+    **kwargs,
+) -> StateDelta: ...
+```
+
+`CurrentState` is a snapshot of what `compute_delta` needs to reason
+about the stock row, read once by `apply_transaction` before the call:
+
+```python
+@dataclass(frozen=True)
+class CurrentState:
+    stock_id: int
+    location_id: int | None
+    confirmed: bool
+    confirmed_at_location: bool
+    stored_at_location: bool
+    dispensed: bool
+    destroyed: bool
+    in_transit: bool
+    qty_in: Decimal
+    qty_out: Decimal
+    unit_qty_in: Decimal
+    unit_qty_out: Decimal
+    has_active_allocation: bool
+    active_allocation_subject: str  # "" if none
+    has_storage_bin_item: bool
+    has_confirmation_at_location_item: bool
+```
+
+No ORM inside `compute_delta`. No `self`. Just a dispatch table:
+
+```python
+_COMPUTERS: dict[str, Callable[..., StateDelta]] = {
+    "RECEIVED": _compute_received,
+    "ALLOCATED": _compute_allocated,
+    "ALLOCATION_ENDED": _compute_allocation_ended,
+    "TRANSFER_RECEIVED": _compute_transfer_received,
+    "DISPENSED": _compute_dispensed,
+    # ... 17 more
+}
+```
+
+Each computer is a small pure function. Easily unit-testable by
+parameterising current-state tuples.
+
+### 3.3 `apply_transaction` — orchestrator
+
+```python
+def apply_transaction(
+    stock: Stock,
+    txn_type: str,
+    actor: User,
+    *,
+    reason: str = "",
+    source_object: models.Model | None = None,
+    **kwargs,
+) -> StockTransaction:
+    current = _snapshot(stock)
+    delta = compute_delta(txn_type, current, **kwargs)
+    if delta.preconditions_failed:
+        raise InvalidTransitionError(
+            f"{txn_type} refused on stock={stock.code}: "
+            f"{'; '.join(delta.preconditions_failed)}"
+        )
+    with transaction.atomic():
+        txn = _write_ledger_row(
+            stock=stock,
+            txn_type=txn_type,
+            delta=delta,
+            actor=actor,
+            reason=reason,
+            source_object=source_object,
+            **kwargs,
+        )
+        _apply_delta(stock, delta, txn=txn, **kwargs)
+    return txn
+```
+
+`_apply_delta` is the only place that does ORM writes on Stock and its
+OneToOne children. It uses `update_fields=` on `Stock.save()` so the
+existing save() guards still apply — in fact those guards should be
+rewritten to accept only calls that originate in `_apply_delta`
+(checked via a thread-local sentinel, not inspection of call stack).
+
+`_write_ledger_row` snapshots the *post-delta* state into
+`StockTransaction.state_after` JSONField. Makes "why is this in this
+state?" a single query.
+
+---
+
+## 4. Triggers — scan utils as the choke-point callers
+
+A subset of transaction types are **scan-driven**: the trigger is not a
+business-object `.save()` but a barcode being scanned through a
+dedicated view or admin action that funnels into a per-list util. Those
+utils are the natural callers of `apply_transaction`, one call per
+scanned code.
+
+| Transaction | Trigger surface | Existing util | Child row materialised |
+|---|---|---|---|
+| `RECEIVED` (received & repacked) | admin actions `confirm_repacked_stock_action` / `confirm_received_stock_action` → scan view `confirm_stock_from_queryset_view` | `utils/confirm_stock.py::confirm_stock` | `Confirmation` |
+| `TRANSFER_RECEIVED` | scan view `confirm_at_location_view` | `utils/confirm_stock_at_location.py` | `ConfirmationAtLocationItem` |
+| `STORED` | scan views `add_to_storage_bin_view` / `move_to_storage_bin_view` | (likely a util alongside the views) | `StorageBinItem` |
+| `DISPENSED` | scan view `dispense_view` | `utils/dispense.py::dispense` | `DispenseItem` |
+| `RETURN_DISPATCHED` / `RETURN_RECEIVED` | (future, mirrors above) | (future) | (future) |
+
+Call shape for every scan-driven flow:
+
+```
+[admin action OR view POST]
+   └─ util(stock_codes, ...)                # iterates the scan list
+        └─ for code in stock_codes:
+              try:
+                  stock = Stock.objects.get(code=code, ...)
+                  apply_transaction(stock, TXN, actor=request.user, ...)
+                  confirmed.append(code)
+              except Stock.DoesNotExist:
+                  invalid.append(code)
+              except InvalidTransitionError:        # already confirmed etc.
+                  already_confirmed.append(code)
+   ↳ returns (confirmed, already_confirmed, invalid)
+```
+
+Today these utils call `Confirmation.objects.create(stock=stock, ...)`
+(etc.) directly, and rely on a `post_save` signal to flip the cache
+flag. After the refactor the util drops the direct `.create(...)`; the
+child row is materialised inside `_apply_delta` per
+`StateDelta.<child_action>="create"`. The util's three-bucket return
+value stays unchanged — `apply_transaction` raising
+`InvalidTransitionError("already confirmed")` maps to the
+`already_confirmed` bucket the existing views already render.
+
+`ScanDuplicates` (the model behind `migrations/0057_scanduplicates.py`)
+is orthogonal — it logs duplicate scan attempts at the surface layer
+and is unaffected by this refactor.
+
+The non-scan-driven transactions (`ALLOCATED`, `ALLOCATION_ENDED`,
+`TRANSFER_DISPATCHED`, `BIN_MOVED`, the exception types `DAMAGED` /
+`LOST` / `EXPIRED` / `VOIDED`, and `ADJUSTED`) are triggered by admin
+actions or model saves where the operator records a fact; no physical
+scan. Same `apply_transaction` choke point, just different caller.
+
+---
+
+## 5. Representative cases (5 of 22)
+
+Enough to prove the shape. The remaining 17 are mechanical fill-in.
+
+### 5.1 `RECEIVED` (scan-driven)
+
+A bulk receipt's labels are scanned at central pharmacy via
+`confirm_stock` after `ReceiveItem` rows already exist.
+
+**Caller:** `utils/confirm_stock.py::confirm_stock`, looping over
+`stock_codes`.
+
+**Preconditions:** stock row exists (created by `ReceiveItem`); not
+already confirmed.
+
+```python
+def _compute_received(current, *, confirmed_datetime, **_) -> StateDelta:
+    if current.confirmed:
+        return StateDelta(preconditions_failed=("already confirmed",))
+    return StateDelta(
+        stock_fields={
+            "confirmed": True,
+            "confirmed_datetime": confirmed_datetime,
+        },
+        confirmation="create",
+        # Note: qty / unit_qty deltas already booked at ReceiveItem time.
+        # RECEIVED here is the *label-confirmation* event, not the
+        # quantity event. If we model qty as also gated on confirmation,
+        # this is where qty_delta moves; keeping it on ReceiveItem for V1
+        # to minimise churn. Open question.
+    )
+```
+
+`_apply_delta` materialises the `Confirmation` row using the
+`confirmed_by` and `confirmed_datetime` kwargs threaded through from
+the util.
+
+### 5.2 `ALLOCATED` (business-action-driven)
+
+Central pharmacist allocates a prepared bottle to a subject (via a
+stock request).
+
+**Preconditions:** not dispensed, not destroyed, no active allocation.
+
+```python
+def _compute_allocated(current, *, stock_request_item, registered_subject, **_):
+    fail = []
+    if current.dispensed:
+        fail.append("already dispensed")
+    if current.destroyed:
+        fail.append("destroyed")
+    if current.has_active_allocation:
+        fail.append("already allocated (end it first)")
+    if fail:
+        return StateDelta(preconditions_failed=tuple(fail))
+    return StateDelta(
+        stock_fields={
+            "subject_identifier": registered_subject.subject_identifier,
+        },
+        allocation_action="create",
+    )
+```
+
+The actual `Allocation` row is created by `_apply_delta` using
+`stock_request_item` + `registered_subject` kwargs. `_apply_delta`
+also sets `Stock.current_allocation_id` (post Allocation FK refactor —
+see companion doc on Allocation OneToOne→FK).
+
+### 5.3 `ALLOCATION_ENDED` (business-action-driven)
+
+Close out an allocation. Reasons: `dispensed`, `returned`,
+`reallocated`, `damaged`, `expired`, `voided`, `lost`.
+
+```python
+VALID_END_REASONS = {
+    "dispensed", "returned", "reallocated",
+    "damaged", "expired", "voided", "lost",
+}
+
+def _compute_allocation_ended(current, *, reason, **_):
+    if not current.has_active_allocation:
+        return StateDelta(preconditions_failed=("no active allocation",))
+    if reason not in VALID_END_REASONS:
+        return StateDelta(preconditions_failed=(f"invalid reason: {reason}",))
+    stock_fields = {}
+    if reason != "dispensed":
+        # All non-dispense endings sever the subject relationship.
+        # For dispensed, subject_identifier is intentionally preserved —
+        # the bottle's recipient is permanent record. See lifecycle table in §5.5.
+        stock_fields["subject_identifier"] = ""
+    return StateDelta(
+        stock_fields=stock_fields,
+        allocation_action="end",
+        allocation_end_reason=reason,
+    )
+```
+
+### 5.4 `TRANSFER_RECEIVED` (scan-driven)
+
+Bottle arrives at the site pharmacy after being dispatched from
+central. Flips `in_transit` off and `confirmed_at_location` on.
+
+**Caller:** `utils/confirm_stock_at_location.py`, looping over the
+codes scanned from the `confirm_at_location_view` POST.
+
+**Preconditions:** in transit; not already confirmed at this location.
+
+```python
+def _compute_transfer_received(current, *, site_location_id, **_):
+    fail = []
+    if not current.in_transit:
+        fail.append("not in transit")
+    if current.confirmed_at_location:
+        fail.append("already confirmed at location")
+    if fail:
+        return StateDelta(preconditions_failed=tuple(fail))
+    return StateDelta(
+        stock_fields={
+            "in_transit": False,
+            "confirmed_at_location": True,
+        },
+        confirmation_at_location_item="create",
+        new_location_id=site_location_id,
+    )
+```
+
+### 5.5 `DISPENSED` (scan-driven)
+
+Patient receives the bottle. Ends the allocation (reason=dispensed) and
+removes the StorageBinItem — currently done as an *accidental*
+side-effect in `dispense_item_on_post_save`; made explicit here.
+
+**Caller:** `utils/dispense.py::dispense`, looping over the bottle
+codes scanned at handover.
+
+```python
+def _compute_dispensed(current, *, dispense_item, **_):
+    fail = []
+    if current.dispensed:
+        fail.append("already dispensed")
+    if not current.stored_at_location:
+        fail.append("not stored at location")
+    if not current.has_active_allocation:
+        fail.append("no active allocation")
+    if fail:
+        return StateDelta(preconditions_failed=tuple(fail))
+    return StateDelta(
+        stock_fields={
+            "dispensed": True,
+            "stored_at_location": False,
+            # subject_identifier intentionally NOT cleared:
+            # dispense is terminal — the bottle's recipient is permanent.
+        },
+        dispense_item="create",
+        storage_bin_item="delete",
+        allocation_action="end",
+        allocation_end_reason="dispensed",
+        qty_delta=-dispense_item.qty,
+        unit_qty_delta=-(dispense_item.unit_qty),
+    )
+```
+
+Note: this single `DISPENSED` call replaces what today takes
+`dispense_item_on_post_save` + the implicit StorageBinItem deletion +
+a separate Allocation end path (which doesn't exist today because
+allocation is OneToOne — it just gets overwritten on reallocation,
+losing history).
+
+**`Stock.subject_identifier` lifecycle.** Because the lifecycle is
+non-obvious, stating it explicitly:
+
+| Transaction | `Stock.subject_identifier` after |
+|---|---|
+| `ALLOCATED` | set to the allocated subject |
+| `DISPENSED` | **kept** — bottle's permanent recipient |
+| `ALLOCATION_ENDED` (reason=dispensed) | **kept** — same rule: recipient identity is permanent record |
+| `ALLOCATION_ENDED` (reason=reallocated) | cleared, then the next `ALLOCATED` sets it to the new subject |
+| `ALLOCATION_ENDED` (reason=returned / damaged / expired / voided / lost) | cleared — bottle no longer with the subject |
+
+`Stock.current_allocation` (the FK pointer added by the Allocation
+refactor) goes to NULL on every end reason including DISPENSED — there
+is no *active* allocation after dispense, even though the recipient
+identity is preserved on the Stock row for reporting and audit. Full
+allocation history remains queryable via `stock.allocations.all()`.
+
+---
+
+## 6. What goes away
+
+Every mutation handler in `signals.py` listed in the code tour
+(lines 73, 92, 211, 222, 235, 248, 261, 272, 320, 332, 342, 352, 362)
+is deleted. The senders that drove those handlers (`Confirmation`,
+`StockTransferItem`, `ConfirmationAtLocationItem`, `StorageBinItem`,
+`DispenseItem`, `Allocation`, `StockAdjustment`) keep their `save()`
+paths but no longer mutate `Stock` directly.
+
+The replacement callers fall into two camps:
+
+**Scan-driven** — utils that already exist and that already loop over
+`stock_codes`. They drop the direct `child_row.objects.create(...)`
+and instead call `apply_transaction(stock, TXN, ...)`, which
+materialises the child row inside `_apply_delta`:
+
+| Today | After |
+|---|---|
+| `confirm_stock` util `Confirmation.objects.create(stock=...)` → `confirmation_on_post_save` flips `stock.confirmed` | `confirm_stock` util calls `apply_transaction(stock, RECEIVED, confirmed_by=..., confirmed_datetime=...)` |
+| `confirm_stock_at_location` util `ConfirmationAtLocationItem.objects.create(...)` → `confirm_at_location_item_on_post_save` flips `stock.confirmed_at_location` | util calls `apply_transaction(stock, TRANSFER_RECEIVED, location=...)` |
+| `add_to_storage_bin` flow `StorageBinItem.objects.create(...)` → `storage_bin_item_on_post_save` flips `stock.stored_at_location` | call `apply_transaction(stock, STORED, bin=...)` |
+| `dispense` util `DispenseItem.objects.create(...)` → `dispense_item_on_post_save` flips `stock.dispensed` and quietly deletes the StorageBinItem | util calls `apply_transaction(stock, DISPENSED, dispense_item_kwargs=...)`; the StorageBinItem deletion becomes an *explicit* `storage_bin_item="delete"` in `StateDelta` |
+
+The earlier draft's claim that `ReceiveItem.save()` triggers `RECEIVED`
+was wrong — `ReceiveItem` records *expected* receipt; the actual
+confirmation event is the label scan that creates `Confirmation`.
+
+**Business-action-driven** — admin actions or model saves where the
+operator records a fact, no scan. These call `apply_transaction`
+inline:
+
+| Today | After |
+|---|---|
+| `transfer_stock` action / `transfer_stock_view` creates `StockTransferItem` → `stock_transfer_item_on_post_save` flips `in_transit` | action calls `apply_transaction(stock, TRANSFER_DISPATCHED, transfer_item=...)` |
+| `allocate_stock` util writes `Allocation`; `allocation_on_post_save` denormalises `subject_identifier` | util calls `apply_transaction(stock, ALLOCATED, registered_subject=..., stock_request_item=...)` |
+| `StockAdjustment.save()` → `stock_adjustment_on_post_save` mutates `unit_qty_in` | adjustment-creation path calls `apply_transaction(stock, ADJUSTED, unit_qty_in_new=...)` |
+
+`Stock.save()`'s current mutation guards (lines 174–224) are
+tightened: all mutation of guarded fields goes through `_apply_delta`,
+which uses a thread-local sentinel so the save() guard can let
+through only those writes. Any other save of a guarded field raises.
+
+---
+
+## 7. Testability payoff
+
+- `compute_delta` is pure — every transaction type is a table test.
+  Current-state in, expected StateDelta out. No DB, no fixtures.
+- `apply_transaction` has one integration test per type that asserts
+  ledger row written + cache matches.
+- `check_stock_ledger` management command replays the log from
+  `RECEIVED` and asserts the resulting projection equals the current
+  cache. Catches any write that bypassed `apply_transaction`.
+
+---
+
+## 8. Not in this sketch (on purpose)
+
+- Schema for expanded `StockTransaction` (defaults, indexes,
+  constraints, `reverses` self-FK). See memory doc `project_edc_pharmacy_refactor.md`
+  §"Expanded StockTransaction schema".
+- Allocation OneToOne → FK migration. Same memory doc,
+  §"Allocation model refactor".
+- Bootstrap migration (synthesising historical ledger rows from existing
+  timestamps). Next sketch (c).
+- Stock schema changes (new cache flags: `return_requested`,
+  `quarantined`). Next sketch (b).
+- REVERSAL machinery. V2.
+
+---
+
+## 9. Open questions to settle before coding
+
+1. **Thread-local vs call-stack sentinel** for Stock.save() guard — thread-local
+   is simpler and faster, but risks silent leaks across requests if poorly
+   scoped. Call-stack inspection is airtight but ugly. Recommend thread-local
+   with an `apply_delta` context-manager that always clears on exit.
+
+2. **`StockTransaction.state_after` JSONField** — redundant with replay. Worth
+   the storage cost? Argument for: makes "why is this here" a single query;
+   makes V2 reconciliation O(1) per row. Argument against: duplication,
+   drift risk. Recommend keeping for V1; revisit.
+
+3. **`source_object` as GenericFK vs separate nullable FKs per source
+   model** — memory doc proposes separate FKs (`receive_item`, `repack_request`,
+   `dispense_item`, etc.). That's more columns but better indexes and
+   type safety. Sticking with separate FKs.
+
+4. **`allocation_action = "end"` vs explicit `ALLOCATION_ENDED` as its own
+   transaction type** — in the sketch above, `DISPENSED` directly sets
+   `allocation_action="end"`. An alternative is: `DISPENSED` emits two ledger
+   rows (`DISPENSED` + `ALLOCATION_ENDED`). Two rows is cleaner for the
+   ledger but complicates `apply_transaction`'s single-row contract.
+   Recommend: single row, `allocation_action` lives in the StateDelta,
+   ledger records the effective end via `to_allocation` / `from_allocation`
+   columns.
+
+5. **Per-scan vs per-batch `transaction.atomic()`** — a scan session can be
+   50+ bottles. Today's utils run each `child_row.objects.create(...)` inside
+   the request transaction, so the whole batch is effectively one atomic
+   block; if any single create fails, none commit. Two options after the
+   refactor:
+
+   - **Per-scan**: each `apply_transaction` opens its own `atomic()`. A
+     mid-batch precondition failure (e.g. one already-confirmed code) does
+     not roll back the bottles already confirmed in this session. Matches
+     current user-visible behaviour where the view buckets results into
+     confirmed / already_confirmed / invalid and shows a per-bottle summary.
+   - **Per-batch**: the util wraps the whole `for code in stock_codes:` loop
+     in one outer `atomic()`, and `apply_transaction` joins it (no nested
+     atomic). One failed precondition still doesn't roll back the batch
+     because preconditions raise before the DB writes; but a DB-level error
+     (constraint violation in a child row create, deadlock) would now roll
+     back the whole batch instead of just the offending bottle.
+
+   Recommend per-scan. It matches today's three-bucket UX, isolates DB
+   surprises to the offending row, and keeps batch sizes from blowing up
+   long-running transactions on MySQL. The "all-or-nothing" semantics for a
+   manifest aren't actually a requirement — the manifest is reconciled by
+   the unconfirmed_count query, not by atomicity.
+
+---
+
+## 10. Next sketches
+
+Per the memory doc's next-step list:
+
+- **(b)** Stock schema changes — new cache flags, changed semantics,
+  migration strategy for existing rows. → **§11 below.**
+- **(c)** Bootstrap migration — synthesise historical `StockTransaction`
+  rows from current data so projection equals replay on day one.
+
+---
+
+## 11. Sketch (b) — Stock schema changes
+
+### 11.1 New cache flag columns
+
+Six boolean flags to add (all `default=False`, `editable=False`):
+
+| Field | Set by | Cleared by | Terminal? |
+|---|---|---|---|
+| `return_requested` | `RETURN_REQUESTED` | `RETURN_DISPATCHED` | No |
+| `quarantined` | `RETURN_DISPOSITION_QUARANTINED` | `RETURN_DISPOSITION_REPOOLED` | No |
+| `damaged` | `DAMAGED` | never | Soft — can subsequently be destroyed |
+| `lost` | `LOST` | never | Yes |
+| `expired` | `EXPIRED` | never | Yes |
+| `voided` | `VOIDED` | never | Yes |
+
+`destroyed` already exists on the model. Retain as-is.
+
+Notes:
+- `quarantined` is the only non-terminal new flag (besides `return_requested`).
+  A quarantined bottle can be re-pooled: `RETURN_DISPOSITION_REPOOLED` clears
+  the flag so "currently quarantined" stays a simple `filter(quarantined=True)`.
+- `damaged` is soft-terminal: a damaged bottle can subsequently be destroyed
+  (`damaged=True` AND `destroyed=True` is a valid state). All others
+  (`lost`, `expired`, `voided`) are hard-terminal — once set, no further
+  transitions in V1.
+- `return_requested` is transient. It is cleared atomically by
+  `RETURN_DISPATCHED`, which also sets `in_transit=True`. The two writes
+  happen inside the single `_apply_delta` call — no intermediate state is
+  ever visible.
+
+### 11.2 Existing flag semantics (governance changes only)
+
+No semantic change to the existing seven flags. What changes is *who sets
+them*.
+
+| Flag | Governed by today | Governed by after |
+|---|---|---|
+| `confirmed` | `confirmation_on_post_save` | `apply_transaction(RECEIVED, ...)` |
+| `confirmed_at_location` | `confirm_at_location_item_on_post_save` | `apply_transaction(TRANSFER_RECEIVED, ...)` |
+| `in_transit` | `stock_transfer_item_on_post_save` | `apply_transaction(TRANSFER_DISPATCHED / RECEIVED, ...)` |
+| `stored_at_location` | `storage_bin_item_on_post_save` | `apply_transaction(STORED / DISPENSED / RETURN_DISPATCHED, ...)` |
+| `dispensed` | `dispense_item_on_post_save` | `apply_transaction(DISPENSED, ...)` |
+| `destroyed` | manual admin write (unguarded today) | `apply_transaction(RETURN_DISPOSITION_DESTROYED / DAMAGED+destroy, ...)` |
+
+The `DISPENSED` path makes `stored_at_location=False` and `dispensed=True`
+atomically — the old implicit side-effect in `dispense_item_on_post_save`
+is now explicit in `StateDelta` (§5.5).
+
+### 11.3 Illegal state combinations
+
+These combinations must never exist. `apply_transaction` enforces them via
+`compute_delta` preconditions; `check_stock_ledger` asserts them at audit
+time.
+
+```
+# Terminal state exclusions (except damaged+destroyed, which is valid)
+dispensed  + destroyed    dispensed + damaged      dispensed + lost
+dispensed  + expired      dispensed + voided
+lost       + destroyed    lost + expired           lost + voided
+expired    + voided       voided + destroyed
+
+# In-motion / storage exclusions
+in_transit + stored_at_location
+dispensed  + stored_at_location    dispensed + in_transit
+destroyed  + in_transit
+```
+
+Encode as a `_check_not_terminal(current)` helper (returns a list of
+failure strings) reused across all transaction computers that must refuse
+to operate on a terminal bottle.
+
+### 11.4 `Stock.save()` guard refactor
+
+Today's guards use `update_fields` inspection — bypassed by any caller
+that passes `update_fields=["in_transit"]` directly:
+
+```python
+# current — bypassable
+if "in_transit" not in kwargs.get("update_fields", []):
+    if self.in_transit != original.in_transit:
+        raise StockError(...)
+```
+
+Replace with a thread-local sentinel:
+
+```python
+import threading
+_tl = threading.local()
+
+@contextmanager
+def _apply_delta_context():
+    _tl.active = True
+    try:
+        yield
+    finally:
+        _tl.active = False
+
+GUARDED_FIELDS = frozenset({
+    "confirmed", "confirmed_at_location", "in_transit",
+    "stored_at_location", "dispensed", "destroyed",
+    "return_requested", "quarantined",
+    "damaged", "lost", "expired", "voided",
+})
+```
+
+In `Stock.save()`, replace the three `update_fields` blocks with:
+
+```python
+if not getattr(_tl, "active", False):
+    try:
+        original = Stock.objects.get(pk=self.pk)
+    except Stock.DoesNotExist:
+        pass  # new row — nothing to guard
+    else:
+        changed = [f for f in GUARDED_FIELDS if getattr(self, f) != getattr(original, f)]
+        if changed:
+            raise StockError(
+                f"Mutating {changed} requires apply_transaction. "
+                "Do not write guarded fields directly."
+            )
+```
+
+`_apply_delta` wraps all ORM writes inside `with _apply_delta_context():`.
+Any path that mutates a guarded field without going through `_apply_delta`
+trips the guard — including management commands, shell scripts, and test
+fixtures that call `stock.save()` directly.
+
+Three save()-time invariants that are NOT field mutations stay in `save()`:
+- `stock_identifier` / `code` assignment (new row only — no guard needed).
+- `verify_assignment_or_raise()` (lot/product consistency — always runs).
+- `update_status()` (derived from `current_allocation`, `qty_in`,
+  `qty_out` — still recomputed on every save so it stays consistent when
+  `_apply_delta` calls `stock.save()`).
+
+### 11.5 `allocation` OneToOne → `current_allocation` FK
+
+Full 4-step migration sketch in the memory doc §"Allocation model
+refactor". Summary for this doc:
+
+- Remove: `allocation = OneToOneField(Allocation)`
+- Add: `current_allocation = FK(Allocation, null=True, on_delete=SET_NULL,
+  related_name="+")`
+
+`update_status()` and `verify_assignment_or_raise()` are updated to test
+`self.current_allocation`. The 4-step migration is independent of the
+boolean flag changes and can land in a separate PR.
+
+### 11.6 `status` field
+
+`status` is computed in `update_status()` from `self.allocation` today;
+after the FK refactor, from `self.current_allocation`. The existing three
+choices (`AVAILABLE`, `ALLOCATED`, `ZERO_ITEM`) remain sufficient for V1
+— exception states are queryable via the new boolean flags rather than
+`status`. Extending `status` to cover `QUARANTINED`, `DAMAGED`, etc. is
+deferred to implementation.
+
+### 11.7 Migration plan
+
+Three independent migrations, deployable in any order:
+
+**Migration A — new boolean flags** (trivial, additive):
+
+```python
+# Single migration, six AddField operations
+migrations.AddField("Stock", "return_requested", models.BooleanField(default=False)),
+migrations.AddField("Stock", "quarantined",      models.BooleanField(default=False)),
+migrations.AddField("Stock", "damaged",          models.BooleanField(default=False)),
+migrations.AddField("Stock", "lost",             models.BooleanField(default=False)),
+migrations.AddField("Stock", "expired",          models.BooleanField(default=False)),
+migrations.AddField("Stock", "voided",           models.BooleanField(default=False)),
+```
+
+No data migration. All existing stock defaults to `False`. On MySQL /
+InnoDB, `ADD COLUMN ... DEFAULT FALSE NOT NULL` is an instant metadata
+operation — no table rebuild.
+
+**Migration B — Allocation FK refactor** (4-step, in memory doc). Can
+run before or after Migration A.
+
+**Migration C — StockTransaction schema expansion** (additive columns,
+then indexes and constraints). Covered in the memory doc §"Expanded
+StockTransaction schema". Must land before any `apply_transaction` call
+writes ledger rows.
+
+No application code changes (signal deletions, `apply_transaction` wiring)
+land until Migrations A and C are in. Migration B can trail — the
+`apply_transaction` machinery uses `current_allocation` only after B
+deploys; until then the deprecated `allocation` property bridge keeps
+existing code working.
+
+---
+
+## 12. Next sketch
+
+- **(c)** Bootstrap migration — synthesise historical `StockTransaction`
+  rows from current data so projection equals replay on day one.
+
+---
+
+## 13. Deployment steps — live database
+
+Run these commands in order when deploying with all PRs merged into develop.
+
+```bash
+# 1. Run all migrations (0139–0145 plus any others)
+uv run --dev manage.py migrate
+
+# 2. Fix known pre-refactor stock inconsistencies before bootstrapping:
+#    - in_transit stuck True (old signal never cleared it)
+#    - allocation not nulled after dispense
+#    - invalid qty_delta=0 on bootstrapped TXN_RECEIVED rows
+uv run --dev manage.py fix_historical_stock_state
+
+# 3. Mark the three irreconcilable pre-refactor stocks as invalid_state=True
+#    so bootstrap and ledger-check skip them.
+#    (UGNXMR, 4992XB, 94UQKG — dispensed with no DispenseItem and no allocation)
+uv run --dev manage.py shell -c \
+  "from edc_pharmacy.models import Stock; Stock.objects.filter(code__in=['UGNXMR','4992XB','94UQKG']).update(invalid_state=True)"
+
+# 4. Back-fill StockTransaction rows for all pre-refactor stock.
+#    Idempotent — safe to re-run. Shows a tqdm progress bar.
+uv run --dev manage.py bootstrap_stock_transactions
+
+# 5. Verify ledger replay matches Stock cache columns.
+#    Expected result: N OK, 0 discrepancies, small number of no-transactions, 3 skipped.
+uv run --dev manage.py check_stock_ledger
+```
+
+### After confirming ledger is clean
+
+The `Stock.invalid_state` field (migration 0140) is a temporary marker.
+Once the ledger check confirms 0 discrepancies on the live database for
+several days, drop it:
+
+```bash
+# Generate and run the migration to remove Stock.invalid_state
+# (do this in a new PR — feat/pharmacy-drop-invalid-state)
+```

--- a/src/edc_pharmacy/admin/stock/stock_transaction_admin.py
+++ b/src/edc_pharmacy/admin/stock/stock_transaction_admin.py
@@ -4,15 +4,18 @@ from django.urls import reverse
 from django_audit_fields.admin import audit_fieldset_tuple
 from edc_model_admin.history import SimpleHistoryAdmin
 from edc_utils.date import to_local
+from import_export.admin import ExportMixin
 from rangefilter.filters import DateRangeFilterBuilder
 
 from ...admin_site import edc_pharmacy_admin
 from ...models import StockTransaction
 from ..model_admin_mixin import ModelAdminMixin
+from .stock_transaction_resource import StockTransactionResource
 
 
 @admin.register(StockTransaction, site=edc_pharmacy_admin)
-class StockTransactionAdmin(ModelAdminMixin, SimpleHistoryAdmin):
+class StockTransactionAdmin(ExportMixin, ModelAdminMixin, SimpleHistoryAdmin):
+    resource_classes = [StockTransactionResource]
     change_list_title = "Pharmacy: Stock transaction ledger"
     change_form_title = "Pharmacy: Stock transaction"
     history_list_display = ()

--- a/src/edc_pharmacy/admin/stock/stock_transaction_resource.py
+++ b/src/edc_pharmacy/admin/stock/stock_transaction_resource.py
@@ -1,0 +1,59 @@
+from import_export import fields, resources
+from import_export.widgets import ForeignKeyWidget
+
+from ...models import StockTransaction
+from ...models.stock.location import Location
+
+
+class StockTransactionResource(resources.ModelResource):
+    stock_code = fields.Field(attribute="stock__code", column_name="Stock code")
+    stock_identifier = fields.Field(
+        attribute="stock__stock_identifier", column_name="Stock identifier"
+    )
+    subject_identifier = fields.Field(column_name="Subject identifier")
+    transaction_type = fields.Field(
+        attribute="transaction_type", column_name="Transaction type"
+    )
+    transaction_datetime = fields.Field(
+        attribute="transaction_datetime", column_name="Transaction datetime"
+    )
+    actor = fields.Field(attribute="actor__username", column_name="Actor")
+    reason = fields.Field(attribute="reason", column_name="Reason")
+    qty_delta = fields.Field(attribute="qty_delta", column_name="Qty delta")
+    unit_qty_delta = fields.Field(
+        attribute="unit_qty_delta", column_name="Unit qty delta"
+    )
+    from_location = fields.Field(
+        attribute="from_location",
+        column_name="From location",
+        widget=ForeignKeyWidget(Location, field="display_name"),
+    )
+    to_location = fields.Field(
+        attribute="to_location",
+        column_name="To location",
+        widget=ForeignKeyWidget(Location, field="display_name"),
+    )
+
+    class Meta:
+        model = StockTransaction
+        fields = (
+            "stock_code",
+            "stock_identifier",
+            "subject_identifier",
+            "transaction_type",
+            "transaction_datetime",
+            "actor",
+            "reason",
+            "qty_delta",
+            "unit_qty_delta",
+            "from_location",
+            "to_location",
+        )
+        export_order = fields
+
+    def dehydrate_subject_identifier(self, obj):
+        """Pull subject from the active or ending allocation on the transaction."""
+        alloc = obj.to_allocation or obj.from_allocation
+        if alloc and alloc.registered_subject_id:
+            return alloc.registered_subject.subject_identifier
+        return obj.stock.subject_identifier or ""

--- a/src/edc_pharmacy/management/commands/bootstrap_stock_transactions.py
+++ b/src/edc_pharmacy/management/commands/bootstrap_stock_transactions.py
@@ -276,6 +276,14 @@ class Command(BaseCommand):
         already_have_txn = set(
             StockTransaction.objects.values_list("stock_id", flat=True).distinct()
         )
+        # Stocks that already have TXN_RECEIVED specifically — used to
+        # detect the case where a stock has other transactions but is missing
+        # its RECEIVED row (created via live apply_transaction before bootstrap ran).
+        already_have_received = set(
+            StockTransaction.objects.filter(transaction_type=TXN_RECEIVED)
+            .values_list("stock_id", flat=True)
+            .distinct()
+        )
 
         total = created_count = no_events = error_count = 0
         already_bootstrapped: list[str] = []
@@ -285,6 +293,38 @@ class Command(BaseCommand):
         for stock in tqdm(qs.iterator(chunk_size=500), total=stock_count, unit="stock"):
             total += 1
             if stock.pk in already_have_txn:
+                # Stock has some transactions — but check whether TXN_RECEIVED is
+                # missing. This can happen when live apply_transaction calls (e.g.
+                # TXN_STORED) ran before bootstrap, creating partial ledger entries
+                # that caused bootstrap to skip the stock entirely on a previous run.
+                if stock.confirmed and stock.pk not in already_have_received:
+                    dt = stock.confirmed_datetime or stock.stock_datetime
+                    actor = _resolve_actor(
+                        stock.user_modified or stock.user_created, actor_cache
+                    )
+                    row = _txn(
+                        stock,
+                        TXN_RECEIVED,
+                        dt,
+                        actor=actor,
+                        qty_delta=Decimal("1"),
+                        unit_qty_delta=stock.container_unit_qty or Decimal("0"),
+                    )
+                    if not dry_run:
+                        try:
+                            with transaction.atomic():
+                                StockTransaction.objects.bulk_create([row])
+                            created_count += 1
+                        except Exception as e:
+                            error_count += 1
+                            self.stderr.write(
+                                self.style.ERROR(f"  {stock.code} (backfill RECEIVED): {e}")
+                            )
+                    else:
+                        self.stdout.write(
+                            f"  {stock.code}: {TXN_RECEIVED} @ {dt} [backfill]"
+                        )
+                        created_count += 1
                 already_bootstrapped.append(stock.code)
                 continue
 

--- a/src/edc_pharmacy/management/commands/check_stock_ledger.py
+++ b/src/edc_pharmacy/management/commands/check_stock_ledger.py
@@ -118,11 +118,12 @@ def _replay(txns) -> dict:
             state["return_requested"] = True
 
         elif tt == TXN_RETURN_DISPATCHED:
+            # Allocation is intentionally NOT ended at dispatch — it is held
+            # until final disposition at central (repooled/quarantined/destroyed).
             state["in_transit"] = True
             state["stored_at_location"] = False
             state["confirmed_at_location"] = False
             state["return_requested"] = False
-            state["has_allocation"] = False
 
         elif tt == TXN_RETURN_RECEIVED:
             state["in_transit"] = False
@@ -130,13 +131,16 @@ def _replay(txns) -> dict:
 
         elif tt == TXN_RETURN_DISPOSITION_REPOOLED:
             state["quarantined"] = False
+            state["has_allocation"] = False
 
         elif tt == TXN_RETURN_DISPOSITION_QUARANTINED:
             state["quarantined"] = True
+            state["has_allocation"] = False
 
         elif tt == TXN_RETURN_DISPOSITION_DESTROYED:
             state["destroyed"] = True
             state["quarantined"] = False
+            state["has_allocation"] = False
 
         elif tt == TXN_DAMAGED:
             state["damaged"] = True

--- a/src/edc_pharmacy/management/commands/fix_historical_stock_state.py
+++ b/src/edc_pharmacy/management/commands/fix_historical_stock_state.py
@@ -184,15 +184,30 @@ class Command(BaseCommand):
         from ...models.stock.repack_request import RepackRequest
 
         # Find repack requests that have no corresponding TXN_REPACK_CONSUMED row.
-        already_logged = set(
+        # Two sources of existing rows:
+        # 1. Rows created by this command (have repack_request FK set).
+        # 2. Rows created by bootstrap_stock_transactions (no FK; linked via stock).
+        # Both must be excluded to stay idempotent when this command is re-run
+        # after bootstrap.
+        already_logged_by_fk = set(
             StockTransaction.objects.filter(
                 transaction_type=TXN_REPACK_CONSUMED,
             )
             .exclude(repack_request=None)
             .values_list("repack_request_id", flat=True)
         )
-        pending = RepackRequest.objects.exclude(pk__in=already_logged).select_related(
-            "from_stock"
+        already_logged_by_stock = set(
+            StockTransaction.objects.filter(
+                transaction_type=TXN_REPACK_CONSUMED,
+                repack_request=None,
+            )
+            .values_list("stock_id", flat=True)
+        )
+        pending = (
+            RepackRequest.objects
+            .exclude(pk__in=already_logged_by_fk)
+            .exclude(from_stock_id__in=already_logged_by_stock)
+            .select_related("from_stock")
         )
 
         count = pending.count()

--- a/src/edc_pharmacy/management/commands/fix_historical_stock_state.py
+++ b/src/edc_pharmacy/management/commands/fix_historical_stock_state.py
@@ -2,9 +2,9 @@
 with the StockTransaction ledger due to gaps in the pre-refactor signal
 handlers.
 
-Three classes of inconsistency are corrected:
+Five classes of inconsistency are corrected:
 
-1. **in_transit stuck True** — the old `stock_transfer_item_on_post_save`
+1. **in_transit stuck True** — the old ``stock_transfer_item_on_post_save``
    signal set ``in_transit=True`` when a transfer item was created but no
    corresponding signal ever cleared it when the stock was confirmed at the
    destination.  Fix: set ``in_transit=False`` for every Stock that has a
@@ -15,11 +15,21 @@ Three classes of inconsistency are corrected:
    set ``dispensed=True`` but never cleared the ``allocation`` FK.  Fix: null
    ``allocation_id`` for every Stock where ``dispensed=True``.
 
-3. **bootstrapped TXN_RECEIVED qty_delta=0** — the bootstrap command created
+3. **stored_at_location stuck True after dispense** — the old dispense signal
+   set ``dispensed=True`` but did not always clear ``stored_at_location``.
+   Fix: clear ``stored_at_location`` for every Stock where ``dispensed=True``.
+
+4. **bootstrapped TXN_RECEIVED qty_delta=0** — the bootstrap command created
    TXN_RECEIVED rows with zero qty deltas.  Because each Stock container
    represents exactly 1 unit of qty_in, the correct delta is +1 (and
    +container_unit_qty for unit_qty_in).  Fix: update those ledger rows in
    bulk.
+
+5. **TXN_REPACK_CONSUMED qty_delta=0 when stock.qty_out=1** — the old repack
+   workflow incremented ``Stock.qty_out`` to 1 when a container was fully
+   consumed, but the bootstrap/fix_repack_consumed path created
+   TXN_REPACK_CONSUMED with ``qty_delta=0``.  Fix: set ``qty_delta=-1`` on
+   those rows.
 
 This command is idempotent.  Re-running it is safe.
 
@@ -60,8 +70,10 @@ class Command(BaseCommand):
 
         errors += self._fix_in_transit(dry_run)
         errors += self._fix_allocation_after_dispense(dry_run)
+        errors += self._fix_stored_at_location_after_dispense(dry_run)
         errors += self._fix_bootstrapped_qty_deltas(dry_run)
         errors += self._fix_repack_consumed(dry_run)
+        errors += self._fix_repack_consumed_qty_delta(dry_run)
         errors += self._mark_invalid_stocks(dry_run)
 
         if errors:
@@ -230,7 +242,69 @@ class Command(BaseCommand):
         return 1 if errors else 0
 
     # ------------------------------------------------------------------
-    # Fix 5: mark irreconcilable stocks as invalid_state=True
+    # Fix 5: stored_at_location stuck True after dispense
+    # ------------------------------------------------------------------
+
+    def _fix_stored_at_location_after_dispense(self, dry_run: bool) -> int:
+        """Clear stored_at_location for dispensed stocks.
+
+        The old dispense_item_on_post_save signal set dispensed=True but did
+        not always clear stored_at_location.  The ledger replay arrives at
+        stored_at_location=False after TXN_DISPENSED; the Stock column should
+        match.
+        """
+        qs = Stock.objects.filter(dispensed=True, stored_at_location=True)
+        count = qs.count()
+        self.stdout.write(
+            f"[stored_at_location] {count} dispensed stocks with stored_at_location=True "
+            f"({'dry-run' if dry_run else 'will update'})"
+        )
+        if count and not dry_run:
+            try:
+                with transaction.atomic():
+                    updated = qs.update(stored_at_location=False)
+                self.stdout.write(self.style.SUCCESS(f"  Updated {updated} rows."))
+            except Exception as exc:
+                self.stderr.write(self.style.ERROR(f"  ERROR: {exc}"))
+                return 1
+        return 0
+
+    # ------------------------------------------------------------------
+    # Fix 6: TXN_REPACK_CONSUMED qty_delta=0 when stock.qty_out=1
+    # ------------------------------------------------------------------
+
+    def _fix_repack_consumed_qty_delta(self, dry_run: bool) -> int:
+        """Set qty_delta=-1 on bootstrapped TXN_REPACK_CONSUMED rows whose
+        source stock already has qty_out=1.
+
+        The old repack workflow incremented Stock.qty_out=1 when a container
+        was fully consumed.  The bootstrap/fix_repack_consumed path created
+        TXN_REPACK_CONSUMED with qty_delta=0, leaving a mismatch between the
+        ledger replay (qty_out=0) and the actual column (qty_out=1).
+        """
+        qs = StockTransaction.objects.filter(
+            transaction_type=TXN_REPACK_CONSUMED,
+            qty_delta=Decimal("0"),
+            stock__qty_out=Decimal("1"),
+        )
+        count = qs.count()
+        self.stdout.write(
+            f"[repack_consumed_qty] {count} TXN_REPACK_CONSUMED rows with qty_delta=0 "
+            f"but stock.qty_out=1 "
+            f"({'dry-run' if dry_run else 'will update'})"
+        )
+        if count and not dry_run:
+            try:
+                with transaction.atomic():
+                    updated = qs.update(qty_delta=Decimal("-1"))
+                self.stdout.write(self.style.SUCCESS(f"  Updated {updated} rows."))
+            except Exception as exc:
+                self.stderr.write(self.style.ERROR(f"  ERROR: {exc}"))
+                return 1
+        return 0
+
+    # ------------------------------------------------------------------
+    # Fix 7: mark irreconcilable stocks as invalid_state=True
     # ------------------------------------------------------------------
 
     def _mark_invalid_stocks(self, dry_run: bool) -> int:

--- a/src/edc_pharmacy/pdf_reports/return_manifest_pdf_report.py
+++ b/src/edc_pharmacy/pdf_reports/return_manifest_pdf_report.py
@@ -177,9 +177,9 @@ class ReturnManifestReport(Report):
             cell_style_xsmall = ParagraphStyle(
                 name="cell_xsmall", alignment=TA_CENTER, fontSize=6, leading=8
             )
-            # current_allocation is None post-dispatch (allocation is ended
-            # as part of TXN_RETURN_DISPATCHED). Fall back to the most recent
-            # historical allocation from the allocations FK history.
+            # current_allocation is set while the stock is in transit or held
+            # at central awaiting disposition. If the manifest is printed after
+            # disposition, fall back to the most recent historical allocation.
             allocation = stock.current_allocation or (
                 stock.allocations
                 .select_related("registered_subject")

--- a/src/edc_pharmacy/pdf_reports/return_manifest_pdf_report.py
+++ b/src/edc_pharmacy/pdf_reports/return_manifest_pdf_report.py
@@ -177,8 +177,18 @@ class ReturnManifestReport(Report):
             cell_style_xsmall = ParagraphStyle(
                 name="cell_xsmall", alignment=TA_CENTER, fontSize=6, leading=8
             )
+            # current_allocation is None post-dispatch (allocation is ended
+            # as part of TXN_RETURN_DISPATCHED). Fall back to the most recent
+            # historical allocation from the allocations FK history.
+            allocation = stock.current_allocation or (
+                stock.allocations
+                .select_related("registered_subject")
+                .order_by("-started_datetime")
+                .first()
+            )
             subject_identifier = (
-                stock.current_allocation.registered_subject.subject_identifier
+                allocation.registered_subject.subject_identifier
+                if allocation else "-"
             )
             data.append(
                 [

--- a/src/edc_pharmacy/templates/edc_pharmacy/central_home.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/central_home.html
@@ -12,8 +12,7 @@
                 <a id="home_list_group_repack" href="{% url 'edc_pharmacy_admin:edc_pharmacy_repackrequest_changelist' %}" class="list-group-item"><b>Repack:</b> Decant, label and confirm</a>
                 <a id="home_list_group_stockrequest" href="{% url 'edc_pharmacy_admin:edc_pharmacy_stockrequest_changelist' %}" class="list-group-item"><B>Manage Requests:</B> Allocate stock to subjects</a>
                 <a id="home_list_group_stocktransfer" href="{% url 'edc_pharmacy_admin:edc_pharmacy_stocktransfer_changelist' %}" class="list-group-item"><b>Transfer stock to site</b></a>
-                <a id="home_list_group_return_receive" href="{% url 'edc_pharmacy:return_receive_url' %}" class="list-group-item"><b>Returns: Receive returned stock</b></a>
-                <a id="home_list_group_return_disposition" href="{% url 'edc_pharmacy:return_disposition_url' %}" class="list-group-item"><b>Returns: Disposition (repool / quarantine / destroy)</b></a>
+                <a id="home_list_group_return_central" href="{% url 'edc_pharmacy:return_central_url' %}" class="list-group-item"><b>Returns: Receive and disposition</b></a>
                 <a id="home_list_group_dispense" href="{% url 'edc_pharmacy_admin:edc_pharmacy_storagebinproxy_changelist' %}" class="list-group-item"><b>Add/Update storage bins</b></a>
                 <a id="home_list_group_dispense" href="{% url 'edc_pharmacy_admin:edc_pharmacy_storagebinitemproxy_changelist' %}" class="list-group-item"><b>Search storage bins</b></a>
 

--- a/src/edc_pharmacy/templates/edc_pharmacy/central_home.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/central_home.html
@@ -12,7 +12,8 @@
                 <a id="home_list_group_repack" href="{% url 'edc_pharmacy_admin:edc_pharmacy_repackrequest_changelist' %}" class="list-group-item"><b>Repack:</b> Decant, label and confirm</a>
                 <a id="home_list_group_stockrequest" href="{% url 'edc_pharmacy_admin:edc_pharmacy_stockrequest_changelist' %}" class="list-group-item"><B>Manage Requests:</B> Allocate stock to subjects</a>
                 <a id="home_list_group_stocktransfer" href="{% url 'edc_pharmacy_admin:edc_pharmacy_stocktransfer_changelist' %}" class="list-group-item"><b>Transfer stock to site</b></a>
-                <a id="home_list_group_stocktransfer" href="{% url 'edc_pharmacy:confirm_at_location_url' location_name=CENTRAL_LOCATION %}" class="list-group-item"><B>Confirm returned stock</B></a>
+                <a id="home_list_group_return_receive" href="{% url 'edc_pharmacy:return_receive_url' %}" class="list-group-item"><b>Returns: Receive returned stock</b></a>
+                <a id="home_list_group_return_disposition" href="{% url 'edc_pharmacy:return_disposition_url' %}" class="list-group-item"><b>Returns: Disposition (repool / quarantine / destroy)</b></a>
                 <a id="home_list_group_dispense" href="{% url 'edc_pharmacy_admin:edc_pharmacy_storagebinproxy_changelist' %}" class="list-group-item"><b>Add/Update storage bins</b></a>
                 <a id="home_list_group_dispense" href="{% url 'edc_pharmacy_admin:edc_pharmacy_storagebinitemproxy_changelist' %}" class="list-group-item"><b>Search storage bins</b></a>
 

--- a/src/edc_pharmacy/templates/edc_pharmacy/site_home.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/site_home.html
@@ -11,7 +11,7 @@
                 <a id="home_list_group_dispense" href="{% url 'edc_pharmacy_admin:edc_pharmacy_storagebin_changelist' %}" class="list-group-item"><b>Add/Update storage bins</b></a>
                 <a id="home_list_group_dispense" href="{% url 'edc_pharmacy_admin:edc_pharmacy_storagebinitem_changelist' %}" class="list-group-item"><b>Search storage bins</b></a>
                 <a id="home_list_group_dispense" href="{% url 'edc_pharmacy:dispense_url' %}" class="list-group-item"><b>Dispense</b></a>
-                <a id="home_list_group_stocktransfer" href="{% url 'edc_pharmacy_admin:edc_pharmacy_stocktransfer_changelist' %}?to_location__name=central" class="list-group-item"><b>Return stock to central (transfer)</b></a>
+                <a id="home_list_group_return_request" href="{% url 'edc_pharmacy:return_request_url' %}" class="list-group-item"><b>Return stock to central</b></a>
             {% endif %}
         </div>
         <div class="panel-heading"></div>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_central.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_central.html
@@ -108,10 +108,6 @@
                             {% endfor %}
                         </tbody>
                     </table>
-                    {% if recent_dispositions %}
-                    <a href="{% url "edc_pharmacy_admin:edc_pharmacy_returnrequest_changelist" %}"
-                       class="small">more &hellip;</a>
-                    {% endif %}
                     {% else %}
                     <p class="text-muted">No dispositions yet.</p>
                     {% endif %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_central.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_central.html
@@ -1,0 +1,89 @@
+{% extends edc_base_template %}
+{% load static %}
+
+{% block main %}
+    {{ block.super }}
+    <div class="container">
+        <div class="col-sm-2"></div>
+        <div class="col-sm-8">
+            <div style="padding:10px">
+                <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
+                Returns
+            </div>
+
+            {# ─── Panel 1: Receive Returned Stock ──────────────────────── #}
+            <div class="panel panel-default">
+                <div class="panel-heading">Receive Returned Stock</div>
+                <div class="panel-body">
+                    {% if pending_receipts %}
+                    <table class="table table-condensed">
+                        <thead>
+                            <tr>
+                                <th>Reference</th>
+                                <th>From</th>
+                                <th>Date</th>
+                                <th>Items in Transit</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for rr in pending_receipts %}
+                            <tr>
+                                <td>{{ rr.return_identifier }}</td>
+                                <td>{{ rr.from_location.display_name }}</td>
+                                <td>{{ rr.return_datetime|date:"d-M-Y" }}</td>
+                                <td>{{ rr.returnitem_set.all|length }}</td>
+                                <td>
+                                    <a href="{% url "edc_pharmacy:return_receive_url" return_request=rr.pk %}"
+                                       class="btn btn-xs btn-primary">Receive</a>
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    {% else %}
+                    <p class="text-muted">No returns currently in transit.</p>
+                    {% endif %}
+                </div>
+            </div>
+
+            {# ─── Panel 2: Return Disposition ──────────────────────────── #}
+            <div class="panel panel-default">
+                <div class="panel-heading">Return Disposition</div>
+                <div class="panel-body">
+                    {% if pending_disposition %}
+                    <table class="table table-condensed">
+                        <thead>
+                            <tr>
+                                <th>Reference</th>
+                                <th>From</th>
+                                <th>Date</th>
+                                <th>Pending Disposition</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for rr in pending_disposition %}
+                            <tr>
+                                <td>{{ rr.return_identifier }}</td>
+                                <td>{{ rr.from_location.display_name }}</td>
+                                <td>{{ rr.return_datetime|date:"d-M-Y" }}</td>
+                                <td>{{ rr.returnitem_set.all|length }}</td>
+                                <td>
+                                    <a href="{% url "edc_pharmacy:return_disposition_url" return_request=rr.pk %}"
+                                       class="btn btn-xs btn-primary">Disposition</a>
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    {% else %}
+                    <p class="text-muted">No returned stock awaiting disposition.</p>
+                    {% endif %}
+                </div>
+            </div>
+
+        </div>
+        <div class="col-sm-2"></div>
+    </div>
+{% endblock main %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_central.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_central.html
@@ -83,6 +83,41 @@
                 </div>
             </div>
 
+            {# ─── Panel 3: Recent Dispositions ────────────────────────── #}
+            <div class="panel panel-default">
+                <div class="panel-heading">Recent Dispositions</div>
+                <div class="panel-body">
+                    {% if recent_dispositions %}
+                    <table class="table table-condensed">
+                        <thead>
+                            <tr>
+                                <th>Reference</th>
+                                <th>From</th>
+                                <th>Date</th>
+                                <th>Items</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for rr in recent_dispositions %}
+                            <tr>
+                                <td>{{ rr.return_identifier }}</td>
+                                <td>{{ rr.from_location.display_name }}</td>
+                                <td>{{ rr.return_datetime|date:"d-M-Y" }}</td>
+                                <td>{{ rr.returnitem_set.count }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    {% if recent_dispositions %}
+                    <a href="{% url "edc_pharmacy_admin:edc_pharmacy_returnrequest_changelist" %}"
+                       class="small">more &hellip;</a>
+                    {% endif %}
+                    {% else %}
+                    <p class="text-muted">No dispositions yet.</p>
+                    {% endif %}
+                </div>
+            </div>
+
         </div>
         <div class="col-sm-2"></div>
     </div>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_disposition.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_disposition.html
@@ -37,7 +37,7 @@
                                 <td>{{ rr.returnitem_set.all|length }}</td>
                                 <td>
                                     <a href="{% url "edc_pharmacy:return_disposition_url" return_request=rr.pk %}"
-                                       class="btn btn-xs btn-default">Disposition</a>
+                                       class="btn btn-xs btn-primary">Disposition</a>
                                 </td>
                             </tr>
                             {% endfor %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_disposition.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_disposition.html
@@ -94,11 +94,26 @@
                                 {% endfor %}
                             </tbody>
                         </table>
+                        <div style="margin-bottom:8px;">
+                            <span class="text-muted small" style="margin-right:6px;">Set all to:</span>
+                            <button type="button" class="btn btn-xs btn-default"
+                                    onclick="setAllDispositions('repooled')">Repool all</button>
+                            <button type="button" class="btn btn-xs btn-default"
+                                    onclick="setAllDispositions('quarantined')">Quarantine all</button>
+                            <button type="button" class="btn btn-xs btn-danger"
+                                    onclick="setAllDispositions('destroyed')">Destroy all</button>
+                        </div>
                         <button type="submit" class="btn btn-primary"
                                 id="submit_disposition">Apply Disposition</button>
                         <a class="btn btn-default" style="margin-left:6px;"
                            href="{% url "edc_pharmacy:return_central_url" %}">Done</a>
                     </form>
+                    <script>
+                        function setAllDispositions(value) {
+                            document.querySelectorAll('select[name^="disposition_"]')
+                                .forEach(function(sel) { sel.value = value; });
+                        }
+                    </script>
                     {% else %}
                     <p class="text-success">All items have been dispositioned.</p>
                     <a class="btn btn-default"

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_disposition.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_disposition.html
@@ -99,14 +99,15 @@
                         <div class="col-sm-12">
                             <button type="submit" class="btn btn-primary"
                                     id="submit_disposition">Apply Disposition</button>
+                            <a class="btn btn-default" style="margin-left:6px;"
+                               href="{% url "edc_pharmacy:return_central_url" %}">Done</a>
                         </div>
                     </form>
                     {% else %}
                     <p class="text-success">All items have been dispositioned.</p>
+                    <a class="btn btn-default"
+                       href="{% url "edc_pharmacy:return_central_url" %}">Done</a>
                     {% endif %}
-
-                    <a class="btn btn-default" style="margin-top:10px"
-                       href="{% url "edc_pharmacy:return_disposition_url" %}">Done</a>
                 </div>
             </div>
             {% endif %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_disposition.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_disposition.html
@@ -8,15 +8,9 @@
         <div class="col-sm-8">
             <div style="padding:10px">
                 <a href="{% url "edc_pharmacy_admin:index" %}">Edc Pharmacy</a> &rsaquo;
-                <a href="{{ changelist_url }}">Return Requests</a>
+                <a href="{% url "edc_pharmacy:return_disposition_url" %}">Return Disposition</a>
                 {% if return_request %}&rsaquo; {{ return_request.return_identifier }}{% endif %}
             </div>
-
-            {% if messages %}
-            {% for message in messages %}
-            <div class="alert alert-{{ message.tags }}">{{ message }}</div>
-            {% endfor %}
-            {% endif %}
 
             {% if not return_request %}
             {# ─── Phase 1: Select a return request to disposition ─────── #}
@@ -111,8 +105,8 @@
                     <p class="text-success">All items have been dispositioned.</p>
                     {% endif %}
 
-                    <button class="btn btn-default" style="margin-top:10px"
-                            onclick="window.location.href='{{ changelist_url }}'">Done</button>
+                    <a class="btn btn-default" style="margin-top:10px"
+                       href="{% url "edc_pharmacy:return_disposition_url" %}">Done</a>
                 </div>
             </div>
             {% endif %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_disposition.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_disposition.html
@@ -7,7 +7,7 @@
         <div class="col-sm-2"></div>
         <div class="col-sm-8">
             <div style="padding:10px">
-                <a href="{% url "edc_pharmacy_admin:index" %}">Edc Pharmacy</a> &rsaquo;
+                <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
                 <a href="{% url "edc_pharmacy:return_disposition_url" %}">Return Disposition</a>
                 {% if return_request %}&rsaquo; {{ return_request.return_identifier }}{% endif %}
             </div>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_disposition.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_disposition.html
@@ -50,58 +50,54 @@
             </div>
 
             {% else %}
-            {# ─── Phase 2: Set disposition on received items ──────────── #}
+            {# ─── Phase 2: Set per-item disposition ───────────────────── #}
             <div class="panel panel-default">
                 <div class="panel-heading">
                     Disposition: {{ return_request.return_identifier }}
                     &mdash; {{ return_request.from_location.display_name }}
                 </div>
                 <div class="panel-body">
-                    <p>
-                        Pending disposition: <strong>{{ pending_count }}</strong>
-                        {% if pending_count == 0 %}
-                            &mdash; <span class="text-success">Complete</span>
-                        {% endif %}
-                    </p>
-
-                    {% if pending_count > 0 %}
-                    <form class="form-horizontal" method="post"
+                    {% if pending_items %}
+                    <form method="post"
                           onSubmit="document.getElementById('submit_disposition').disabled=true;">
                         {% csrf_token %}
-                        <div class="form-group">
-                            <label class="control-label col-sm-4">Disposition</label>
-                            <div class="col-sm-8">
-                                {% for value, label in disposition_choices %}
-                                <div class="radio">
-                                    <label>
-                                        <input type="radio" name="disposition" value="{{ value }}"
-                                               {% if forloop.first %}checked{% endif %}>
-                                        {{ label }}
-                                    </label>
-                                </div>
+                        <table class="table table-condensed">
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Code</th>
+                                    <th>Subject</th>
+                                    <th>Formulation</th>
+                                    <th>Disposition</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for item in pending_items %}
+                                <tr>
+                                    <td>{{ forloop.counter }}</td>
+                                    <td><code>{{ item.stock.code }}</code></td>
+                                    <td>
+                                        {% if item.stock.current_allocation %}
+                                            {{ item.stock.current_allocation.registered_subject.subject_identifier }}
+                                        {% else %}-{% endif %}
+                                    </td>
+                                    <td>{{ item.stock.product.formulation.imp_description }}</td>
+                                    <td>
+                                        <select class="form-control input-sm"
+                                                name="disposition_{{ item.pk }}" required>
+                                            {% for value, label in disposition_choices %}
+                                            <option value="{{ value }}">{{ label }}</option>
+                                            {% endfor %}
+                                        </select>
+                                    </td>
+                                </tr>
                                 {% endfor %}
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            {% for i in item_count %}
-                                <label class="control-label col-sm-3" for="codes_{{ forloop.counter }}">
-                                    {{ forloop.counter }}.
-                                </label>
-                                <div class="col-sm-9">
-                                    <input type="text" class="form-control" name="codes"
-                                           id="codes_{{ forloop.counter }}"
-                                           placeholder="stock code {{ forloop.counter }}"
-                                           pattern="[A-Z0-9]{6}"
-                                           {% if forloop.first %}autofocus{% endif %}>
-                                </div>
-                            {% endfor %}
-                        </div>
-                        <div class="col-sm-12">
-                            <button type="submit" class="btn btn-primary"
-                                    id="submit_disposition">Apply Disposition</button>
-                            <a class="btn btn-default" style="margin-left:6px;"
-                               href="{% url "edc_pharmacy:return_central_url" %}">Done</a>
-                        </div>
+                            </tbody>
+                        </table>
+                        <button type="submit" class="btn btn-primary"
+                                id="submit_disposition">Apply Disposition</button>
+                        <a class="btn btn-default" style="margin-left:6px;"
+                           href="{% url "edc_pharmacy:return_central_url" %}">Done</a>
                     </form>
                     {% else %}
                     <p class="text-success">All items have been dispositioned.</p>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_receive.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_receive.html
@@ -39,7 +39,7 @@
                                 </td>
                                 <td>
                                     <a href="{% url "edc_pharmacy:return_receive_url" return_request=rr.pk %}"
-                                       class="btn btn-xs btn-default">Receive</a>
+                                       class="btn btn-xs btn-primary">Receive</a>
                                 </td>
                             </tr>
                             {% endfor %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_receive.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_receive.html
@@ -7,7 +7,7 @@
         <div class="col-sm-2"></div>
         <div class="col-sm-8">
             <div style="padding:10px">
-                <a href="{% url "edc_pharmacy_admin:index" %}">Edc Pharmacy</a> &rsaquo;
+                <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
                 <a href="{% url "edc_pharmacy:return_receive_url" %}">Receive Returns</a>
                 {% if return_request %}&rsaquo; {{ return_request.return_identifier }}{% endif %}
             </div>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_receive.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_receive.html
@@ -8,15 +8,9 @@
         <div class="col-sm-8">
             <div style="padding:10px">
                 <a href="{% url "edc_pharmacy_admin:index" %}">Edc Pharmacy</a> &rsaquo;
-                <a href="{{ changelist_url }}">Return Requests</a>
+                <a href="{% url "edc_pharmacy:return_receive_url" %}">Receive Returns</a>
                 {% if return_request %}&rsaquo; {{ return_request.return_identifier }}{% endif %}
             </div>
-
-            {% if messages %}
-            {% for message in messages %}
-            <div class="alert alert-{{ message.tags }}">{{ message }}</div>
-            {% endfor %}
-            {% endif %}
 
             {% if not return_request %}
             {# ─── Phase 1: Select a return request to receive ─────────── #}
@@ -103,8 +97,8 @@
                     <p class="text-success">All items received.</p>
                     {% endif %}
 
-                    <button class="btn btn-default" style="margin-top:10px"
-                            onclick="window.location.href='{{ changelist_url }}'">Done</button>
+                    <a class="btn btn-default" style="margin-top:10px"
+                       href="{% url "edc_pharmacy:return_receive_url" %}">Done</a>
                 </div>
             </div>
             {% endif %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_receive.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_receive.html
@@ -91,14 +91,15 @@
                         <div class="col-sm-12">
                             <button type="submit" class="btn btn-primary"
                                     id="submit_receive">Confirm Receipt</button>
+                            <a class="btn btn-default" style="margin-left:6px;"
+                               href="{% url "edc_pharmacy:return_receive_url" %}">Done</a>
                         </div>
                     </form>
                     {% else %}
                     <p class="text-success">All items received.</p>
-                    {% endif %}
-
-                    <a class="btn btn-default" style="margin-top:10px"
+                    <a class="btn btn-default"
                        href="{% url "edc_pharmacy:return_receive_url" %}">Done</a>
+                    {% endif %}
                 </div>
             </div>
             {% endif %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
@@ -7,7 +7,7 @@
         <div class="col-sm-2"></div>
         <div class="col-sm-8">
             <div style="padding:10px">
-                <a href="{% url "edc_pharmacy_admin:index" %}">Edc Pharmacy</a> &rsaquo;
+                <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
                 <a href="{% url "edc_pharmacy:return_request_url" %}">Return Requests</a>
                 {% if return_request %}&rsaquo; {{ return_request.return_identifier }}{% endif %}
             </div>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
@@ -8,7 +8,7 @@
         <div class="col-sm-8">
             <div style="padding:10px">
                 <a href="{% url "edc_pharmacy_admin:index" %}">Edc Pharmacy</a> &rsaquo;
-                <a href="{{ changelist_url }}">Return Requests</a>
+                <a href="{% url "edc_pharmacy:return_request_url" %}">Return Requests</a>
                 {% if return_request %}&rsaquo; {{ return_request.return_identifier }}{% endif %}
             </div>
 
@@ -26,7 +26,10 @@
                                 <select class="form-control" id="from_location_id" name="from_location_id" required autofocus>
                                     <option value="">---------</option>
                                     {% for loc in from_locations %}
-                                        <option value="{{ loc.id }}">{{ loc.display_name }}</option>
+                                        <option value="{{ loc.id }}"
+                                            {% if current_site_location and loc.id == current_site_location.id %}selected{% endif %}>
+                                            {{ loc.display_name }}
+                                        </option>
                                     {% endfor %}
                                 </select>
                             </div>
@@ -134,8 +137,8 @@
                     <p class="text-success">All items dispatched.</p>
                     {% endif %}
 
-                    <button class="btn btn-default" style="margin-top:10px"
-                            onclick="window.location.href='{{ changelist_url }}'">Done</button>
+                    <a class="btn btn-default" style="margin-top:10px"
+                       href="{% url "edc_pharmacy:return_request_url" %}">Done</a>
                 </div>
             </div>
             {% endif %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
@@ -58,10 +58,10 @@
                 </div>
             </div>
 
-            {% if pending_returns %}
             <div class="panel panel-default">
                 <div class="panel-heading">Open Return Requests</div>
                 <div class="panel-body">
+                    {% if pending_returns %}
                     <table class="table table-condensed">
                         <thead>
                             <tr>
@@ -87,9 +87,11 @@
                             {% endfor %}
                         </tbody>
                     </table>
+                    {% else %}
+                    <p class="text-muted">No open return requests.</p>
+                    {% endif %}
                 </div>
             </div>
-            {% endif %}
 
             {% else %}
             {# ─── Phase 2: Dispatch items on an existing ReturnRequest ──── #}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
@@ -112,6 +112,7 @@
                                 <th>From</th>
                                 <th>Date</th>
                                 <th>Items</th>
+                                <th></th>
                             </tr>
                         </thead>
                         <tbody>
@@ -121,6 +122,12 @@
                                 <td>{{ rr.from_location.display_name }}</td>
                                 <td>{{ rr.return_datetime|date:"d-M-Y" }}</td>
                                 <td>{{ rr.dispatched_item_count }} / {{ rr.item_count }}</td>
+                                <td>
+                                    <a href="{% url "edc_pharmacy:return_manifest_url" return_request=rr.pk %}"
+                                       class="btn btn-xs btn-default" target="_blank">
+                                        <i class="fas fa-file-pdf"></i> Manifest
+                                    </a>
+                                </td>
                             </tr>
                             {% endfor %}
                         </tbody>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
@@ -102,7 +102,7 @@
             </div>
 
             <div class="panel panel-default">
-                <div class="panel-heading">Recent Completed Return Requests</div>
+                <div class="panel-heading">Recent Return Requests</div>
                 <div class="panel-body">
                     {% if completed_returns %}
                     <table class="table table-condensed">

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
@@ -139,6 +139,19 @@
                     <p class="text-success">All items dispatched.</p>
                     {% endif %}
 
+                    <hr>
+                    <form class="form-inline" method="post" style="margin-top:6px;">
+                        {% csrf_token %}
+                        <input type="hidden" name="update_item_count" value="1">
+                        <div class="form-group">
+                            <label for="item_count_update" style="margin-right:6px;">Update expected count:</label>
+                            <input type="number" class="form-control input-sm" id="item_count_update"
+                                   name="item_count" min="{{ dispatched_count|default:1 }}" max="500"
+                                   value="{{ return_request.item_count }}" style="width:80px;">
+                        </div>
+                        <button type="submit" class="btn btn-default btn-sm" style="margin-left:6px;">Update</button>
+                    </form>
+
                     <a class="btn btn-default" style="margin-top:10px"
                        href="{% url "edc_pharmacy:return_request_url" %}">Done</a>
                 </div>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
@@ -112,6 +112,19 @@
                         {% endif %}
                     </p>
 
+                    {# ── Update expected count (always visible) ── #}
+                    <form class="form-inline" method="post" style="margin-bottom:12px;">
+                        {% csrf_token %}
+                        <input type="hidden" name="update_item_count" value="1">
+                        <div class="form-group">
+                            <label for="item_count_update" style="margin-right:6px;">Update expected count:</label>
+                            <input type="number" class="form-control input-sm" id="item_count_update"
+                                   name="item_count" min="{{ dispatched_count|default:1 }}" max="500"
+                                   value="{{ return_request.item_count }}" style="width:80px;">
+                        </div>
+                        <button type="submit" class="btn btn-default btn-sm" style="margin-left:6px;">Update</button>
+                    </form>
+
                     {% if remaining_count > 0 %}
                     <form class="form-horizontal" method="post"
                           onSubmit="document.getElementById('submit_dispatch').disabled=true;">
@@ -133,27 +146,15 @@
                         <div class="col-sm-12">
                             <button type="submit" class="btn btn-primary"
                                     id="submit_dispatch">Dispatch</button>
+                            <a class="btn btn-default" style="margin-left:6px;"
+                               href="{% url "edc_pharmacy:return_request_url" %}">Done</a>
                         </div>
                     </form>
                     {% else %}
                     <p class="text-success">All items dispatched.</p>
-                    {% endif %}
-
-                    <hr>
-                    <form class="form-inline" method="post" style="margin-top:6px;">
-                        {% csrf_token %}
-                        <input type="hidden" name="update_item_count" value="1">
-                        <div class="form-group">
-                            <label for="item_count_update" style="margin-right:6px;">Update expected count:</label>
-                            <input type="number" class="form-control input-sm" id="item_count_update"
-                                   name="item_count" min="{{ dispatched_count|default:1 }}" max="500"
-                                   value="{{ return_request.item_count }}" style="width:80px;">
-                        </div>
-                        <button type="submit" class="btn btn-default btn-sm" style="margin-left:6px;">Update</button>
-                    </form>
-
-                    <a class="btn btn-default" style="margin-top:10px"
+                    <a class="btn btn-default"
                        href="{% url "edc_pharmacy:return_request_url" %}">Done</a>
+                    {% endif %}
                 </div>
             </div>
             {% endif %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
@@ -82,6 +82,14 @@
                                 <td>
                                     <a href="{% url "edc_pharmacy:return_request_url" return_request=rr.pk %}"
                                        class="btn btn-xs btn-primary">Edit</a>
+                                    {% if rr.dispatched_item_count == 0 %}
+                                    <form method="post" style="display:inline;"
+                                          onsubmit="return confirm('Delete {{ rr.return_identifier }}?');">
+                                        {% csrf_token %}
+                                        <input type="hidden" name="delete_pk" value="{{ rr.pk }}">
+                                        <button type="submit" class="btn btn-xs btn-danger">Delete</button>
+                                    </form>
+                                    {% endif %}
                                 </td>
                             </tr>
                             {% endfor %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
@@ -130,7 +130,7 @@
                     {% endif %}
                     {% if completed_returns %}
                     <a href="{% url "edc_pharmacy_admin:edc_pharmacy_returnrequest_changelist" %}"
-                       class="text-muted small">more &hellip;</a>
+                       class="small">more &hellip;</a>
                     {% endif %}
                 </div>
             </div>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
@@ -50,7 +50,7 @@
                         <div class="form-group">
                             <div class="col-sm-offset-4 col-sm-8">
                                 <button type="submit" class="btn btn-primary" id="submit_new">
-                                    Create Return Request
+                                    Create
                                 </button>
                             </div>
                         </div>
@@ -81,7 +81,7 @@
                                 <td>{{ rr.received_item_count }} / {{ rr.item_count }}</td>
                                 <td>
                                     <a href="{% url "edc_pharmacy:return_request_url" return_request=rr.pk %}"
-                                       class="btn btn-xs btn-default">Dispatch</a>
+                                       class="btn btn-xs btn-primary">Edit</a>
                                 </td>
                             </tr>
                             {% endfor %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
@@ -101,6 +101,36 @@
                 </div>
             </div>
 
+            <div class="panel panel-default">
+                <div class="panel-heading">Recent Completed Return Requests</div>
+                <div class="panel-body">
+                    {% if completed_returns %}
+                    <table class="table table-condensed">
+                        <thead>
+                            <tr>
+                                <th>Reference</th>
+                                <th>From</th>
+                                <th>Date</th>
+                                <th>Items</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for rr in completed_returns %}
+                            <tr>
+                                <td>{{ rr.return_identifier }}</td>
+                                <td>{{ rr.from_location.display_name }}</td>
+                                <td>{{ rr.return_datetime|date:"d-M-Y" }}</td>
+                                <td>{{ rr.dispatched_item_count }} / {{ rr.item_count }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    {% else %}
+                    <p class="text-muted">No completed return requests.</p>
+                    {% endif %}
+                </div>
+            </div>
+
             {% else %}
             {# ─── Phase 2: Dispatch items on an existing ReturnRequest ──── #}
             <div class="panel panel-default">

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/return_request.html
@@ -128,6 +128,10 @@
                     {% else %}
                     <p class="text-muted">No completed return requests.</p>
                     {% endif %}
+                    {% if completed_returns %}
+                    <a href="{% url "edc_pharmacy_admin:edc_pharmacy_returnrequest_changelist" %}"
+                       class="text-muted small">more &hellip;</a>
+                    {% endif %}
                 </div>
             </div>
 

--- a/src/edc_pharmacy/tests/tests/test_return.py
+++ b/src/edc_pharmacy/tests/tests/test_return.py
@@ -241,10 +241,32 @@ class TestReturn(TestCase):
         self.assertEqual(stock.location, self.location_central)
         self.assertTrue(ReturnItem.objects.filter(stock=stock).exists())
 
-    def test_return_dispatched_requires_return_requested(self):
-        """dispatch_return skips stock that is not return_requested."""
+    def test_return_dispatched_auto_requests(self):
+        """dispatch_return auto-applies TXN_RETURN_REQUESTED when not already set.
+
+        The view scans codes in a single step, so pre-calling
+        request_stock_return() is not required.
+        """
         stock = Stock.objects.first()
-        # Do NOT call TXN_RETURN_REQUESTED first.
+        # Do NOT pre-call TXN_RETURN_REQUESTED — dispatch handles it.
+        return_request = ReturnRequest.objects.create(
+            from_location=self.location_site,
+            to_location=self.location_central,
+            item_count=1,
+        )
+        dispatched, skipped = dispatch_return(return_request, [stock.code], self.actor)
+        self.assertEqual(dispatched, [stock.code])
+        self.assertEqual(skipped, [])
+        stock.refresh_from_db()
+        self.assertTrue(stock.in_transit)
+
+    def test_return_dispatched_skips_stock_not_stored_at_location(self):
+        """dispatch_return skips stock that is not in a bin at the site."""
+        stock = Stock.objects.first()
+        # Force stored_at_location=False via update() to bypass the guarded-field
+        # check in save() — this is deliberate test setup, not production code.
+        Stock.objects.filter(pk=stock.pk).update(stored_at_location=False)
+        stock.refresh_from_db()
         return_request = ReturnRequest.objects.create(
             from_location=self.location_site,
             to_location=self.location_central,
@@ -252,12 +274,12 @@ class TestReturn(TestCase):
         )
         dispatched, skipped = dispatch_return(return_request, [stock.code], self.actor)
         self.assertEqual(dispatched, [])
-        self.assertEqual(skipped, [stock.code])
+        self.assertEqual(len(skipped), 1)
+        self.assertIn(stock.code, skipped[0])
 
     def test_return_received(self):
         """TXN_RETURN_RECEIVED clears in_transit at central."""
         stock = Stock.objects.first()
-        apply_transaction(stock, TXN_RETURN_REQUESTED, self.actor)
         return_request = ReturnRequest.objects.create(
             from_location=self.location_site,
             to_location=self.location_central,

--- a/src/edc_pharmacy/tests/tests/test_return.py
+++ b/src/edc_pharmacy/tests/tests/test_return.py
@@ -415,3 +415,62 @@ class TestReturn(TestCase):
                 to_location=self.location_central,
                 item_count=1,
             )
+
+    def test_allocation_held_until_disposition(self):
+        """Allocation is NOT ended at dispatch or receipt — only at disposition.
+
+        Stock remains allocated to the subject throughout the return journey.
+        The allocation ends only when central sets a final disposition.
+        """
+        from edc_pharmacy.models import Allocation
+        from edc_pharmacy.transaction_log._sentinel import apply_delta_context
+
+        stock = Stock.objects.first()
+
+        # Create a minimal allocation bypassing Allocation.save() guards
+        # (stock_request_item, registered_subject not needed for this test).
+        # Pre-assign pk so bulk_create works on MySQL (no RETURNING support).
+        # Assignment must match stock.lot.assignment to pass verify_assignment_or_raise().
+        import uuid as _uuid
+        alloc_pk = _uuid.uuid4()
+        Allocation.objects.bulk_create([
+            Allocation(
+                id=alloc_pk,
+                stock=stock,
+                code=stock.code,
+                allocated_by="testactor",
+                allocation_identifier="test_alloc_001",
+                started_datetime=timezone.now(),
+                assignment=stock.lot.assignment,
+            )
+        ])
+        allocation = Allocation.objects.get(pk=alloc_pk)
+        with apply_delta_context():
+            stock.current_allocation = allocation
+            stock.save(update_fields=["current_allocation"])
+
+        return_request = ReturnRequest.objects.create(
+            from_location=self.location_site,
+            to_location=self.location_central,
+            item_count=1,
+        )
+
+        # After dispatch: allocation still active.
+        dispatch_return(return_request, [stock.code], self.actor)
+        stock.refresh_from_db()
+        self.assertIsNotNone(stock.current_allocation)
+        self.assertEqual(stock.current_allocation.pk, allocation.pk)
+
+        # After receipt: allocation still active.
+        receive_return(return_request, [stock.code], self.actor)
+        stock.refresh_from_db()
+        self.assertIsNotNone(stock.current_allocation)
+        self.assertEqual(stock.current_allocation.pk, allocation.pk)
+
+        # After disposition (destroyed): allocation is ended.
+        disposition_return([stock.code], self.actor, disposition="destroyed")
+        stock.refresh_from_db()
+        self.assertIsNone(stock.current_allocation)
+        allocation.refresh_from_db()
+        self.assertIsNotNone(allocation.ended_datetime)
+        self.assertEqual(allocation.ended_reason, "destroyed")

--- a/src/edc_pharmacy/transaction_log/apply_transaction.py
+++ b/src/edc_pharmacy/transaction_log/apply_transaction.py
@@ -25,7 +25,9 @@ def _snapshot(stock: Stock) -> CurrentState:
     allocation = stock.current_allocation
     has_active_allocation = allocation is not None
     active_allocation_subject = (
-        allocation.registered_subject.subject_identifier if has_active_allocation else ""
+        (allocation.registered_subject.subject_identifier
+         if allocation.registered_subject_id else "")
+        if has_active_allocation else ""
     )
     try:
         stock.storagebinitem  # noqa: B018
@@ -118,13 +120,17 @@ def _apply_delta(stock: Stock, delta: StateDelta, **kwargs) -> dict:
         elif delta.allocation_action == "end":
             ending_allocation = stock.current_allocation
             if ending_allocation is not None:
-                ending_allocation.ended_datetime = kwargs.get(
-                    "ended_datetime", timezone.now()
+                ended_datetime = kwargs.get("ended_datetime", timezone.now())
+                ended_reason = delta.allocation_end_reason or kwargs.get("ended_reason", "")
+                # Use update() rather than save() to avoid running Allocation.save()
+                # logic (e.g. registered_subject.subject_identifier lookup) when only
+                # stamping the end time and reason.
+                Allocation.objects.filter(pk=ending_allocation.pk).update(
+                    ended_datetime=ended_datetime,
+                    ended_reason=ended_reason,
                 )
-                ending_allocation.ended_reason = kwargs.get("ended_reason", "")
-                ending_allocation.save(
-                    update_fields=["ended_datetime", "ended_reason"]
-                )
+                ending_allocation.ended_datetime = ended_datetime
+                ending_allocation.ended_reason = ended_reason
             created_objects["from_allocation"] = ending_allocation
             stock.current_allocation = None
             update_fields.append("current_allocation")

--- a/src/edc_pharmacy/transaction_log/compute_delta.py
+++ b/src/edc_pharmacy/transaction_log/compute_delta.py
@@ -209,19 +209,17 @@ def _compute_return_dispatched(current: CurrentState, *, central_location_id: in
         fail.append("not stored at location")
     if fail:
         return StateDelta(preconditions_failed=tuple(fail))
-    stock_fields = {
-        "return_requested": False,
-        "in_transit": True,
-        "stored_at_location": False,
-        "confirmed_at_location": False,
-    }
-    if current.has_active_allocation:
-        stock_fields["subject_identifier"] = ""
+    # Allocation is NOT ended here — stock remains allocated to the subject
+    # while in transit and while held at central awaiting disposition.
+    # The allocation ends only at final disposition (repooled/quarantined/destroyed).
     return StateDelta(
-        stock_fields=stock_fields,
+        stock_fields={
+            "return_requested": False,
+            "in_transit": True,
+            "stored_at_location": False,
+            "confirmed_at_location": False,
+        },
         storage_bin_item="delete",
-        allocation_action="end" if current.has_active_allocation else "unchanged",
-        allocation_end_reason="returned" if current.has_active_allocation else None,
         new_location_id=central_location_id,
     )
 
@@ -238,7 +236,11 @@ def _compute_return_received(current: CurrentState, *, central_location_id: int,
 def _compute_return_disposition_repooled(current: CurrentState, **_) -> StateDelta:
     if current.in_transit:
         return StateDelta(preconditions_failed=("still in transit",))
-    return StateDelta(stock_fields={"quarantined": False})
+    return StateDelta(
+        stock_fields={"quarantined": False, "subject_identifier": ""},
+        allocation_action="end" if current.has_active_allocation else "unchanged",
+        allocation_end_reason="repooled" if current.has_active_allocation else None,
+    )
 
 
 def _compute_return_disposition_quarantined(current: CurrentState, **_) -> StateDelta:
@@ -247,7 +249,11 @@ def _compute_return_disposition_quarantined(current: CurrentState, **_) -> State
         fail.append("still in transit")
     if fail:
         return StateDelta(preconditions_failed=tuple(fail))
-    return StateDelta(stock_fields={"quarantined": True})
+    return StateDelta(
+        stock_fields={"quarantined": True, "subject_identifier": ""},
+        allocation_action="end" if current.has_active_allocation else "unchanged",
+        allocation_end_reason="quarantined" if current.has_active_allocation else None,
+    )
 
 
 def _compute_return_disposition_destroyed(current: CurrentState, **_) -> StateDelta:
@@ -255,7 +261,11 @@ def _compute_return_disposition_destroyed(current: CurrentState, **_) -> StateDe
         return StateDelta(preconditions_failed=("already destroyed",))
     if current.in_transit:
         return StateDelta(preconditions_failed=("still in transit",))
-    return StateDelta(stock_fields={"destroyed": True, "quarantined": False})
+    return StateDelta(
+        stock_fields={"destroyed": True, "quarantined": False, "subject_identifier": ""},
+        allocation_action="end" if current.has_active_allocation else "unchanged",
+        allocation_end_reason="destroyed" if current.has_active_allocation else None,
+    )
 
 
 def _compute_adjusted(current: CurrentState, *, unit_qty_delta: Decimal, **_) -> StateDelta:

--- a/src/edc_pharmacy/urls.py
+++ b/src/edc_pharmacy/urls.py
@@ -12,6 +12,7 @@ from .views import (
     MoveToStorageBinView,
     PrepareAndReviewStockRequestView,
     PrintLabelsView,
+    ReturnCentralView,
     ReturnDispositionView,
     ReturnReceiveView,
     ReturnRequestView,
@@ -161,6 +162,11 @@ urlpatterns = [
         "return-request/",
         ReturnRequestView.as_view(),
         name="return_request_url",
+    ),
+    path(
+        "return-central/",
+        ReturnCentralView.as_view(),
+        name="return_central_url",
     ),
     path(
         "return-receive/<uuid:return_request>/",

--- a/src/edc_pharmacy/utils/process_return_request.py
+++ b/src/edc_pharmacy/utils/process_return_request.py
@@ -31,7 +31,7 @@ from ..constants import (
     TXN_RETURN_RECEIVED,
     TXN_RETURN_REQUESTED,
 )
-from ..exceptions import ReturnError
+from ..exceptions import InvalidTransitionError, ReturnError
 from ..transaction_log import apply_transaction
 
 if TYPE_CHECKING:
@@ -100,26 +100,35 @@ def dispatch_return(
             stock = stock_model_cls.objects.get(
                 code=code,
                 invalid_state=False,
-                return_requested=True,
                 location=return_request.from_location,
             )
         except stock_model_cls.DoesNotExist:
             skipped.append(code)
             continue
-        with transaction.atomic():
-            return_item = return_item_model_cls.objects.create(
-                stock=stock,
-                return_request=return_request,
-                user_created=actor.username,
-            )
-            apply_transaction(
-                stock,
-                TXN_RETURN_DISPATCHED,
-                actor,
-                central_location_id=central_location.id,
-                return_item=return_item,
-                reason=reason,
-            )
+        try:
+            with transaction.atomic():
+                # Auto-request if not already flagged — the view dispatches in
+                # one step, so TXN_RETURN_REQUESTED and TXN_RETURN_DISPATCHED
+                # are collapsed into a single scan action.
+                if not stock.return_requested:
+                    apply_transaction(stock, TXN_RETURN_REQUESTED, actor, reason=reason)
+                    stock.refresh_from_db()
+                return_item = return_item_model_cls.objects.create(
+                    stock=stock,
+                    return_request=return_request,
+                    user_created=actor.username,
+                )
+                apply_transaction(
+                    stock,
+                    TXN_RETURN_DISPATCHED,
+                    actor,
+                    central_location_id=central_location.id,
+                    return_item=return_item,
+                    reason=reason,
+                )
+        except InvalidTransitionError as e:
+            skipped.append(f"{code} ({e})")
+            continue
         dispatched.append(code)
     return dispatched, skipped
 

--- a/src/edc_pharmacy/utils/process_return_request.py
+++ b/src/edc_pharmacy/utils/process_return_request.py
@@ -96,15 +96,13 @@ def dispatch_return(
 
     dispatched, skipped = [], []
     for code in stock_codes:
-        try:
-            stock = stock_model_cls.objects.get(
-                code=code,
-                invalid_state=False,
-                location=return_request.from_location,
-            )
-        except stock_model_cls.DoesNotExist:
-            skipped.append(code)
+        skip_reason = _why_dispatch_skip(
+            code, return_request.from_location, stock_model_cls
+        )
+        if skip_reason:
+            skipped.append(f"{code}: {skip_reason}")
             continue
+        stock = stock_model_cls.objects.get(code=code)
         try:
             with transaction.atomic():
                 # Auto-request if not already flagged — the view dispatches in
@@ -127,10 +125,42 @@ def dispatch_return(
                     reason=reason,
                 )
         except InvalidTransitionError as e:
-            skipped.append(f"{code} ({e})")
+            skipped.append(f"{code}: {e}")
             continue
         dispatched.append(code)
     return dispatched, skipped
+
+
+def _why_dispatch_skip(
+    code: str,
+    from_location,
+    stock_model_cls,
+) -> str | None:
+    """Return a human-readable reason why this code cannot be dispatched,
+    or None if it looks dispatchable."""
+    try:
+        stock = stock_model_cls.objects.get(code=code)
+    except stock_model_cls.DoesNotExist:
+        return "code not found"
+
+    if stock.invalid_state:
+        return "stock has an invalid state and cannot be processed"
+    if stock.dispensed:
+        return "already dispensed"
+    if stock.in_transit:
+        return "already in transit"
+    if stock.destroyed:
+        return "stock is destroyed"
+    if stock.quarantined:
+        return "stock is quarantined"
+    if stock.location != from_location:
+        return (
+            f"stock is at '{stock.location}', "
+            f"not '{from_location}'"
+        )
+    if not stock.stored_at_location:
+        return "not stored in a bin at the site"
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/src/edc_pharmacy/views/__init__.py
+++ b/src/edc_pharmacy/views/__init__.py
@@ -12,6 +12,7 @@ from .print_labels_view import PrintLabelsView
 from .print_stock_transfer_manifest_view import print_stock_transfer_manifest_view
 from .print_stock_view import print_stock_view
 from .print_return_manifest_view import print_return_manifest_view
+from .return_central_view import ReturnCentralView
 from .return_disposition_view import ReturnDispositionView
 from .return_receive_view import ReturnReceiveView
 from .return_request_view import ReturnRequestView

--- a/src/edc_pharmacy/views/return_central_view.py
+++ b/src/edc_pharmacy/views/return_central_view.py
@@ -1,0 +1,58 @@
+"""Combined returns view for the central pharmacist.
+
+Shows two panels on one page:
+  1. Receive Returned Stock  — in-transit returns awaiting receipt confirmation.
+  2. Return Disposition      — received returns awaiting final disposition.
+
+Phase 2 scanning for each action is handled by the existing per-UUID views
+(ReturnReceiveView and ReturnDispositionView), which redirect back here on
+completion.
+"""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView
+
+from edc_dashboard.view_mixins import EdcViewMixin
+from edc_navbar import NavbarViewMixin
+from edc_protocol.view_mixins import EdcProtocolViewMixin
+
+from ..models import ReturnRequest
+
+
+@method_decorator(login_required, name="dispatch")
+class ReturnCentralView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateView):
+    """Central pharmacist: combined receive + disposition dashboard."""
+
+    template_name = "edc_pharmacy/stock/return_central.html"
+    navbar_name = settings.APP_NAME
+    navbar_selected_item = "pharmacy"
+
+    def get_context_data(self, **kwargs):
+        pending_receipts = (
+            ReturnRequest.objects.filter(
+                returnitem__stock__in_transit=True,
+                cancel__in=["", "N/A"],
+            )
+            .distinct()
+            .order_by("-return_datetime")
+        )
+        pending_disposition = (
+            ReturnRequest.objects.filter(
+                returnitem__stock__in_transit=False,
+                returnitem__stock__dispensed=False,
+                returnitem__stock__quarantined=False,
+                returnitem__stock__destroyed=False,
+                cancel__in=["", "N/A"],
+            )
+            .distinct()
+            .order_by("-return_datetime")
+        )
+        kwargs.update(
+            pending_receipts=pending_receipts,
+            pending_disposition=pending_disposition,
+        )
+        return super().get_context_data(**kwargs)

--- a/src/edc_pharmacy/views/return_central_view.py
+++ b/src/edc_pharmacy/views/return_central_view.py
@@ -51,8 +51,17 @@ class ReturnCentralView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Tem
             .distinct()
             .order_by("-return_datetime")
         )
+        # Recently completed dispositions: have items, not still pending.
+        recent_dispositions = (
+            ReturnRequest.objects.filter(returnitem__isnull=False)
+            .exclude(pk__in=pending_disposition.values("pk"))
+            .exclude(returnitem__stock__in_transit=True)
+            .distinct()
+            .order_by("-return_datetime")[:5]
+        )
         kwargs.update(
             pending_receipts=pending_receipts,
             pending_disposition=pending_disposition,
+            recent_dispositions=recent_dispositions,
         )
         return super().get_context_data(**kwargs)

--- a/src/edc_pharmacy/views/return_disposition_view.py
+++ b/src/edc_pharmacy/views/return_disposition_view.py
@@ -70,9 +70,6 @@ class ReturnDispositionView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin,
             pending_count=pending_count,
             item_count=list(range(1, items_to_scan + 1)),
             disposition_choices=DISPOSITION_CHOICES,
-            changelist_url=reverse(
-                "edc_pharmacy_admin:edc_pharmacy_returnrequest_changelist"
-            ),
         )
         return super().get_context_data(**kwargs)
 
@@ -138,6 +135,9 @@ class ReturnDispositionView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin,
                     kwargs={"return_request": return_request.pk},
                 )
             )
-        return HttpResponseRedirect(
-            reverse("edc_pharmacy_admin:edc_pharmacy_returnrequest_changelist")
+        messages.add_message(
+            request,
+            messages.SUCCESS,
+            f"All items dispositioned for {return_request.return_identifier}.",
         )
+        return HttpResponseRedirect(reverse("edc_pharmacy:return_central_url"))

--- a/src/edc_pharmacy/views/return_disposition_view.py
+++ b/src/edc_pharmacy/views/return_disposition_view.py
@@ -52,23 +52,24 @@ class ReturnDispositionView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin,
             cancel__in=["", "N/A"],
         ).distinct().order_by("-return_datetime")
 
-        pending_count = 0
+        pending_items = []
         if return_request:
-            pending_count = return_request.returnitem_set.filter(
-                stock__in_transit=False,
-                stock__dispensed=False,
-                stock__quarantined=False,
-                stock__destroyed=False,
-            ).count()
-            items_to_scan = min(pending_count, 12)
-        else:
-            items_to_scan = 0
+            pending_items = list(
+                return_request.returnitem_set.filter(
+                    stock__in_transit=False,
+                    stock__dispensed=False,
+                    stock__quarantined=False,
+                    stock__destroyed=False,
+                ).select_related(
+                    "stock__product__formulation",
+                    "stock__current_allocation__registered_subject",
+                )
+            )
 
         kwargs.update(
             return_request=return_request,
             pending_disposition=pending_disposition,
-            pending_count=pending_count,
-            item_count=list(range(1, items_to_scan + 1)),
+            pending_items=pending_items,
             disposition_choices=DISPOSITION_CHOICES,
         )
         return super().get_context_data(**kwargs)
@@ -89,38 +90,47 @@ class ReturnDispositionView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin,
         if not return_request:
             return HttpResponseRedirect(reverse("edc_pharmacy:return_disposition_url"))
 
-        disposition = request.POST.get("disposition", "").strip()
-        stock_codes = [c.strip().upper() for c in request.POST.getlist("codes") if c.strip()]
+        # Each pending ReturnItem posts its disposition as disposition_<pk>.
+        pending_items = return_request.returnitem_set.filter(
+            stock__in_transit=False,
+            stock__dispensed=False,
+            stock__quarantined=False,
+            stock__destroyed=False,
+        ).select_related("stock")
 
-        if not disposition:
-            messages.add_message(request, messages.ERROR, "Please select a disposition.")
-            return HttpResponseRedirect(
-                reverse(
-                    "edc_pharmacy:return_disposition_url",
-                    kwargs={"return_request": return_request.pk},
-                )
-            )
-
-        if stock_codes:
+        processed, skipped, missing = [], [], []
+        for item in pending_items:
+            disposition = request.POST.get(f"disposition_{item.pk}", "").strip()
+            if not disposition:
+                missing.append(item.stock.code)
+                continue
             try:
-                processed, skipped = disposition_return(
-                    stock_codes, request.user, disposition=disposition
+                done, skip = disposition_return(
+                    [item.stock.code], request.user, disposition=disposition
                 )
+                processed.extend(done)
+                skipped.extend(skip)
             except ReturnError as e:
                 messages.add_message(request, messages.ERROR, str(e))
-            else:
-                if processed:
-                    messages.add_message(
-                        request,
-                        messages.SUCCESS,
-                        f"Applied '{disposition}' to {len(processed)} item(s).",
-                    )
-                if skipped:
-                    messages.add_message(
-                        request,
-                        messages.WARNING,
-                        f"Skipped {len(skipped)} item(s): {', '.join(skipped)}",
-                    )
+
+        if processed:
+            messages.add_message(
+                request,
+                messages.SUCCESS,
+                f"Dispositioned {len(processed)} item(s).",
+            )
+        if skipped:
+            messages.add_message(
+                request,
+                messages.WARNING,
+                f"Skipped {len(skipped)} item(s): {', '.join(skipped)}",
+            )
+        if missing:
+            messages.add_message(
+                request,
+                messages.WARNING,
+                f"No disposition selected for {len(missing)} item(s): {', '.join(missing)}",
+            )
 
         pending_count = return_request.returnitem_set.filter(
             stock__in_transit=False,

--- a/src/edc_pharmacy/views/return_receive_view.py
+++ b/src/edc_pharmacy/views/return_receive_view.py
@@ -59,9 +59,6 @@ class ReturnReceiveView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Tem
             received_count=received_count,
             pending_count=pending_count,
             item_count=list(range(1, items_to_scan + 1)),
-            changelist_url=reverse(
-                "edc_pharmacy_admin:edc_pharmacy_returnrequest_changelist"
-            ),
         )
         return super().get_context_data(**kwargs)
 
@@ -113,6 +110,9 @@ class ReturnReceiveView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Tem
                     kwargs={"return_request": return_request.pk},
                 )
             )
-        return HttpResponseRedirect(
-            reverse("edc_pharmacy_admin:edc_pharmacy_returnrequest_changelist")
+        messages.add_message(
+            request,
+            messages.SUCCESS,
+            f"All items received for {return_request.return_identifier}.",
         )
+        return HttpResponseRedirect(reverse("edc_pharmacy:return_central_url"))

--- a/src/edc_pharmacy/views/return_request_view.py
+++ b/src/edc_pharmacy/views/return_request_view.py
@@ -77,9 +77,6 @@ class ReturnRequestView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Tem
             item_count=list(range(1, items_to_scan + 1)),
             central_location=central_location,
             from_locations=from_locations,
-            changelist_url=reverse(
-                "edc_pharmacy_admin:edc_pharmacy_returnrequest_changelist"
-            ),
         )
         return super().get_context_data(**kwargs)
 
@@ -158,13 +155,17 @@ class ReturnRequestView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Tem
                     )
 
         dispatched_count = return_request.returnitem_set.count()
-        if dispatched_count < (return_request.item_count or 0):
-            return HttpResponseRedirect(
-                reverse(
-                    "edc_pharmacy:return_request_url",
-                    kwargs={"return_request": return_request.pk},
-                )
+        if dispatched_count >= (return_request.item_count or 0):
+            messages.add_message(
+                request,
+                messages.SUCCESS,
+                f"Return request {return_request.return_identifier} complete: "
+                f"{dispatched_count} item(s) dispatched to central.",
             )
+            return HttpResponseRedirect(reverse("edc_pharmacy:return_request_url"))
         return HttpResponseRedirect(
-            reverse("edc_pharmacy_admin:edc_pharmacy_returnrequest_changelist")
+            reverse(
+                "edc_pharmacy:return_request_url",
+                kwargs={"return_request": return_request.pk},
+            )
         )

--- a/src/edc_pharmacy/views/return_request_view.py
+++ b/src/edc_pharmacy/views/return_request_view.py
@@ -107,7 +107,29 @@ class ReturnRequestView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Tem
     def post(self, request, *args, **kwargs):  # noqa: ARG002
         return_request = self._get_return_request()
 
-        # --- Phase 1: create a new ReturnRequest and flag codes ---
+        # --- Phase 1a: delete an empty ReturnRequest ---
+        if not return_request and request.POST.get("delete_pk"):
+            try:
+                rr = ReturnRequest.objects.get(pk=request.POST["delete_pk"])
+                if rr.returnitem_set.exists():
+                    messages.add_message(
+                        request,
+                        messages.ERROR,
+                        f"Cannot delete {rr.return_identifier}: items already dispatched.",
+                    )
+                else:
+                    identifier = rr.return_identifier
+                    rr.delete()
+                    messages.add_message(
+                        request,
+                        messages.SUCCESS,
+                        f"Return request {identifier} deleted.",
+                    )
+            except ReturnRequest.DoesNotExist:
+                messages.add_message(request, messages.ERROR, "Return request not found.")
+            return HttpResponseRedirect(reverse("edc_pharmacy:return_request_url"))
+
+        # --- Phase 1b: create a new ReturnRequest and flag codes ---
         if not return_request:
             from_location_id = request.POST.get("from_location_id")
             item_count = request.POST.get("item_count")

--- a/src/edc_pharmacy/views/return_request_view.py
+++ b/src/edc_pharmacy/views/return_request_view.py
@@ -68,6 +68,12 @@ class ReturnRequestView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Tem
         from_locations = Location.objects.filter(
             site__in=self.request.user.userprofile.sites.all()
         )
+        # Pre-select the location that matches the current request site so
+        # the pharmacist doesn't have to choose from the dropdown each time.
+        try:
+            current_site_location = Location.objects.get(site=self.request.site)
+        except (Location.DoesNotExist, Location.MultipleObjectsReturned):
+            current_site_location = None
 
         kwargs.update(
             return_request=return_request,
@@ -77,6 +83,7 @@ class ReturnRequestView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Tem
             item_count=list(range(1, items_to_scan + 1)),
             central_location=central_location,
             from_locations=from_locations,
+            current_site_location=current_site_location,
         )
         return super().get_context_data(**kwargs)
 

--- a/src/edc_pharmacy/views/return_request_view.py
+++ b/src/edc_pharmacy/views/return_request_view.py
@@ -144,7 +144,36 @@ class ReturnRequestView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Tem
                 )
             )
 
-        # --- Phase 2: dispatch stock codes on an existing ReturnRequest ---
+        # --- Phase 2a: update the expected item count ---
+        if request.POST.get("update_item_count"):
+            try:
+                new_count = int(request.POST.get("item_count", 0))
+                dispatched_count = return_request.returnitem_set.count()
+                if new_count < dispatched_count:
+                    messages.add_message(
+                        request,
+                        messages.ERROR,
+                        f"Cannot set count to {new_count}: "
+                        f"{dispatched_count} item(s) already dispatched.",
+                    )
+                else:
+                    return_request.item_count = new_count
+                    return_request.save(update_fields=["item_count"])
+                    messages.add_message(
+                        request,
+                        messages.SUCCESS,
+                        f"Expected count updated to {new_count}.",
+                    )
+            except (ValueError, TypeError):
+                messages.add_message(request, messages.ERROR, "Invalid item count.")
+            return HttpResponseRedirect(
+                reverse(
+                    "edc_pharmacy:return_request_url",
+                    kwargs={"return_request": return_request.pk},
+                )
+            )
+
+        # --- Phase 2b: dispatch stock codes on an existing ReturnRequest ---
         stock_codes = [c.strip().upper() for c in request.POST.getlist("codes") if c.strip()]
         if stock_codes:
             try:

--- a/src/edc_pharmacy/views/return_request_view.py
+++ b/src/edc_pharmacy/views/return_request_view.py
@@ -54,6 +54,14 @@ class ReturnRequestView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Tem
             .filter(dispatched_item_count__lt=F("item_count"))
             .order_by("-return_datetime")
         )
+        completed_returns = (
+            ReturnRequest.objects.filter(
+                from_location__site=self.request.site,
+            )
+            .annotate(dispatched_item_count=Count("returnitem"))
+            .filter(dispatched_item_count__gte=F("item_count"))
+            .order_by("-return_datetime")[:5]
+        )
 
         dispatched_count = 0
         remaining_count = 0
@@ -90,6 +98,7 @@ class ReturnRequestView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Tem
             central_location=central_location,
             from_locations=from_locations,
             current_site_location=current_site_location,
+            completed_returns=completed_returns,
         )
         return super().get_context_data(**kwargs)
 

--- a/src/edc_pharmacy/views/return_request_view.py
+++ b/src/edc_pharmacy/views/return_request_view.py
@@ -18,6 +18,7 @@ from django.apps import apps as django_apps
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.db.models import Count, F
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -44,10 +45,15 @@ class ReturnRequestView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Tem
 
     def get_context_data(self, **kwargs):
         return_request = self._get_return_request()
-        pending_returns = ReturnRequest.objects.filter(
-            from_location__site=self.request.site,
-            cancel__in=["", "N/A"],
-        ).order_by("-return_datetime")
+        pending_returns = (
+            ReturnRequest.objects.filter(
+                from_location__site=self.request.site,
+                cancel__in=["", "N/A"],
+            )
+            .annotate(dispatched_item_count=Count("returnitem"))
+            .filter(dispatched_item_count__lt=F("item_count"))
+            .order_by("-return_datetime")
+        )
 
         dispatched_count = 0
         remaining_count = 0


### PR DESCRIPTION
## Summary

- Add `StockTransactionResource` (`import_export.resources.ModelResource`) with columns: stock code, stock identifier, subject identifier, transaction type, datetime, actor, reason, qty delta, unit qty delta, from/to location display name
- Subject identifier resolved from `to_allocation` / `from_allocation` with fallback to `stock.subject_identifier`
- Wire `ExportMixin` into `StockTransactionAdmin` — adds the standard django-import-export Export button and format selector (CSV, XLSX, JSON, …) to the changelist

`import_export` is already in `INSTALLED_APPS` and `django-import-export>=4.3.0` is already a project dependency — no new dependencies required.

## Test plan

- [ ] Open Stock Transaction ledger admin — verify Export button appears in the changelist toolbar
- [ ] Export as CSV and XLSX — verify all columns present and subject identifiers resolve correctly
- [ ] Apply filters (date range, transaction type) then export — verify only filtered rows are exported

🤖 Generated with [Claude Code](https://claude.com/claude-code)