### PR TITLE
feat: add stock-transfer landing page and refactor scan UI

### DIFF
--- a/src/edc_pharmacy/admin/stock/stock_admin.py
+++ b/src/edc_pharmacy/admin/stock/stock_admin.py
@@ -304,7 +304,7 @@ class StockAdmin(ModelAdminMixin, SimpleHistoryAdmin):
         txn = obj.transactions.order_by("-transaction_datetime").first()
         if txn:
             local_dt = to_local(txn.transaction_datetime)
-            url = reverse("edc_pharmacy_admin:edc_pharmacy_stocktransaction_changelist")
+            url = reverse("edc_pharmacy:ledger_url")
             url = f"{url}?q={obj.code}"
             return format_html(
                 '<a href="{}">{}</a><br><small style="color:#6c757d">{}</small>',

--- a/src/edc_pharmacy/management/commands/bootstrap_stock_transactions.py
+++ b/src/edc_pharmacy/management/commands/bootstrap_stock_transactions.py
@@ -227,7 +227,7 @@ def _bootstrap_one(stock: Stock, actor_cache: dict) -> list[StockTransaction]:
         # Prefer the user who processed the repack over the generic stock actor.
         # RepackRequest.user_modified is set by process_repack_request().
         repack_actor = actor
-        rr = stock.repackrequest_set.order_by("-modified").first()
+        rr = stock.repack_requests.order_by("-modified").first()
         if rr is not None:
             rr_username = getattr(rr, "user_modified", None) or getattr(rr, "user_created", None)
             if rr_username:

--- a/src/edc_pharmacy/management/commands/bootstrap_stock_transactions.py
+++ b/src/edc_pharmacy/management/commands/bootstrap_stock_transactions.py
@@ -73,6 +73,7 @@ def _txn(
         unit_qty_delta: Decimal = Decimal("0"),
         **fk_kwargs,
 ) -> StockTransaction:
+    username = actor.username if actor else ""
     return StockTransaction(
         stock=stock,
         transaction_type=txn_type,
@@ -86,6 +87,8 @@ def _txn(
         from_location_id=from_location_id or stock.location_id,
         to_location_id=to_location_id or stock.location_id,
         state_after=_BOOTSTRAPPED,
+        user_created=username,
+        user_modified=username,
         **fk_kwargs,
     )
 
@@ -221,12 +224,20 @@ def _bootstrap_one(stock: Stock, actor_cache: dict) -> list[StockTransaction]:
                             .aggregate(total=Sum("unit_qty_in"))["total"]
                         ) or Decimal("0")
     if consumed_unit_qty > 0:
+        # Prefer the user who processed the repack over the generic stock actor.
+        # RepackRequest.user_modified is set by process_repack_request().
+        repack_actor = actor
+        rr = stock.repackrequest_set.order_by("-modified").first()
+        if rr is not None:
+            rr_username = getattr(rr, "user_modified", None) or getattr(rr, "user_created", None)
+            if rr_username:
+                repack_actor = _resolve_actor(rr_username, actor_cache) or actor
         rows.append(
             _txn(
                 stock,
                 TXN_REPACK_CONSUMED,
                 stock.stock_datetime,
-                actor=actor,
+                actor=repack_actor,
                 unit_qty_delta=-consumed_unit_qty,
             )
         )

--- a/src/edc_pharmacy/management/commands/bootstrap_stock_transactions.py
+++ b/src/edc_pharmacy/management/commands/bootstrap_stock_transactions.py
@@ -67,13 +67,16 @@ def _txn(
         dt,
         *,
         actor=None,
+        username: str = "",
         from_location_id=None,
         to_location_id=None,
         qty_delta: Decimal = Decimal("0"),
         unit_qty_delta: Decimal = Decimal("0"),
         **fk_kwargs,
 ) -> StockTransaction:
-    username = actor.username if actor else ""
+    # Use the explicit username string when provided (even if actor is None
+    # because the User account no longer exists in the DB).
+    effective_username = username or (actor.username if actor else "")
     return StockTransaction(
         stock=stock,
         transaction_type=txn_type,
@@ -87,8 +90,8 @@ def _txn(
         from_location_id=from_location_id or stock.location_id,
         to_location_id=to_location_id or stock.location_id,
         state_after=_BOOTSTRAPPED,
-        user_created=username,
-        user_modified=username,
+        user_created=effective_username,
+        user_modified=effective_username,
         **fk_kwargs,
     )
 
@@ -96,7 +99,15 @@ def _txn(
 def _bootstrap_one(stock: Stock, actor_cache: dict) -> list[StockTransaction]:
     """Return unsaved StockTransaction instances for a single stock."""
     rows: list[StockTransaction] = []
-    actor = _resolve_actor(stock.user_modified or stock.user_created, actor_cache)
+
+    # raw_username is the string stored on the model — kept even when the User
+    # account no longer exists so that user_created/user_modified are populated.
+    raw_username = stock.user_modified or stock.user_created or ""
+    actor = _resolve_actor(raw_username, actor_cache)
+
+    def t(txn_type, dt, *, actor=actor, username=raw_username, **kw):
+        """Shorthand: call _txn with stock, raw_username and defaults bound."""
+        return _txn(stock, txn_type, dt, actor=actor, username=username, **kw)
 
     # Resolve allocation — stock.current_allocation is None for dispensed/ended stocks,
     # but Allocation.code == stock.code so the record is still recoverable.
@@ -107,59 +118,38 @@ def _bootstrap_one(stock: Stock, actor_cache: dict) -> list[StockTransaction]:
     # RECEIVED — qty_in=+1, unit_qty_in=+container_unit_qty.
     if stock.confirmed:
         dt = stock.confirmed_datetime or stock.stock_datetime
-        rows.append(
-            _txn(
-                stock,
-                TXN_RECEIVED,
-                dt,
-                actor=actor,
-                qty_delta=Decimal("1"),
-                unit_qty_delta=stock.container_unit_qty or Decimal("0"),
-            )
-        )
+        rows.append(t(
+            TXN_RECEIVED, dt,
+            qty_delta=Decimal("1"),
+            unit_qty_delta=stock.container_unit_qty or Decimal("0"),
+        ))
 
     # ALLOCATED
     if allocation is not None:
-        rows.append(
-            _txn(
-                stock,
-                TXN_ALLOCATED,
-                allocation.allocation_datetime,
-                actor=actor,
-                to_allocation=allocation,
-            )
-        )
+        rows.append(t(TXN_ALLOCATED, allocation.allocation_datetime, to_allocation=allocation))
 
     # TRANSFER_DISPATCHED — one row per transfer (stock may have been transferred
     # more than once, e.g. central → site → central → site).
     for sti in stock.stocktransferitem_set.all():
-        rows.append(
-            _txn(
-                stock,
-                TXN_TRANSFER_DISPATCHED,
-                sti.transfer_item_datetime,
-                actor=actor,
-                from_location_id=sti.stock_transfer.from_location_id,
-                to_location_id=sti.stock_transfer.to_location_id,
-                stock_transfer_item=sti,
-                to_allocation=allocation,
-            )
-        )
+        rows.append(t(
+            TXN_TRANSFER_DISPATCHED,
+            sti.transfer_item_datetime,
+            from_location_id=sti.stock_transfer.from_location_id,
+            to_location_id=sti.stock_transfer.to_location_id,
+            stock_transfer_item=sti,
+            to_allocation=allocation,
+        ))
 
     # TRANSFER_RECEIVED
     try:
         cali: ConfirmationAtLocationItem = stock.confirmationatlocationitem
-        rows.append(
-            _txn(
-                stock,
-                TXN_TRANSFER_RECEIVED,
-                cali.confirmed_datetime or cali.transfer_confirmation_item_datetime,
-                actor=actor,
-                to_location_id=cali.confirm_at_location.location_id,
-                stock_transfer_item=cali.stock_transfer_item,
-                to_allocation=allocation,
-            )
-        )
+        rows.append(t(
+            TXN_TRANSFER_RECEIVED,
+            cali.confirmed_datetime or cali.transfer_confirmation_item_datetime,
+            to_location_id=cali.confirm_at_location.location_id,
+            stock_transfer_item=cali.stock_transfer_item,
+            to_allocation=allocation,
+        ))
     except ConfirmationAtLocationItem.DoesNotExist:
         pass
 
@@ -181,66 +171,59 @@ def _bootstrap_one(stock: Stock, actor_cache: dict) -> list[StockTransaction]:
     if stored_dt is None and stock.stored_at_location:
         stored_dt = stock.stock_datetime
     if stored_dt is not None:
-        rows.append(_txn(stock, TXN_STORED, stored_dt, actor=actor, to_allocation=allocation))
+        rows.append(t(TXN_STORED, stored_dt, to_allocation=allocation))
 
     # DISPENSED — also covers historical stocks where DispenseItem was deleted.
     has_dispense_item = False
     try:
         di: DispenseItem = stock.dispenseitem
         has_dispense_item = True
-        rows.append(
-            _txn(
-                stock,
-                TXN_DISPENSED,
-                di.dispense_item_datetime,
-                actor=actor,
-                qty_delta=Decimal("-1"),
-                unit_qty_delta=-(stock.container_unit_qty or Decimal("0")),
-                dispense_item=di,
-                from_allocation=allocation,
-            )
-        )
+        rows.append(t(
+            TXN_DISPENSED,
+            di.dispense_item_datetime,
+            qty_delta=Decimal("-1"),
+            unit_qty_delta=-(stock.container_unit_qty or Decimal("0")),
+            dispense_item=di,
+            from_allocation=allocation,
+        ))
     except DispenseItem.DoesNotExist:
         pass
     if stock.dispensed and not has_dispense_item:
-        rows.append(
-            _txn(
-                stock,
-                TXN_DISPENSED,
-                stock.stock_datetime,
-                actor=actor,
-                qty_delta=Decimal("-1"),
-                unit_qty_delta=-(stock.container_unit_qty or Decimal("0")),
-                from_allocation=allocation,
-            )
-        )
+        rows.append(t(
+            TXN_DISPENSED,
+            stock.stock_datetime,
+            qty_delta=Decimal("-1"),
+            unit_qty_delta=-(stock.container_unit_qty or Decimal("0")),
+            from_allocation=allocation,
+        ))
 
     # REPACK_CONSUMED — sum unit_qty_in across child stocks via the RepackRequest
     # bridge (repack_request__from_stock=stock).  This is more reliable than
     # filtering on Stock.from_stock directly: that FK may be NULL on older records
     # where the field was added after the repack was processed.
     consumed_unit_qty = (
-                            Stock.objects.filter(repack_request__from_stock=stock)
-                            .aggregate(total=Sum("unit_qty_in"))["total"]
-                        ) or Decimal("0")
+        Stock.objects.filter(repack_request__from_stock=stock)
+        .aggregate(total=Sum("unit_qty_in"))["total"]
+    ) or Decimal("0")
     if consumed_unit_qty > 0:
         # Prefer the user who processed the repack over the generic stock actor.
         # RepackRequest.user_modified is set by process_repack_request().
-        repack_actor = actor
         rr = stock.repack_requests.order_by("-modified").first()
+        rr_raw = ""
+        rr_actor = actor
         if rr is not None:
-            rr_username = getattr(rr, "user_modified", None) or getattr(rr, "user_created", None)
-            if rr_username:
-                repack_actor = _resolve_actor(rr_username, actor_cache) or actor
-        rows.append(
-            _txn(
-                stock,
-                TXN_REPACK_CONSUMED,
-                stock.stock_datetime,
-                actor=repack_actor,
-                unit_qty_delta=-consumed_unit_qty,
+            rr_raw = (
+                getattr(rr, "user_modified", "") or getattr(rr, "user_created", "") or ""
             )
-        )
+            if rr_raw:
+                rr_actor = _resolve_actor(rr_raw, actor_cache) or actor
+        rows.append(t(
+            TXN_REPACK_CONSUMED,
+            stock.stock_datetime,
+            actor=rr_actor,
+            username=rr_raw or raw_username,
+            unit_qty_delta=-consumed_unit_qty,
+        ))
 
     # Sort by datetime so the ledger reads chronologically.
     rows.sort(key=lambda r: r.transaction_datetime)
@@ -310,14 +293,14 @@ class Command(BaseCommand):
                 # that caused bootstrap to skip the stock entirely on a previous run.
                 if stock.confirmed and stock.pk not in already_have_received:
                     dt = stock.confirmed_datetime or stock.stock_datetime
-                    actor = _resolve_actor(
-                        stock.user_modified or stock.user_created, actor_cache
-                    )
+                    raw_username = stock.user_modified or stock.user_created or ""
+                    actor = _resolve_actor(raw_username, actor_cache)
                     row = _txn(
                         stock,
                         TXN_RECEIVED,
                         dt,
                         actor=actor,
+                        username=raw_username,
                         qty_delta=Decimal("1"),
                         unit_qty_delta=stock.container_unit_qty or Decimal("0"),
                     )

--- a/src/edc_pharmacy/management/commands/bootstrap_stock_transactions.py
+++ b/src/edc_pharmacy/management/commands/bootstrap_stock_transactions.py
@@ -211,15 +211,17 @@ def _bootstrap_one(stock: Stock, actor_cache: dict) -> list[StockTransaction]:
         rr = stock.repack_requests.order_by("-modified").first()
         rr_raw = ""
         rr_actor = actor
+        repack_dt = stock.stock_datetime
         if rr is not None:
             rr_raw = (
                 getattr(rr, "user_modified", "") or getattr(rr, "user_created", "") or ""
             )
             if rr_raw:
                 rr_actor = _resolve_actor(rr_raw, actor_cache) or actor
+            repack_dt = rr.repack_datetime or stock.stock_datetime
         rows.append(t(
             TXN_REPACK_CONSUMED,
-            stock.stock_datetime,
+            repack_dt,
             actor=rr_actor,
             username=rr_raw or raw_username,
             unit_qty_delta=-consumed_unit_qty,

--- a/src/edc_pharmacy/pdf_reports/manifest_pdf_report.py
+++ b/src/edc_pharmacy/pdf_reports/manifest_pdf_report.py
@@ -43,7 +43,10 @@ class ManifestReport(Report):
 
     @property
     def queryset(self):
-        return self.stock_transfer.stocktransferitem_set.all().order_by(
+        return self.stock_transfer.stocktransferitem_set.select_related(
+            "stock__current_allocation__registered_subject",
+            "stock__product__formulation",
+        ).order_by(
             "stock__current_allocation__registered_subject__subject_identifier"
         )
 
@@ -168,8 +171,9 @@ class ManifestReport(Report):
             barcode = code128.Code128(
                 stock_transfer_item.stock.code, barHeight=5 * mm, barWidth=0.7, gap=1.7
             )
+            alloc = stock_transfer_item.stock.current_allocation
             subject_identifier = (
-                stock_transfer_item.stock.current_allocation.registered_subject.subject_identifier
+                alloc.registered_subject.subject_identifier if alloc else "—"
             )
             formulation = stock_transfer_item.stock.product.formulation
             description = f"{formulation.imp_description} "

--- a/src/edc_pharmacy/pdf_reports/manifest_pdf_report.py
+++ b/src/edc_pharmacy/pdf_reports/manifest_pdf_report.py
@@ -47,7 +47,7 @@ class ManifestReport(Report):
             "stock__current_allocation__registered_subject",
             "stock__product__formulation",
         ).prefetch_related(
-            "stock__allocation_set",
+            "stock__allocations",
         ).order_by(
             "stock__current_allocation__registered_subject__subject_identifier"
         )
@@ -186,7 +186,7 @@ class ManifestReport(Report):
                 # written to the Stock row.  Recover from the most recent
                 # Allocation row (prefetched above).
                 past_alloc = sorted(
-                    stock.allocation_set.all(),
+                    stock.allocations.all(),
                     key=lambda a: a.allocation_datetime,
                     reverse=True,
                 )

--- a/src/edc_pharmacy/pdf_reports/manifest_pdf_report.py
+++ b/src/edc_pharmacy/pdf_reports/manifest_pdf_report.py
@@ -173,7 +173,9 @@ class ManifestReport(Report):
             )
             alloc = stock_transfer_item.stock.current_allocation
             subject_identifier = (
-                alloc.registered_subject.subject_identifier if alloc else "—"
+                alloc.registered_subject.subject_identifier
+                if alloc
+                else stock_transfer_item.stock.subject_identifier or "—"
             )
             formulation = stock_transfer_item.stock.product.formulation
             description = f"{formulation.imp_description} "

--- a/src/edc_pharmacy/pdf_reports/manifest_pdf_report.py
+++ b/src/edc_pharmacy/pdf_reports/manifest_pdf_report.py
@@ -46,6 +46,8 @@ class ManifestReport(Report):
         return self.stock_transfer.stocktransferitem_set.select_related(
             "stock__current_allocation__registered_subject",
             "stock__product__formulation",
+        ).prefetch_related(
+            "stock__allocation_set",
         ).order_by(
             "stock__current_allocation__registered_subject__subject_identifier"
         )
@@ -171,12 +173,24 @@ class ManifestReport(Report):
             barcode = code128.Code128(
                 stock_transfer_item.stock.code, barHeight=5 * mm, barWidth=0.7, gap=1.7
             )
-            alloc = stock_transfer_item.stock.current_allocation
-            subject_identifier = (
-                alloc.registered_subject.subject_identifier
-                if alloc
-                else stock_transfer_item.stock.subject_identifier or "—"
-            )
+            stock = stock_transfer_item.stock
+            alloc = stock.current_allocation
+            if alloc:
+                subject_identifier = alloc.registered_subject.subject_identifier
+            elif stock.subject_identifier:
+                # Preserved on dispense via _compute_dispensed (intentional).
+                subject_identifier = stock.subject_identifier
+            else:
+                # Bootstrapped items: allocation record still exists but
+                # current_allocation is None and subject_identifier was never
+                # written to the Stock row.  Recover from the most recent
+                # Allocation row (prefetched above).
+                past_alloc = sorted(
+                    stock.allocation_set.all(),
+                    key=lambda a: a.allocation_datetime,
+                    reverse=True,
+                )
+                subject_identifier = past_alloc[0].subject_identifier if past_alloc else "—"
             formulation = stock_transfer_item.stock.product.formulation
             description = f"{formulation.imp_description} "
             style = ParagraphStyle(

--- a/src/edc_pharmacy/templates/edc_pharmacy/central_home.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/central_home.html
@@ -23,6 +23,7 @@
         <div class="list-group">
             <a id="home_list_group_stock" href="{% url 'edc_pharmacy_admin:edc_pharmacy_stock_changelist' %}" class="list-group-item">Stock</a>
             <a id="home_list_group_stock_transactions" href="{% url 'edc_pharmacy:ledger_url' %}" class="list-group-item">Stock transaction ledger</a>
+            <a id="home_list_group_bulk_stock_report" href="{% url 'edc_pharmacy:bulk_stock_report_url' %}" class="list-group-item">Bulk container report</a>
             <a id="home_list_group_allocation" href="{% url 'edc_pharmacy_admin:edc_pharmacy_allocation_changelist' %}" class="list-group-item">Allocations</a>
             <a id="home_list_group_stockavailability" href="{% url 'edc_pharmacy_admin:edc_pharmacy_stockavailability_changelist' %}?has_codes=No" class="list-group-item">Stock availability</a>
             <a id="home_list_group_allocation" href="{% url 'edc_pylabels_admin:index' %}" class="list-group-item">Label Configurations</a>

--- a/src/edc_pharmacy/templates/edc_pharmacy/central_home.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/central_home.html
@@ -11,7 +11,7 @@
                 <a id="home_list_group_receive" href="{% url 'edc_pharmacy_admin:edc_pharmacy_receive_changelist' %}" class="list-group-item"><B>Receiving:</B> Label and confirm received stock</a>
                 <a id="home_list_group_repack" href="{% url 'edc_pharmacy_admin:edc_pharmacy_repackrequest_changelist' %}" class="list-group-item"><b>Repack:</b> Decant, label and confirm</a>
                 <a id="home_list_group_stockrequest" href="{% url 'edc_pharmacy_admin:edc_pharmacy_stockrequest_changelist' %}" class="list-group-item"><B>Manage Requests:</B> Allocate stock to subjects</a>
-                <a id="home_list_group_stocktransfer" href="{% url 'edc_pharmacy_admin:edc_pharmacy_stocktransfer_changelist' %}" class="list-group-item"><b>Transfer stock to site</b></a>
+                <a id="home_list_group_stocktransfer" href="{% url 'edc_pharmacy:stock_transfer_home_url' %}" class="list-group-item"><b>Transfer stock to site</b></a>
                 <a id="home_list_group_return_central" href="{% url 'edc_pharmacy:return_central_url' %}" class="list-group-item"><b>Returns: Receive and disposition</b></a>
                 <a id="home_list_group_stock_adjustments" href="{% url 'edc_pharmacy:stock_adjustments_url' %}" class="list-group-item"><b>Stock adjustments</b></a>
                 <a id="home_list_group_dispense" href="{% url 'edc_pharmacy_admin:edc_pharmacy_storagebinproxy_changelist' %}" class="list-group-item"><b>Add/Update storage bins</b></a>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/bulk_stock_report.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/bulk_stock_report.html
@@ -1,0 +1,86 @@
+{% extends edc_base_template %}
+{% load static %}
+
+{% block main %}
+    {{ block.super }}
+    <div class="container">
+        <div class="col-sm-1"></div>
+        <div class="col-sm-10">
+
+            <div style="padding:10px;">
+                <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
+                Bulk container report
+            </div>
+
+            {% if rows %}
+            <table class="table table-condensed table-hover">
+                <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Batch</th>
+                        <th>Assignment</th>
+                        <th>Formulation</th>
+                        <th>Container</th>
+                        <th>Location</th>
+                        <th style="text-align:right;">Unit Qty In</th>
+                        <th style="text-align:right;">Unit Qty Out</th>
+                        <th style="text-align:right;">Balance</th>
+                        <th style="text-align:center;">Repacks</th>
+                        <th>Ledger</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in rows %}
+                    {% with s=row.stock %}
+                    <tr {% if row.balance < 0 %}style="color:#c00;"{% endif %}>
+                        <td>
+                            <a href="{% url "edc_pharmacy_admin:edc_pharmacy_stock_change" s.pk %}">
+                                <code>{{ s.code }}</code>
+                            </a>
+                        </td>
+                        <td style="white-space:nowrap;">{{ s.lot.lot_no }}</td>
+                        <td>{{ s.lot.assignment|default:"—" }}</td>
+                        <td>{{ s.product.formulation.imp_description|default:"—" }}</td>
+                        <td>{{ s.container|default:"—" }}</td>
+                        <td style="white-space:nowrap;">{{ s.location.display_name|default:"—" }}</td>
+                        <td style="text-align:right;">{{ row.unit_qty_in }}</td>
+                        <td style="text-align:right;">{{ row.unit_qty_out }}</td>
+                        <td style="text-align:right;">
+                            {% if row.balance == 0 %}
+                                <span class="label label-success">0</span>
+                            {% elif row.balance < 0 %}
+                                <span class="label label-danger">{{ row.balance }}</span>
+                            {% else %}
+                                {{ row.balance }}
+                            {% endif %}
+                        </td>
+                        <td style="text-align:center;">{{ row.repack_count }}</td>
+                        <td>
+                            <a href="{{ row.ledger_url }}">Ledger</a>
+                        </td>
+                    </tr>
+                    {% endwith %}
+                    {% endfor %}
+                </tbody>
+                <tfoot>
+                    <tr style="font-weight:bold; border-top:2px solid #ddd;">
+                        <td colspan="6" style="text-align:right;">Total</td>
+                        <td style="text-align:right;">{{ totals.unit_qty_in }}</td>
+                        <td style="text-align:right;">{{ totals.unit_qty_out }}</td>
+                        <td style="text-align:right;">{{ totals.balance }}</td>
+                        <td colspan="2"></td>
+                    </tr>
+                </tfoot>
+            </table>
+            {% else %}
+                <p class="text-muted">No bulk containers found.</p>
+            {% endif %}
+
+            <p style="margin-top:8px;">
+                <a href="{% url "edc_pharmacy_admin:edc_pharmacy_stock_changelist" %}?from_stock__isnull=1">View in admin &rsaquo;</a>
+            </p>
+
+        </div>
+        <div class="col-sm-1"></div>
+    </div>
+{% endblock main %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/bulk_stock_report.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/bulk_stock_report.html
@@ -1,11 +1,31 @@
 {% extends edc_base_template %}
 {% load static %}
 
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.11.5/css/jquery.dataTables.min.css">
+{% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <script src="https://cdn.datatables.net/1.11.5/js/jquery.dataTables.min.js"></script>
+{% endblock %}
+
+{% block document_ready %}
+    <script>
+        $(document).ready(function() {
+            $('#bulk_stock_table').DataTable({
+                order: [[1, 'asc']],
+                pageLength: 25,
+            });
+        });
+    </script>
+{% endblock %}
+
 {% block main %}
     {{ block.super }}
     <div class="container">
-        <div class="col-sm-1"></div>
-        <div class="col-sm-10">
+        <div class="col-sm-12">
 
             <div style="padding:10px;">
                 <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
@@ -13,12 +33,13 @@
             </div>
 
             {% if rows %}
-            <table class="table table-condensed table-hover">
+            <table id="bulk_stock_table" class="table table-condensed table-hover">
                 <thead>
                     <tr>
                         <th>Code</th>
-                        <th>Batch</th>
-                        <th>Assignment</th>
+                        {% if PHARMACIST_ROLE in roles %}<th>Batch</th>{% endif %}
+                        <th>Date</th>
+                        {% if PHARMACIST_ROLE in roles %}<th>Assignment</th>{% endif %}
                         <th>Formulation</th>
                         <th>Container</th>
                         <th>Location</th>
@@ -38,8 +59,9 @@
                                 <code>{{ s.code }}</code>
                             </a>
                         </td>
-                        <td style="white-space:nowrap;">{{ s.lot.lot_no }}</td>
-                        <td>{{ s.lot.assignment|default:"—" }}</td>
+                        {% if PHARMACIST_ROLE in roles %}<td style="white-space:nowrap;">{{ s.lot.lot_no }}</td>{% endif %}
+                        <td style="white-space:nowrap;">{{ s.lot.expiration_date|date:"Y-m-d"|default:"—" }}</td>
+                        {% if PHARMACIST_ROLE in roles %}<td>{{ s.lot.assignment|default:"—" }}</td>{% endif %}
                         <td>{{ s.product.formulation.imp_description|default:"—" }}</td>
                         <td>{{ s.container|default:"—" }}</td>
                         <td style="white-space:nowrap;">{{ s.location.display_name|default:"—" }}</td>
@@ -64,7 +86,7 @@
                 </tbody>
                 <tfoot>
                     <tr style="font-weight:bold; border-top:2px solid #ddd;">
-                        <td colspan="6" style="text-align:right;">Total</td>
+                        <td colspan="{% if PHARMACIST_ROLE in roles %}7{% else %}5{% endif %}" style="text-align:right;">Total</td>
                         <td style="text-align:right;">{{ totals.unit_qty_in }}</td>
                         <td style="text-align:right;">{{ totals.unit_qty_out }}</td>
                         <td style="text-align:right;">{{ totals.balance }}</td>
@@ -81,6 +103,5 @@
             </p>
 
         </div>
-        <div class="col-sm-1"></div>
     </div>
 {% endblock main %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/ledger.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/ledger.html
@@ -41,6 +41,7 @@
                             <tr>
                                 <th>Transaction</th>
                                 <th>Stock #</th>
+                                <th>Subject</th>
                                 <th>Type</th>
                                 <th>Date</th>
                                 <th>Actor</th>
@@ -63,6 +64,15 @@
                                     <a href="{% url "edc_pharmacy_admin:edc_pharmacy_stock_changelist" %}?q={{ txn.stock.code }}">
                                         <code>{{ txn.stock.code }}</code>
                                     </a>
+                                </td>
+                                <td style="white-space:nowrap;">
+                                    {% if txn._subject_identifier %}
+                                        <a href="{% url "edc_pharmacy:ledger_url" %}?q={{ txn._subject_identifier }}">
+                                            {{ txn._subject_identifier }}
+                                        </a>
+                                    {% else %}
+                                        —
+                                    {% endif %}
                                 </td>
                                 <td>{{ txn.get_transaction_type_display|default:txn.transaction_type }}</td>
                                 <td style="white-space:nowrap;">{{ txn.transaction_datetime|date:"d-M-Y" }}</td>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/ledger.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/ledger.html
@@ -99,6 +99,8 @@
 
                     <p style="margin-top:8px;">
                         <a href="{{ admin_url }}">View in admin (export, filter, sort) &rsaquo;</a>
+                        &nbsp;&nbsp;
+                        <a href="{% url "edc_pharmacy:stock_adjustments_url" %}">Stock adjustments &rsaquo;</a>
                     </p>
 
                 {% else %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/ledger.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/ledger.html
@@ -53,7 +53,8 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {% for txn in transactions %}
+                            {% for row in transactions %}
+                            {% with txn=row.txn %}
                             <tr>
                                 <td>
                                     <a href="{% url "edc_pharmacy_admin:edc_pharmacy_stocktransaction_change" txn.pk %}">
@@ -66,9 +67,9 @@
                                     </a>
                                 </td>
                                 <td style="white-space:nowrap;">
-                                    {% if txn._subject_identifier %}
-                                        <a href="{% url "edc_pharmacy:ledger_url" %}?q={{ txn._subject_identifier }}">
-                                            {{ txn._subject_identifier }}
+                                    {% if row.subject_identifier %}
+                                        <a href="{% url "edc_pharmacy:ledger_url" %}?q={{ row.subject_identifier }}">
+                                            {{ row.subject_identifier }}
                                         </a>
                                     {% else %}
                                         —
@@ -83,6 +84,7 @@
                                 <td>{{ txn.unit_qty_delta }}</td>
                                 <td>{{ txn.reason|default:"—" }}</td>
                             </tr>
+                            {% endwith %}
                             {% endfor %}
                         </tbody>
                     </table>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/ledger.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/ledger.html
@@ -1,11 +1,31 @@
 {% extends edc_base_template %}
 {% load static %}
 
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.11.5/css/jquery.dataTables.min.css">
+{% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <script src="https://cdn.datatables.net/1.11.5/js/jquery.dataTables.min.js"></script>
+{% endblock %}
+
+{% block document_ready %}
+    <script>
+        $(document).ready(function() {
+            $('#ledger_table').DataTable({
+                order: [[4, 'desc']],
+                pageLength: 25,
+            });
+        });
+    </script>
+{% endblock %}
+
 {% block main %}
     {{ block.super }}
     <div class="container">
-        <div class="col-sm-1"></div>
-        <div class="col-sm-10">
+        <div class="col-sm-12">
             <div style="padding:10px">
                 <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
                 Stock Transaction Ledger
@@ -36,7 +56,7 @@
                     <p class="text-muted small">{{ transactions|length }} transaction{{ transactions|length|pluralize }} found.</p>
                     {% endif %}
 
-                    <table class="table table-condensed table-hover">
+                    <table id="ledger_table" class="table table-condensed table-hover">
                         <thead>
                             <tr>
                                 <th>Transaction</th>
@@ -76,7 +96,7 @@
                                     {% endif %}
                                 </td>
                                 <td>{{ txn.get_transaction_type_display|default:txn.transaction_type }}</td>
-                                <td style="white-space:nowrap;">{{ txn.transaction_datetime|date:"d-M-Y" }}</td>
+                                <td style="white-space:nowrap;" data-order="{{ txn.transaction_datetime|date:"Y-m-d H:i:s" }}">{{ txn.transaction_datetime|date:"d-M-Y H:i" }}</td>
                                 <td>{{ txn.actor.username|default:"—" }}</td>
                                 <td>{{ txn.from_location.display_name|default:"—" }}</td>
                                 <td>{{ txn.to_location.display_name|default:"—" }}</td>
@@ -117,6 +137,5 @@
             {% endif %}
 
         </div>
-        <div class="col-sm-1"></div>
     </div>
 {% endblock main %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/ledger.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/ledger.html
@@ -87,6 +87,14 @@
                             {% endwith %}
                             {% endfor %}
                         </tbody>
+                        <tfoot>
+                            <tr style="font-weight:bold; border-top:2px solid #ddd;">
+                                <td colspan="8" style="text-align:right;">Total</td>
+                                <td>{{ qty_total }}</td>
+                                <td>{{ unit_qty_total }}</td>
+                                <td></td>
+                            </tr>
+                        </tfoot>
                     </table>
 
                     <p style="margin-top:8px;">

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_adjustments.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_adjustments.html
@@ -70,7 +70,7 @@
             </div>
 
             {# ─── Panel 2: Quantity Adjustment ────────────────────────── #}
-            <div class="panel panel-default">
+            <div id="qty-adjustment" class="panel panel-default">
                 <div class="panel-heading">Quantity Adjustment</div>
                 <div class="panel-body">
                     <p class="text-muted small">
@@ -83,10 +83,12 @@
 
                         <div class="form-group" style="max-width:280px;">
                             <label>Stock code</label>
-                            <input type="text" name="code" class="form-control input-sm"
+                            <input type="text" name="code" id="qty_code_input"
+                                   class="form-control input-sm"
                                    placeholder="Scan or type code"
                                    autocomplete="off" autocorrect="off"
                                    autocapitalize="characters" spellcheck="false"
+                                   value="{{ last_code }}"
                                    required>
                         </div>
 
@@ -107,6 +109,14 @@
                                 class="btn btn-primary">Apply Adjustment</button>
                         <a class="btn btn-default" style="margin-left:6px;"
                            href="{% url "edc_pharmacy:home_url" %}">Done</a>
+
+                        <div style="margin-top:10px;">
+                            <a id="qty_ledger_link"
+                               href="{% if last_ledger_url %}{{ last_ledger_url }}{% else %}#{% endif %}"
+                               style="font-size:0.9em;{% if not last_ledger_url %}display:none;{% endif %}">
+                                Last adjustment (<code id="qty_ledger_code">{{ last_code }}</code>): view in ledger &rsaquo;
+                            </a>
+                        </div>
                     </form>
                 </div>
             </div>
@@ -170,6 +180,31 @@
                 container.appendChild(hidden);
             });
         }
+
+        // Quantity Adjustment — live ledger link
+        (function() {
+            var ledgerBase = "{% url 'edc_pharmacy:ledger_url' %}";
+            var codeInput = document.getElementById('qty_code_input');
+            var link = document.getElementById('qty_ledger_link');
+            var codeLabel = document.getElementById('qty_ledger_code');
+            if (codeInput && link) {
+                function updateLink() {
+                    var code = codeInput.value.trim();
+                    if (code) {
+                        link.href = ledgerBase + '?q=' + encodeURIComponent(code);
+                        link.style.display = '';
+                        if (codeLabel) codeLabel.textContent = code;
+                    } else {
+                        link.href = '#';
+                        link.style.display = 'none';
+                    }
+                }
+                codeInput.addEventListener('input', updateLink);
+                codeInput.addEventListener('change', updateLink);
+                // Fire once on load in case the field is pre-filled (post-redirect)
+                updateLink();
+            }
+        })();
 
         // Allow Enter key to add a code
         document.getElementById('scan_input').addEventListener('keydown', function(e) {

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_transfer_home.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_transfer_home.html
@@ -1,0 +1,87 @@
+{% extends edc_base_template %}
+{% load static %}
+
+{% block main %}
+    {{ block.super }}
+    <div class="container">
+        <div class="col-sm-1"></div>
+        <div class="col-sm-10">
+
+            <div style="padding:10px;">
+                <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
+                Transfer stock to site
+            </div>
+
+            <div style="margin-bottom:12px;">
+                <a href="{% url "edc_pharmacy_admin:edc_pharmacy_stocktransfer_add" %}"
+                   class="btn btn-primary btn-sm">
+                    <i class="fas fa-plus"></i> New transfer
+                </a>
+                <a href="{% url "edc_pharmacy_admin:edc_pharmacy_stocktransfer_changelist" %}"
+                   class="btn btn-default btn-sm" style="margin-left:6px;">
+                    Admin &rsaquo;
+                </a>
+            </div>
+
+            {% if transfers %}
+            <table class="table table-condensed table-hover">
+                <thead>
+                    <tr>
+                        <th>Transfer #</th>
+                        <th>Date</th>
+                        <th>Route</th>
+                        <th style="text-align:center;">Planned</th>
+                        <th style="text-align:center;">Scanned</th>
+                        <th style="text-align:center;">Remaining</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in transfers %}
+                    {% with t=row.obj %}
+                    <tr>
+                        <td>
+                            <a href="{% url "edc_pharmacy_admin:edc_pharmacy_stocktransfer_change" t.pk %}">
+                                {{ t.transfer_identifier }}
+                            </a>
+                        </td>
+                        <td style="white-space:nowrap;">{{ t.transfer_datetime|date:"d-M-Y" }}</td>
+                        <td style="white-space:nowrap;">
+                            {{ t.from_location.display_name }}
+                            &nbsp;&rsaquo;&rsaquo;&nbsp;
+                            {{ t.to_location.display_name }}
+                        </td>
+                        <td style="text-align:center;">{{ t.item_count }}</td>
+                        <td style="text-align:center;">{{ row.scanned_count }}</td>
+                        <td style="text-align:center;">
+                            {% if row.complete %}
+                                <span class="label label-success">Done</span>
+                            {% else %}
+                                <span class="label label-warning">{{ row.remaining }}</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if not row.complete %}
+                                <a href="{% url "edc_pharmacy:transfer_stock_url" stock_transfer=t.pk %}"
+                                   class="btn btn-primary btn-xs">
+                                    <i class="fas fa-barcode"></i> Scan
+                                </a>
+                            {% endif %}
+                            <a href="{% url "edc_pharmacy:generate_manifest" stock_transfer=t.pk %}"
+                               class="btn btn-default btn-xs" target="_blank" style="margin-left:4px;">
+                                Manifest
+                            </a>
+                        </td>
+                    </tr>
+                    {% endwith %}
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% else %}
+                <p class="text-muted">No stock transfers found.</p>
+            {% endif %}
+
+        </div>
+        <div class="col-sm-1"></div>
+    </div>
+{% endblock main %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/transfer_stock.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/transfer_stock.html
@@ -1,64 +1,145 @@
 {% extends edc_base_template %}
-
 {% load static %}
 
 {% block main %}
     {{ block.super }}
     <div class="container">
-        <div class="col-sm-4"></div>
-        <div class="col-sm-4">
-            <div style="padding:10px">
-                <a href="{% url "edc_pharmacy_admin:index" %}">Edc Pharmacy</a> >
-                <a href="{% url "edc_pharmacy_admin:edc_pharmacy_stocktransfer_changelist" %}">Stock Transfer</a> >
-                <a href="{% url "edc_pharmacy_admin:edc_pharmacy_stocktransfer_changelist" %}?q={{ stock_transfer.transfer_identifier }}">{{ stock_transfer.transfer_identifier }}</a>
+        <div class="col-sm-2"></div>
+        <div class="col-sm-8">
+
+            <div style="padding:10px;">
+                <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
+                <a href="{% url "edc_pharmacy:stock_transfer_home_url" %}">Transfer stock to site</a> &rsaquo;
+                {{ stock_transfer.transfer_identifier }}
             </div>
+
             <div class="panel panel-default">
                 <div class="panel-heading">
-                    {% if from_location and to_location %}Transfer stock from {{ from_location.display_name }} to
-                        {{ to_location.display_name }}{% else %}Transfer stock to site{% endif %}</div>
+                    <strong>Scan items to transfer</strong>
+                    &mdash;
+                    {{ stock_transfer.from_location.display_name }}
+                    &nbsp;&rsaquo;&rsaquo;&nbsp;
+                    {{ stock_transfer.to_location.display_name }}
+                </div>
                 <div class="panel-body">
-                    <form class="form-horizontal" action="{{ url }}" method="post" onSubmit="document.getElementById('submit').disabled=true;">
+
+                    {# ── Progress ─────────────────────────────────── #}
+                    <p class="text-muted small" style="margin-bottom:10px;">
+                        Transfer <strong>{{ stock_transfer.transfer_identifier }}</strong>:
+                        <strong>{{ transferred_count }}</strong> of
+                        <strong>{{ stock_transfer.item_count }}</strong> scanned
+                        {% if transferred_count < stock_transfer.item_count %}
+                            &mdash; <strong>{{ remaining_count }}</strong> remaining
+                        {% else %}
+                            &mdash; <span class="label label-success">Complete</span>
+                        {% endif %}
+                    </p>
+
+                    {# ── Scan input ────────────────────────────────── #}
+                    <div class="input-group" style="max-width:360px; margin-bottom:10px;">
+                        <input type="text" id="scan-input"
+                               class="form-control"
+                               placeholder="Scan stock code"
+                               autocomplete="off" autofocus
+                               pattern="[A-Z0-9]+"
+                               onkeydown="if(event.key==='Enter'){event.preventDefault();addCode();}">
+                        <span class="input-group-btn">
+                            <button type="button" class="btn btn-default" onclick="addCode()">Add</button>
+                        </span>
+                    </div>
+
+                    {# ── Pending codes list ────────────────────────── #}
+                    <div id="code-list-container" style="margin-bottom:12px; display:none;">
+                        <p class="text-muted small">
+                            <span id="code-counter" class="badge">0</span>
+                            code(s) pending — will be transferred on submit
+                        </p>
+                        <ul id="code-list" class="list-unstyled" style="column-count:3; margin-bottom:6px;"></ul>
+                    </div>
+
+                    {# ── Submit form ───────────────────────────────── #}
+                    <form id="transfer-form" method="post" action="">
                         {% csrf_token %}
-                        <div class="form-group">
-                            {% if stock_transfer %}
-                                {% for i in item_count %}
-                                    <label class="control-label col-sm-3" for="codes">{{ forloop.counter }}.</label>
-                                    <div class="col-sm-9">
-                                        <input type="text" class="form-control" id="codes" name="codes" placeholder="stock # {{ i }} " value="" pattern="[A-Z0-9]{6}" required autofocus>
-                                    </div>
-                                {% endfor %}
-                                <input type="hidden" class="form-control" id="stock_transfer" name="stock_transfer" value="{{ stock_transfer.id }}">
-
-                            {% else %}
-
-                                <div class="col-sm-12">
-                                    <label class="control-label" for="from_location">From</label>
-                                    <select class="form-control" id="from_location" name="from_location" required autofocus>
-                                        <option value="" selected> -----</option>
-                                        {% for from_location in from_locations %}
-                                            <option value="{{ from_location.id }}">{{ from_location.display_name }}</option>
-                                        {% endfor %}
-                                    </select>
-                                    <label class="control-label" for="to_location">To</label>
-                                    <select class="form-control" id="to_location" name="to_location" required>
-                                        <option value="" selected> -----</option>
-                                        {% for to_location in to_locations %}
-                                            <option value="{{ to_location.id }}">{{ to_location.site.id }}. {{ to_location.display_name }}</option>
-                                        {% endfor %}
-                                    </select>
-                                    <label class="control-label" for="stock_count">Number of stock items</label>
-                                    <input type="text" class="form-control" id="stock_count" name="stock_count" placeholder="" value="" pattern="[0-9]{1,4}" required>
-                                </div>
-                            {% endif %}
-                            <div class="col-sm-12">
-                                <button type="submit" class="btn btn-default" name="submit" id="submit">Submit</button>
-                            </div>
-                        </div>
+                        <div id="hidden-codes"></div>
+                        <button type="submit" id="submit-btn" class="btn btn-primary" disabled>
+                            Transfer <span id="submit-counter">0</span> item(s)
+                        </button>
+                        <a href="{% url "edc_pharmacy:stock_transfer_home_url" %}"
+                           class="btn btn-default" style="margin-left:8px;">
+                            Done
+                        </a>
                     </form>
-                    <button class="btn btn-default" name="done" id="done" onclick="window.location.href='{{ source_changelist_url }}'">Done</button>
+
                 </div>
             </div>
+
+            {# ── Django messages ───────────────────────────────────── #}
+            {% if messages %}
+            <div style="margin-top:10px;">
+                {% for message in messages %}
+                <div class="alert alert-{{ message.tags|default:"info" }}">{{ message }}</div>
+                {% endfor %}
+            </div>
+            {% endif %}
+
         </div>
-        <div class="col-sm-4"></div>
+        <div class="col-sm-2"></div>
     </div>
+
+    <script>
+    (function () {
+        var codes = [];
+
+        window.addCode = function () {
+            var inp = document.getElementById('scan-input');
+            var raw = inp.value.trim().toUpperCase();
+            inp.value = '';
+            inp.focus();
+            if (!raw) return;
+            if (codes.indexOf(raw) !== -1) {
+                alert('Code ' + raw + ' already in list.');
+                return;
+            }
+            codes.push(raw);
+            render();
+        };
+
+        window.removeCode = function (code) {
+            codes = codes.filter(function (c) { return c !== code; });
+            render();
+        };
+
+        function render() {
+            var list = document.getElementById('code-list');
+            var hidden = document.getElementById('hidden-codes');
+            var counter = document.getElementById('code-counter');
+            var submitCounter = document.getElementById('submit-counter');
+            var submitBtn = document.getElementById('submit-btn');
+            var container = document.getElementById('code-list-container');
+
+            list.innerHTML = '';
+            hidden.innerHTML = '';
+
+            codes.forEach(function (c) {
+                var li = document.createElement('li');
+                li.innerHTML = '<code>' + c + '</code> '
+                    + '<a href="#" onclick="removeCode(\'' + c + '\'); return false;"'
+                    + ' style="color:#c00; font-size:0.85em;">&times;</a>';
+                list.appendChild(li);
+
+                var inp = document.createElement('input');
+                inp.type = 'hidden';
+                inp.name = 'codes';
+                inp.value = c;
+                hidden.appendChild(inp);
+            });
+
+            var n = codes.length;
+            counter.textContent = n;
+            submitCounter.textContent = n;
+            submitBtn.disabled = (n === 0);
+            container.style.display = (n > 0) ? 'block' : 'none';
+        }
+    })();
+    </script>
 {% endblock main %}

--- a/src/edc_pharmacy/transaction_log/compute_delta.py
+++ b/src/edc_pharmacy/transaction_log/compute_delta.py
@@ -271,6 +271,15 @@ def _compute_return_disposition_destroyed(current: CurrentState, **_) -> StateDe
 
 
 def _compute_adjusted(current: CurrentState, *, unit_qty_delta: Decimal, **_) -> StateDelta:
+    if unit_qty_delta < 0:
+        available = current.unit_qty_in - current.unit_qty_out
+        if abs(unit_qty_delta) > available:
+            return StateDelta(
+                preconditions_failed=(
+                    f"adjustment of {unit_qty_delta} exceeds available units "
+                    f"({available} remaining)",
+                )
+            )
     return StateDelta(unit_qty_delta=unit_qty_delta)
 
 

--- a/src/edc_pharmacy/urls.py
+++ b/src/edc_pharmacy/urls.py
@@ -18,6 +18,7 @@ from .views import (
     ReturnReceiveView,
     ReturnRequestView,
     StockAdjustmentView,
+    StockTransferHomeView,
     TransferStockView,
     get_stock_transfers_view,
     print_return_manifest_view,
@@ -87,6 +88,11 @@ urlpatterns = [
         "allocate/<uuid:stock_request>/",
         AllocateToSubjectView.as_view(),
         name="allocate_url",
+    ),
+    path(
+        "stock-transfer/",
+        StockTransferHomeView.as_view(),
+        name="stock_transfer_home_url",
     ),
     path(
         "transfer-stock/<uuid:stock_transfer>/",

--- a/src/edc_pharmacy/urls.py
+++ b/src/edc_pharmacy/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from .admin_site import edc_pharmacy_admin
 from .views import (
     AddToStorageBinView,
+    BulkStockReportView,
     AllocateToSubjectView,
     CeleryTaskStatusView,
     ConfirmaAtLocationView,
@@ -205,6 +206,11 @@ urlpatterns = [
         "return-disposition/",
         ReturnDispositionView.as_view(),
         name="return_disposition_url",
+    ),
+    path(
+        "bulk-stock-report/",
+        BulkStockReportView.as_view(),
+        name="bulk_stock_report_url",
     ),
     # ───────────────────────────────────────────────────────────────────────
     path("admin/", edc_pharmacy_admin.urls),

--- a/src/edc_pharmacy/utils/transfer_stock_to_location.py
+++ b/src/edc_pharmacy/utils/transfer_stock_to_location.py
@@ -45,7 +45,7 @@ def transfer_stock_to_location(
         opts = dict(
             code=stock_code,
             confirmation__isnull=False,
-            allocation__registered_subject__isnull=False,
+            current_allocation__registered_subject__isnull=False,
             location=stock_transfer.from_location,
         )
         try:
@@ -55,11 +55,11 @@ def transfer_stock_to_location(
         else:
             if stock_transfer.to_location.name == CENTRAL_LOCATION:
                 opts.update(
-                    allocation__registered_subject__site=stock_transfer.from_location.site,
+                    current_allocation__registered_subject__site=stock_transfer.from_location.site,
                 )
             else:
                 opts.update(
-                    allocation__registered_subject__site=stock_transfer.to_location.site
+                    current_allocation__registered_subject__site=stock_transfer.to_location.site
                 )
             try:
                 stock_obj = stock_model_cls.objects.get(**opts)

--- a/src/edc_pharmacy/views/__init__.py
+++ b/src/edc_pharmacy/views/__init__.py
@@ -1,4 +1,5 @@
 from .add_to_storage_bin_view import AddToStorageBinView
+from .bulk_stock_report_view import BulkStockReportView
 from .allocate_to_subject_view import AllocateToSubjectView
 from .celery_task_status_view import CeleryTaskStatusView
 from .confirm_at_location_view import ConfirmaAtLocationView

--- a/src/edc_pharmacy/views/__init__.py
+++ b/src/edc_pharmacy/views/__init__.py
@@ -18,4 +18,5 @@ from .stock_adjustment_view import StockAdjustmentView
 from .return_disposition_view import ReturnDispositionView
 from .return_receive_view import ReturnReceiveView
 from .return_request_view import ReturnRequestView
+from .stock_transfer_home_view import StockTransferHomeView
 from .transfer_stock_view import TransferStockView

--- a/src/edc_pharmacy/views/bulk_stock_report_view.py
+++ b/src/edc_pharmacy/views/bulk_stock_report_view.py
@@ -22,10 +22,11 @@ from edc_navbar import NavbarViewMixin
 from edc_protocol.view_mixins import EdcProtocolViewMixin
 
 from ..models import Stock
+from .auths_view_mixin import AuthsViewMixin
 
 
 @method_decorator(login_required, name="dispatch")
-class BulkStockReportView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateView):
+class BulkStockReportView(AuthsViewMixin, EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateView):
     """Unit-qty in/out/balance report for bulk (non-dispensing) containers."""
 
     template_name = "edc_pharmacy/stock/bulk_stock_report.html"

--- a/src/edc_pharmacy/views/bulk_stock_report_view.py
+++ b/src/edc_pharmacy/views/bulk_stock_report_view.py
@@ -1,0 +1,78 @@
+"""Bulk container unit-qty report.
+
+Shows all root stock items (from_stock=None) — the large containers that
+are received and repacked, not dispensed directly to patients.  Provides
+unit_qty_in / unit_qty_out / balance per container so the pharmacist can
+audit how many tablet-units have been consumed and how many remain.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.db.models import Count, F, Sum
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView
+
+from edc_dashboard.view_mixins import EdcViewMixin
+from edc_navbar import NavbarViewMixin
+from edc_protocol.view_mixins import EdcProtocolViewMixin
+
+from ..models import Stock
+
+
+@method_decorator(login_required, name="dispatch")
+class BulkStockReportView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateView):
+    """Unit-qty in/out/balance report for bulk (non-dispensing) containers."""
+
+    template_name = "edc_pharmacy/stock/bulk_stock_report.html"
+    navbar_name = settings.APP_NAME
+    navbar_selected_item = "pharmacy"
+
+    def get_context_data(self, **kwargs):
+        qs = (
+            Stock.objects.filter(
+                from_stock__isnull=True,
+                container__may_request_as=False,
+                container__may_dispense_as=False,
+            )
+            .select_related(
+                "lot__assignment",
+                "product__formulation",
+                "container",
+                "location",
+            )
+            .annotate(repack_count=Count("repack_requests", distinct=True))
+            .order_by("lot__lot_no", "code")
+        )
+
+        ledger_base = reverse("edc_pharmacy:ledger_url")
+
+        rows = []
+        total_in = Decimal("0")
+        total_out = Decimal("0")
+        for stock in qs:
+            unit_in = stock.unit_qty_in or Decimal("0")
+            unit_out = stock.unit_qty_out or Decimal("0")
+            balance = unit_in - unit_out
+            total_in += unit_in
+            total_out += unit_out
+            rows.append({
+                "stock": stock,
+                "unit_qty_in": unit_in,
+                "unit_qty_out": unit_out,
+                "balance": balance,
+                "repack_count": stock.repack_count,
+                "ledger_url": f"{ledger_base}?q={stock.code}",
+            })
+
+        totals = {
+            "unit_qty_in": total_in,
+            "unit_qty_out": total_out,
+            "balance": total_in - total_out,
+        }
+
+        return super().get_context_data(rows=rows, totals=totals, **kwargs)

--- a/src/edc_pharmacy/views/ledger_view.py
+++ b/src/edc_pharmacy/views/ledger_view.py
@@ -48,13 +48,23 @@ class LedgerView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateVi
                 "actor",
                 "from_location",
                 "to_location",
-                "from_allocation__registered_subject",
-                "to_allocation__registered_subject",
+                "from_allocation",
+                "to_allocation",
             ).order_by("-transaction_datetime").distinct()
 
             total = qs.count()
             truncated = total > MAX_ROWS
-            transactions = list(qs[:MAX_ROWS])
+            rows = list(qs[:MAX_ROWS])
+
+            # Attach subject_identifier to each transaction for display.
+            # Priority: to_allocation → from_allocation → stock.subject_identifier.
+            for txn in rows:
+                alloc = txn.to_allocation or txn.from_allocation
+                if alloc and alloc.subject_identifier:
+                    txn._subject_identifier = alloc.subject_identifier
+                else:
+                    txn._subject_identifier = txn.stock.subject_identifier or ""
+            transactions = rows
 
         # Build the admin changelist URL, optionally pre-filtered.
         admin_url = reverse("edc_pharmacy_admin:edc_pharmacy_stocktransaction_changelist")

--- a/src/edc_pharmacy/views/ledger_view.py
+++ b/src/edc_pharmacy/views/ledger_view.py
@@ -54,17 +54,17 @@ class LedgerView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateVi
 
             total = qs.count()
             truncated = total > MAX_ROWS
-            rows = list(qs[:MAX_ROWS])
 
-            # Attach subject_identifier to each transaction for display.
+            # Build (txn, subject_identifier) pairs.
             # Priority: to_allocation → from_allocation → stock.subject_identifier.
-            for txn in rows:
+            transactions = []
+            for txn in qs[:MAX_ROWS]:
                 alloc = txn.to_allocation or txn.from_allocation
                 if alloc and alloc.subject_identifier:
-                    txn._subject_identifier = alloc.subject_identifier
+                    subject_identifier = alloc.subject_identifier
                 else:
-                    txn._subject_identifier = txn.stock.subject_identifier or ""
-            transactions = rows
+                    subject_identifier = txn.stock.subject_identifier or ""
+                transactions.append({"txn": txn, "subject_identifier": subject_identifier})
 
         # Build the admin changelist URL, optionally pre-filtered.
         admin_url = reverse("edc_pharmacy_admin:edc_pharmacy_stocktransaction_changelist")

--- a/src/edc_pharmacy/views/ledger_view.py
+++ b/src/edc_pharmacy/views/ledger_view.py
@@ -55,15 +55,20 @@ class LedgerView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateVi
             total = qs.count()
             truncated = total > MAX_ROWS
 
-            # Build (txn, subject_identifier) pairs.
+            # Build row dicts and accumulate totals.
             # Priority: to_allocation → from_allocation → stock.subject_identifier.
+            from decimal import Decimal as _D
             transactions = []
+            qty_total = _D("0")
+            unit_qty_total = _D("0")
             for txn in qs[:MAX_ROWS]:
                 alloc = txn.to_allocation or txn.from_allocation
                 if alloc and alloc.subject_identifier:
                     subject_identifier = alloc.subject_identifier
                 else:
                     subject_identifier = txn.stock.subject_identifier or ""
+                qty_total += txn.qty_delta or _D("0")
+                unit_qty_total += txn.unit_qty_delta or _D("0")
                 transactions.append({"txn": txn, "subject_identifier": subject_identifier})
 
         # Build the admin changelist URL, optionally pre-filtered.
@@ -77,5 +82,7 @@ class LedgerView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateVi
             truncated=truncated,
             max_rows=MAX_ROWS,
             admin_url=admin_url,
+            qty_total=qty_total,
+            unit_qty_total=unit_qty_total,
         )
         return super().get_context_data(**kwargs)

--- a/src/edc_pharmacy/views/ledger_view.py
+++ b/src/edc_pharmacy/views/ledger_view.py
@@ -8,6 +8,8 @@ deeper filtering/export.
 
 from __future__ import annotations
 
+from decimal import Decimal
+
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.db.models import Q
@@ -36,6 +38,8 @@ class LedgerView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateVi
         q = self.request.GET.get("q", "").strip()
         transactions = []
         truncated = False
+        qty_total = Decimal("0")
+        unit_qty_total = Decimal("0")
 
         if q:
             qs = StockTransaction.objects.filter(
@@ -57,18 +61,14 @@ class LedgerView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateVi
 
             # Build row dicts and accumulate totals.
             # Priority: to_allocation → from_allocation → stock.subject_identifier.
-            from decimal import Decimal as _D
-            transactions = []
-            qty_total = _D("0")
-            unit_qty_total = _D("0")
             for txn in qs[:MAX_ROWS]:
                 alloc = txn.to_allocation or txn.from_allocation
                 if alloc and alloc.subject_identifier:
                     subject_identifier = alloc.subject_identifier
                 else:
                     subject_identifier = txn.stock.subject_identifier or ""
-                qty_total += txn.qty_delta or _D("0")
-                unit_qty_total += txn.unit_qty_delta or _D("0")
+                qty_total += txn.qty_delta or Decimal("0")
+                unit_qty_total += txn.unit_qty_delta or Decimal("0")
                 transactions.append({"txn": txn, "subject_identifier": subject_identifier})
 
         # Build the admin changelist URL, optionally pre-filtered.

--- a/src/edc_pharmacy/views/stock_adjustment_view.py
+++ b/src/edc_pharmacy/views/stock_adjustment_view.py
@@ -44,8 +44,13 @@ class StockAdjustmentView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, T
     navbar_selected_item = "pharmacy"
 
     def get_context_data(self, **kwargs):
+        last_code = self.request.GET.get("last_code", "").strip().upper()
+        ledger_base = reverse("edc_pharmacy:ledger_url")
+        last_ledger_url = f"{ledger_base}?q={last_code}" if last_code else ""
         kwargs.update(
             status_adjustment_types=STATUS_ADJUSTMENT_TYPES,
+            last_code=last_code,
+            last_ledger_url=last_ledger_url,
         )
         return super().get_context_data(**kwargs)
 
@@ -152,4 +157,6 @@ class StockAdjustmentView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, T
         except InvalidTransitionError as e:
             messages.error(request, str(e))
 
-        return HttpResponseRedirect(reverse("edc_pharmacy:stock_adjustments_url"))
+        return HttpResponseRedirect(
+            reverse("edc_pharmacy:stock_adjustments_url") + f"?last_code={code}#qty-adjustment"
+        )

--- a/src/edc_pharmacy/views/stock_transfer_home_view.py
+++ b/src/edc_pharmacy/views/stock_transfer_home_view.py
@@ -1,0 +1,47 @@
+"""Stock-transfer landing page.
+
+Lists all StockTransfers (newest first) with scanned-vs-planned progress so
+the central pharmacist can see at a glance which transfers still need items
+scanned and jump straight into the scan workflow.
+"""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.db.models import Count
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView
+
+from edc_dashboard.view_mixins import EdcViewMixin
+from edc_navbar import NavbarViewMixin
+from edc_protocol.view_mixins import EdcProtocolViewMixin
+
+from ..models import StockTransfer
+
+MAX_TRANSFERS = 100
+
+
+@method_decorator(login_required, name="dispatch")
+class StockTransferHomeView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateView):
+    """Landing page for the transfer-stock workflow."""
+
+    template_name = "edc_pharmacy/stock/stock_transfer_home.html"
+    navbar_name = settings.APP_NAME
+    navbar_selected_item = "pharmacy"
+
+    def get_context_data(self, **kwargs):
+        qs = (
+            StockTransfer.objects.annotate(scanned_count=Count("stocktransferitem"))
+            .order_by("-transfer_identifier")[:MAX_TRANSFERS]
+        )
+        transfers = [
+            {
+                "obj": t,
+                "scanned_count": t.scanned_count,
+                "remaining": max(0, t.item_count - t.scanned_count),
+                "complete": t.scanned_count >= t.item_count,
+            }
+            for t in qs
+        ]
+        return super().get_context_data(transfers=transfers, **kwargs)

--- a/src/edc_pharmacy/views/transfer_stock_view.py
+++ b/src/edc_pharmacy/views/transfer_stock_view.py
@@ -1,4 +1,3 @@
-from django.apps import apps as django_apps
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -13,20 +12,19 @@ from edc_protocol.view_mixins import EdcProtocolViewMixin
 
 from ..constants import CENTRAL_LOCATION
 from ..exceptions import StockTransferError
-from ..models import Location, StockTransfer, StockTransferItem
+from ..models import StockTransfer, StockTransferItem
 from ..utils import transfer_stock_to_location
 
 
 @method_decorator(login_required, name="dispatch")
 class TransferStockView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateView):
-    """A view for transferring stock from central to a site.
+    """Scan page for transferring stock items on a specific StockTransfer.
 
-    Creates a StockTransferItem instance per stock instance.
-
-    See also: StockTransferConfirmationItem
+    Creates a StockTransferItem + TXN_TRANSFER_DISPATCHED transaction per
+    scanned code.  The user scans codes one at a time via the JS accumulation
+    UI and submits the batch.
     """
 
-    model_pks: list[str] | None = None
     template_name: str = "edc_pharmacy/stock/transfer_stock.html"
     navbar_name = settings.APP_NAME
     navbar_selected_item = "pharmacy"
@@ -36,25 +34,17 @@ class TransferStockView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Tem
         transferred_count = StockTransferItem.objects.filter(
             stock_transfer=stock_transfer
         ).count()
-        item_count = stock_transfer.item_count - transferred_count
-        item_count = min(item_count, 12)
+        remaining_count = max(0, stock_transfer.item_count - transferred_count)
         kwargs.update(
             stock_transfer=stock_transfer,
-            source_model_name=self.model_cls._meta.verbose_name_plural,
-            source_changelist_url=self.source_changelist_url,
-            from_locations=Location.objects.filter(site__isnull=True),
-            to_locations=Location.objects.filter(site__isnull=False),
-            item_count=list(range(1, item_count + 1)),
+            transferred_count=transferred_count,
+            remaining_count=remaining_count,
         )
         return super().get_context_data(**kwargs)
 
     @property
-    def source_changelist_url(self):
-        return reverse("edc_pharmacy_admin:edc_pharmacy_stocktransfer_changelist")
-
-    @property
-    def model_cls(self):
-        return django_apps.get_model("edc_pharmacy.stocktransfer")
+    def _home_url(self):
+        return reverse("edc_pharmacy:stock_transfer_home_url")
 
     def post(self, request, *args, **kwargs):  # noqa: ARG002
         stock_transfer = StockTransfer.objects.get(pk=self.kwargs.get("stock_transfer"))
@@ -66,13 +56,14 @@ class TransferStockView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Tem
                     transfer_stock_to_location(stock_transfer, stock_codes, request=request)
                 )
             except StockTransferError as e:
-                messages.add_message(request, messages.ERROR, f"An error occured. {e}")
+                messages.add_message(request, messages.ERROR, f"An error occurred. {e}")
 
-            if len(transferred) > 0:
+            if transferred:
                 messages.add_message(
                     request,
                     messages.SUCCESS,
-                    f"Successfully transferred {len(transferred)} stock items. ",
+                    f"Successfully transferred {len(transferred)} stock item"
+                    f"{'s' if len(transferred) != 1 else ''}.",
                 )
             if skipped_codes:
                 location = (
@@ -86,10 +77,8 @@ class TransferStockView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Tem
                     (
                         f"Skipped {len(skipped_codes)} "
                         f"stock item{'s' if len(skipped_codes) != 1 else ''}. "
-                        f"Not for {location}. "
-                        f"See {StockTransfer._meta.verbose_name} "
-                        f"{stock_transfer.transfer_identifier}. "
-                        f"Got {', '.join(skipped_codes)}"
+                        f"Not allocated for {location}. "
+                        f"Got: {', '.join(skipped_codes)}"
                     ),
                 )
             if dispensed_codes:
@@ -97,29 +86,27 @@ class TransferStockView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Tem
                     request,
                     messages.ERROR,
                     f"Skipped {len(dispensed_codes)} stock item"
-                    f"{'s' if len(dispensed_codes) != 1 else ''}. "
-                    f"Already dispensed. Got {', '.join(dispensed_codes)}",
+                    f"{'s' if len(dispensed_codes) != 1 else ''} — already dispensed. "
+                    f"Got: {', '.join(dispensed_codes)}",
                 )
-
             if invalid_codes:
                 messages.add_message(
                     request,
                     messages.ERROR,
-                    f"Skipped {len(invalid_codes)} stock item"
+                    f"Skipped {len(invalid_codes)} invalid code"
                     f"{'s' if len(invalid_codes) != 1 else ''}. "
-                    f" are invalid. Got {', '.join(invalid_codes)}",
+                    f"Got: {', '.join(invalid_codes)}",
                 )
 
+        # Redirect back to scan page (more items remain) or home (complete).
         transferred_count = StockTransferItem.objects.filter(
             stock_transfer=stock_transfer
         ).count()
         if stock_transfer.item_count > transferred_count:
-            url = reverse(
-                "edc_pharmacy:transfer_stock_url",
-                kwargs={
-                    "stock_transfer": stock_transfer.id,
-                },
+            return HttpResponseRedirect(
+                reverse(
+                    "edc_pharmacy:transfer_stock_url",
+                    kwargs={"stock_transfer": stock_transfer.id},
+                )
             )
-            return HttpResponseRedirect(url)
-        url = f"{self.source_changelist_url}"
-        return HttpResponseRedirect(url)
+        return HttpResponseRedirect(self._home_url)


### PR DESCRIPTION
- New /edc_pharmacy/stock-transfer/ page lists all transfers with
  planned/scanned/remaining progress; [Scan] and [Manifest] buttons per row
- Refactor scan page to JS accumulation (one input + badge counter +
  removable list) replacing the old N static input boxes
- Fix stale allocation__* → current_allocation__* lookups in
  transfer_stock_to_location utility (would have raised FieldError at runtime)
- Guard manifest PDF against None current_allocation (pre-existing crash)
- central_home.html "Transfer stock to site" now links to new landing page

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
