### PR TITLE
fix: replace stale stock__allocation lookups with stock__current_allocation

### DIFF
--- a/src/edc_pharmacy/admin/stock/confirmation_at_location_item_admin.py
+++ b/src/edc_pharmacy/admin/stock/confirmation_at_location_item_admin.py
@@ -72,7 +72,7 @@ class ConfirmationAtLocationItemAdmin(
         "confirm_at_location__pk",
         "stock_transfer_item__stock__code",
         "stock_transfer_item__stock__pk",
-        "stock_transfer_item__stock__allocation__registered_subject__subject_identifier",
+        "stock_transfer_item__stock__current_allocation__registered_subject__subject_identifier",
     )
 
     @admin.display(

--- a/src/edc_pharmacy/admin/stock/stock_transfer_item_admin.py
+++ b/src/edc_pharmacy/admin/stock/stock_transfer_item_admin.py
@@ -28,7 +28,7 @@ class ConfirmedAtLocationFilter(SimpleListFilter):
             opts = dict(
                 stock__from_stock__isnull=False,
                 stock__confirmation__isnull=False,
-                stock__allocation__isnull=False,
+                stock__current_allocation__isnull=False,
             )
             if self.value() == YES:
                 qs = queryset.filter(
@@ -95,7 +95,7 @@ class StockTransferItemAdmin(ModelAdminMixin, SimpleHistoryAdmin):
         "transfer_item_identifier",
         "stock_transfer__id",
         "stock__code",
-        "stock__allocation__registered_subject__subject_identifier",
+        "stock__current_allocation__registered_subject__subject_identifier",
     )
 
     readonly_fields = (


### PR DESCRIPTION
## Summary

- `stock__allocation` lookups in three admin files were causing `FieldError` because the FK on `Stock` was renamed to `current_allocation` during the refactor
- Fixed in `stock_transfer_item_admin.py` (search field + queryset filter) and `confirmation_at_location_item_admin.py` (search field)
- `stockrequestitem__allocation__*` lookups in `stock_request_admin.py` are correct — they traverse the reverse of `Allocation.stock_request_item` (OneToOneField), not the Stock FK

## Test plan

- [ ] Load StockTransferItem changelist — no FieldError
- [ ] Load ConfirmationAtLocationItem changelist — no FieldError
- [ ] Search by subject identifier in both changelists returns results

🤖 Generated with [Claude Code](https://claude.com/claude-code)