### PR TITLE
fix: require stored_at_location=True before RETURN_REQUESTED

### DIFF
--- a/src/edc_pharmacy/admin/stock/confirmation_at_location_item_admin.py
+++ b/src/edc_pharmacy/admin/stock/confirmation_at_location_item_admin.py
@@ -72,7 +72,7 @@ class ConfirmationAtLocationItemAdmin(
         "confirm_at_location__pk",
         "stock_transfer_item__stock__code",
         "stock_transfer_item__stock__pk",
-        "stock_transfer_item__stock__allocation__registered_subject__subject_identifier",
+        "stock_transfer_item__stock__current_allocation__registered_subject__subject_identifier",
     )
 
     @admin.display(

--- a/src/edc_pharmacy/admin/stock/stock_transfer_item_admin.py
+++ b/src/edc_pharmacy/admin/stock/stock_transfer_item_admin.py
@@ -28,7 +28,7 @@ class ConfirmedAtLocationFilter(SimpleListFilter):
             opts = dict(
                 stock__from_stock__isnull=False,
                 stock__confirmation__isnull=False,
-                stock__allocation__isnull=False,
+                stock__current_allocation__isnull=False,
             )
             if self.value() == YES:
                 qs = queryset.filter(
@@ -95,7 +95,7 @@ class StockTransferItemAdmin(ModelAdminMixin, SimpleHistoryAdmin):
         "transfer_item_identifier",
         "stock_transfer__id",
         "stock__code",
-        "stock__allocation__registered_subject__subject_identifier",
+        "stock__current_allocation__registered_subject__subject_identifier",
     )
 
     readonly_fields = (

--- a/src/edc_pharmacy/transaction_log/compute_delta.py
+++ b/src/edc_pharmacy/transaction_log/compute_delta.py
@@ -196,6 +196,8 @@ def _compute_return_requested(current: CurrentState, **_) -> StateDelta:
         fail.append("return already requested")
     if current.in_transit:
         fail.append("in transit")
+    if not current.stored_at_location:
+        fail.append("not stored at location")
     if fail:
         return StateDelta(preconditions_failed=tuple(fail))
     return StateDelta(stock_fields={"return_requested": True})


### PR DESCRIPTION
## Summary

`RETURN_REQUESTED` now requires `stored_at_location=True`, matching the existing precondition on `RETURN_DISPATCHED`.

Previously an item could have a return flagged while only `confirmed_at_location` (not yet in a bin). It would then be stuck — the dispatch step requires `stored_at_location=True` — with no way forward without manually storing it first.

## Test plan

- [ ] Attempting `RETURN_REQUESTED` on a `confirmed_at_location` but not `stored_at_location` item fails with "not stored at location"
- [ ] `RETURN_REQUESTED` on a `stored_at_location=True` item succeeds as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)