### PR TITLE
feat: add container balance and site stock reports

### DIFF
--- a/src/edc_pharmacy/templates/edc_pharmacy/central_home.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/central_home.html
@@ -24,6 +24,8 @@
             <a id="home_list_group_stock" href="{% url 'edc_pharmacy_admin:edc_pharmacy_stock_changelist' %}" class="list-group-item">Stock</a>
             <a id="home_list_group_stock_transactions" href="{% url 'edc_pharmacy:ledger_url' %}" class="list-group-item">Stock transaction ledger</a>
             <a id="home_list_group_bulk_stock_report" href="{% url 'edc_pharmacy:bulk_stock_report_url' %}" class="list-group-item">Bulk container report</a>
+            <a id="home_list_group_container_balance_report" href="{% url 'edc_pharmacy:container_balance_report_url' %}" class="list-group-item">Container balance report</a>
+            <a id="home_list_group_site_stock_report" href="{% url 'edc_pharmacy:site_stock_report_url' %}" class="list-group-item">Site stock report</a>
             <a id="home_list_group_allocation" href="{% url 'edc_pharmacy_admin:edc_pharmacy_allocation_changelist' %}" class="list-group-item">Allocations</a>
             <a id="home_list_group_stockavailability" href="{% url 'edc_pharmacy_admin:edc_pharmacy_stockavailability_changelist' %}?has_codes=No" class="list-group-item">Stock availability</a>
             <a id="home_list_group_allocation" href="{% url 'edc_pylabels_admin:index' %}" class="list-group-item">Label Configurations</a>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/container_balance_report.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/container_balance_report.html
@@ -1,0 +1,114 @@
+{% extends edc_base_template %}
+{% load static %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.11.5/css/jquery.dataTables.min.css">
+{% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <script src="https://cdn.datatables.net/1.11.5/js/jquery.dataTables.min.js"></script>
+{% endblock %}
+
+{% block document_ready %}
+    <script>
+        $(document).ready(function() {
+            var cntCol = {% if show_assignment %}4{% else %}3{% endif %};
+            var inCol  = {% if show_assignment %}5{% else %}4{% endif %};
+            var outCol = {% if show_assignment %}6{% else %}5{% endif %};
+            var balCol = {% if show_assignment %}7{% else %}6{% endif %};
+
+            function sumCol(api, idx) {
+                return api.column(idx, {search: 'applied'}).data().reduce(function(acc, val) {
+                    var n = parseFloat(String(val).replace(/<[^>]*>/g, '').trim());
+                    return acc + (isNaN(n) ? 0 : n);
+                }, 0);
+            }
+
+            $('#container_balance_table').DataTable({
+                order: [[0, 'asc'], [1, 'asc'], [2, 'asc']],
+                pageLength: 50,
+                footerCallback: function() {
+                    var api = this.api();
+                    $(api.column(cntCol).footer()).text(sumCol(api, cntCol).toLocaleString());
+                    var totalIn  = sumCol(api, inCol);
+                    var totalOut = sumCol(api, outCol);
+                    var balance  = totalIn - totalOut;
+                    $(api.column(inCol).footer()).text(totalIn.toLocaleString());
+                    $(api.column(outCol).footer()).text(totalOut.toLocaleString());
+                    $(api.column(balCol).footer()).text(balance.toLocaleString());
+                },
+            });
+        });
+    </script>
+{% endblock %}
+
+{% block main %}
+    {{ block.super }}
+    <div class="container">
+        <div class="col-sm-12">
+
+            <div style="padding:10px;">
+                <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
+                Container balance report
+            </div>
+
+            {% if groups %}
+            <table id="container_balance_table" class="table table-condensed table-hover">
+                <thead>
+                    <tr>
+                        <th>Container Type</th>
+                        <th>Container</th>
+                        <th>Location</th>
+                        {% if show_assignment %}<th>Assignment</th>{% endif %}
+                        <th style="text-align:right;">Stock items</th>
+                        <th style="text-align:right;">Unit Qty In</th>
+                        <th style="text-align:right;">Unit Qty Out</th>
+                        <th style="text-align:right;">Balance</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for group in groups %}
+                        {% for row in group.rows %}
+                        <tr {% if row.balance < 0 %}style="color:#c00;"{% endif %}>
+                            <td>{{ group.container_type }}</td>
+                            <td>{{ row.container }}</td>
+                            <td>{{ row.location }}</td>
+                            {% if show_assignment %}<td>{{ row.assignment }}</td>{% endif %}
+                            <td style="text-align:right;">{{ row.stock_count }}</td>
+                            <td style="text-align:right;">{{ row.unit_qty_in }}</td>
+                            <td style="text-align:right;">{{ row.unit_qty_out }}</td>
+                            <td style="text-align:right;">
+                                {% if row.balance == 0 %}
+                                    <span class="label label-success">0</span>
+                                {% elif row.balance < 0 %}
+                                    <span class="label label-danger">{{ row.balance }}</span>
+                                {% else %}
+                                    {{ row.balance }}
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    {% endfor %}
+                </tbody>
+                <tfoot>
+                    <tr style="font-weight:bold; border-top:2px solid #ddd;">
+                        <td></td>
+                        <td></td>
+                        <td style="text-align:right;">Total</td>
+                        {% if show_assignment %}<td></td>{% endif %}
+                        <td style="text-align:right;"></td>
+                        <td style="text-align:right;"></td>
+                        <td style="text-align:right;"></td>
+                        <td style="text-align:right;"></td>
+                    </tr>
+                </tfoot>
+            </table>
+            {% else %}
+                <p class="text-muted">No stock found.</p>
+            {% endif %}
+
+        </div>
+    </div>
+{% endblock main %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/site_stock_report.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/site_stock_report.html
@@ -1,0 +1,114 @@
+{% extends edc_base_template %}
+{% load static %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.11.5/css/jquery.dataTables.min.css">
+{% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <script src="https://cdn.datatables.net/1.11.5/js/jquery.dataTables.min.js"></script>
+{% endblock %}
+
+{% block document_ready %}
+    <script>
+        $(document).ready(function() {
+            var cntCol = {% if show_assignment %}4{% else %}3{% endif %};
+            var inCol  = {% if show_assignment %}5{% else %}4{% endif %};
+            var outCol = {% if show_assignment %}6{% else %}5{% endif %};
+            var balCol = {% if show_assignment %}7{% else %}6{% endif %};
+
+            function sumCol(api, idx) {
+                return api.column(idx, {search: 'applied'}).data().reduce(function(acc, val) {
+                    var n = parseFloat(String(val).replace(/<[^>]*>/g, '').trim());
+                    return acc + (isNaN(n) ? 0 : n);
+                }, 0);
+            }
+
+            $('#site_stock_table').DataTable({
+                order: [[0, 'asc'], [1, 'asc'], [2, 'asc']],
+                pageLength: 50,
+                footerCallback: function() {
+                    var api = this.api();
+                    $(api.column(cntCol).footer()).text(sumCol(api, cntCol).toLocaleString());
+                    var totalIn  = sumCol(api, inCol);
+                    var totalOut = sumCol(api, outCol);
+                    var balance  = totalIn - totalOut;
+                    $(api.column(inCol).footer()).text(totalIn.toLocaleString());
+                    $(api.column(outCol).footer()).text(totalOut.toLocaleString());
+                    $(api.column(balCol).footer()).text(balance.toLocaleString());
+                },
+            });
+        });
+    </script>
+{% endblock %}
+
+{% block main %}
+    {{ block.super }}
+    <div class="container">
+        <div class="col-sm-12">
+
+            <div style="padding:10px;">
+                <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
+                Site stock report
+            </div>
+
+            {% if groups %}
+            <table id="site_stock_table" class="table table-condensed table-hover">
+                <thead>
+                    <tr>
+                        <th>Location</th>
+                        <th>Container Type</th>
+                        <th>Container</th>
+                        {% if show_assignment %}<th>Assignment</th>{% endif %}
+                        <th style="text-align:right;">Stock items</th>
+                        <th style="text-align:right;">Unit Qty In</th>
+                        <th style="text-align:right;">Unit Qty Out</th>
+                        <th style="text-align:right;">Balance</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for group in groups %}
+                        {% for row in group.rows %}
+                        <tr {% if row.balance < 0 %}style="color:#c00;"{% endif %}>
+                            <td style="white-space:nowrap;">{{ group.location }}</td>
+                            <td>{{ row.container_type }}</td>
+                            <td>{{ row.container }}</td>
+                            {% if show_assignment %}<td>{{ row.assignment }}</td>{% endif %}
+                            <td style="text-align:right;">{{ row.stock_count }}</td>
+                            <td style="text-align:right;">{{ row.unit_qty_in }}</td>
+                            <td style="text-align:right;">{{ row.unit_qty_out }}</td>
+                            <td style="text-align:right;">
+                                {% if row.balance == 0 %}
+                                    <span class="label label-success">0</span>
+                                {% elif row.balance < 0 %}
+                                    <span class="label label-danger">{{ row.balance }}</span>
+                                {% else %}
+                                    {{ row.balance }}
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    {% endfor %}
+                </tbody>
+                <tfoot>
+                    <tr style="font-weight:bold; border-top:2px solid #ddd;">
+                        <td></td>
+                        <td></td>
+                        <td style="text-align:right;">Total</td>
+                        {% if show_assignment %}<td></td>{% endif %}
+                        <td style="text-align:right;"></td>
+                        <td style="text-align:right;"></td>
+                        <td style="text-align:right;"></td>
+                        <td style="text-align:right;"></td>
+                    </tr>
+                </tfoot>
+            </table>
+            {% else %}
+                <p class="text-muted">No stock currently held at site locations.</p>
+            {% endif %}
+
+        </div>
+    </div>
+{% endblock main %}

--- a/src/edc_pharmacy/urls.py
+++ b/src/edc_pharmacy/urls.py
@@ -4,6 +4,8 @@ from .admin_site import edc_pharmacy_admin
 from .views import (
     AddToStorageBinView,
     BulkStockReportView,
+    ContainerBalanceReportView,
+    SiteStockReportView,
     AllocateToSubjectView,
     CeleryTaskStatusView,
     ConfirmaAtLocationView,
@@ -211,6 +213,16 @@ urlpatterns = [
         "bulk-stock-report/",
         BulkStockReportView.as_view(),
         name="bulk_stock_report_url",
+    ),
+    path(
+        "container-balance-report/",
+        ContainerBalanceReportView.as_view(),
+        name="container_balance_report_url",
+    ),
+    path(
+        "site-stock-report/",
+        SiteStockReportView.as_view(),
+        name="site_stock_report_url",
     ),
     # ───────────────────────────────────────────────────────────────────────
     path("admin/", edc_pharmacy_admin.urls),

--- a/src/edc_pharmacy/views/__init__.py
+++ b/src/edc_pharmacy/views/__init__.py
@@ -1,5 +1,7 @@
 from .add_to_storage_bin_view import AddToStorageBinView
 from .bulk_stock_report_view import BulkStockReportView
+from .container_balance_report_view import ContainerBalanceReportView
+from .site_stock_report_view import SiteStockReportView
 from .allocate_to_subject_view import AllocateToSubjectView
 from .celery_task_status_view import CeleryTaskStatusView
 from .confirm_at_location_view import ConfirmaAtLocationView

--- a/src/edc_pharmacy/views/container_balance_report_view.py
+++ b/src/edc_pharmacy/views/container_balance_report_view.py
@@ -1,0 +1,147 @@
+"""Container balance report.
+
+Summarises unit_qty_in / unit_qty_out / balance from Stock, grouped first
+by ContainerType then by Container.  Useful for a quick audit of how many
+units have been received vs consumed across every container format.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from decimal import Decimal
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.db.models import Count, Sum
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView
+
+from edc_dashboard.view_mixins import EdcViewMixin
+from edc_navbar import NavbarViewMixin
+from edc_protocol.view_mixins import EdcProtocolViewMixin
+
+from ..models import Stock
+from ..models.medication import Assignment
+from .auths_view_mixin import AuthsViewMixin
+
+
+@method_decorator(login_required, name="dispatch")
+class ContainerBalanceReportView(
+    AuthsViewMixin, EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateView
+):
+    """Unit-qty in/out/balance report grouped by container type then container."""
+
+    template_name = "edc_pharmacy/stock/container_balance_report.html"
+    navbar_name = settings.APP_NAME
+    navbar_selected_item = "pharmacy"
+
+    def get_context_data(self, **kwargs):
+        from ..auth_objects import PHARMACIST_ROLE
+
+        roles = [obj.name for obj in self.request.user.userprofile.roles.all()]
+        show_assignment = PHARMACIST_ROLE in roles
+
+        # Build assignment lookup: id → display_name (decrypted in Python)
+        assignment_map: dict = {}
+        if show_assignment:
+            assignment_map = {
+                str(a.pk): str(a) for a in Assignment.objects.all()
+            }
+
+        values_fields = [
+            "container__container_type__display_name",
+            "container__container_type__name",
+            "container__display_name",
+            "container__name",
+            "container_id",
+            "location__display_name",
+            "location__name",
+            "location_id",
+        ]
+        if show_assignment:
+            values_fields.append("lot__assignment_id")
+
+        order_fields = [
+            "container__container_type__display_name",
+            "container__display_name",
+            "location__display_name",
+        ]
+        if show_assignment:
+            order_fields.append("lot__assignment_id")
+
+        qs = (
+            Stock.objects.filter(invalid_state=False)
+            .values(*values_fields)
+            .annotate(
+                total_unit_qty_in=Sum("unit_qty_in"),
+                total_unit_qty_out=Sum("unit_qty_out"),
+                stock_count=Count("id"),
+            )
+            .order_by(*order_fields)
+        )
+
+        # Group rows by container type for template rendering
+        groups: dict[str, dict] = defaultdict(lambda: {
+            "rows": [],
+            "subtotal_in": Decimal("0"),
+            "subtotal_out": Decimal("0"),
+        })
+
+        grand_in = Decimal("0")
+        grand_out = Decimal("0")
+
+        for row in qs:
+            ct_label = (
+                row["container__container_type__display_name"]
+                or row["container__container_type__name"]
+                or "—"
+            )
+            container_label = row["container__display_name"] or row["container__name"] or "—"
+            location_label = row["location__display_name"] or row["location__name"] or "—"
+            unit_in = row["total_unit_qty_in"] or Decimal("0")
+            unit_out = row["total_unit_qty_out"] or Decimal("0")
+            balance = unit_in - unit_out
+
+            assignment_label = ""
+            if show_assignment:
+                assignment_id = str(row.get("lot__assignment_id") or "")
+                assignment_label = assignment_map.get(assignment_id, "—")
+
+            groups[ct_label]["rows"].append({
+                "container": container_label,
+                "location": location_label,
+                "assignment": assignment_label,
+                "stock_count": int(row["stock_count"] or 0),
+                "unit_qty_in": unit_in,
+                "unit_qty_out": unit_out,
+                "balance": balance,
+            })
+            groups[ct_label]["subtotal_in"] += unit_in
+            groups[ct_label]["subtotal_out"] += unit_out
+            grand_in += unit_in
+            grand_out += unit_out
+
+        # Convert to a sorted list for the template
+        group_list = [
+            {
+                "container_type": ct_label,
+                "rows": g["rows"],
+                "subtotal_in": g["subtotal_in"],
+                "subtotal_out": g["subtotal_out"],
+                "subtotal_balance": g["subtotal_in"] - g["subtotal_out"],
+            }
+            for ct_label, g in sorted(groups.items())
+        ]
+
+        totals = {
+            "unit_qty_in": grand_in,
+            "unit_qty_out": grand_out,
+            "balance": grand_in - grand_out,
+        }
+
+        return super().get_context_data(
+            groups=group_list,
+            totals=totals,
+            show_assignment=show_assignment,
+            **kwargs,
+        )

--- a/src/edc_pharmacy/views/site_stock_report_view.py
+++ b/src/edc_pharmacy/views/site_stock_report_view.py
@@ -1,0 +1,150 @@
+"""Site stock report.
+
+Shows stock currently held at site locations (non-Central), grouped by
+location → container type → container.  Excludes dispensed, returned
+(location moved back to Central), zero-unit, and invalid items.
+
+For PHARMACIST_ROLE users an extra Assignment column is shown.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from decimal import Decimal
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.db.models import Count, Sum
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView
+
+from edc_dashboard.view_mixins import EdcViewMixin
+from edc_navbar import NavbarViewMixin
+from edc_protocol.view_mixins import EdcProtocolViewMixin
+
+from ..auth_objects import PHARMACIST_ROLE
+from ..constants import ZERO_ITEM
+from ..models import Stock
+from ..models.medication import Assignment
+from .auths_view_mixin import AuthsViewMixin
+
+
+@method_decorator(login_required, name="dispatch")
+class SiteStockReportView(
+    AuthsViewMixin, EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateView
+):
+    """Unit-qty in/out/balance for stock currently held at site locations."""
+
+    template_name = "edc_pharmacy/stock/site_stock_report.html"
+    navbar_name = settings.APP_NAME
+    navbar_selected_item = "pharmacy"
+
+    def get_context_data(self, **kwargs):
+        roles = [obj.name for obj in self.request.user.userprofile.roles.all()]
+        show_assignment = PHARMACIST_ROLE in roles
+
+        assignment_map: dict = {}
+        if show_assignment:
+            assignment_map = {str(a.pk): str(a) for a in Assignment.objects.all()}
+
+        values_fields = [
+            "location__display_name",
+            "location__name",
+            "location_id",
+            "container__container_type__display_name",
+            "container__container_type__name",
+            "container__display_name",
+            "container__name",
+            "container_id",
+        ]
+        if show_assignment:
+            values_fields.append("lot__assignment_id")
+
+        order_fields = [
+            "location__display_name",
+            "container__container_type__display_name",
+            "container__display_name",
+        ]
+        if show_assignment:
+            order_fields.append("lot__assignment_id")
+
+        qs = (
+            Stock.objects.filter(
+                invalid_state=False,
+                dispensed=False,
+                location__site__isnull=False,
+            )
+            .exclude(status=ZERO_ITEM)
+            .values(*values_fields)
+            .annotate(
+                total_unit_qty_in=Sum("unit_qty_in"),
+                total_unit_qty_out=Sum("unit_qty_out"),
+                stock_count=Count("id"),
+            )
+            .order_by(*order_fields)
+        )
+
+        # Group by location for template rendering
+        groups: dict[str, dict] = defaultdict(lambda: {
+            "rows": [],
+            "subtotal_in": Decimal("0"),
+            "subtotal_out": Decimal("0"),
+        })
+
+        grand_in = Decimal("0")
+        grand_out = Decimal("0")
+
+        for row in qs:
+            location_label = row["location__display_name"] or row["location__name"] or "—"
+            ct_label = (
+                row["container__container_type__display_name"]
+                or row["container__container_type__name"]
+                or "—"
+            )
+            container_label = row["container__display_name"] or row["container__name"] or "—"
+            unit_in = row["total_unit_qty_in"] or Decimal("0")
+            unit_out = row["total_unit_qty_out"] or Decimal("0")
+            balance = unit_in - unit_out
+
+            assignment_label = ""
+            if show_assignment:
+                assignment_id = str(row.get("lot__assignment_id") or "")
+                assignment_label = assignment_map.get(assignment_id, "—")
+
+            groups[location_label]["rows"].append({
+                "container_type": ct_label,
+                "container": container_label,
+                "assignment": assignment_label,
+                "stock_count": int(row["stock_count"] or 0),
+                "unit_qty_in": unit_in,
+                "unit_qty_out": unit_out,
+                "balance": balance,
+            })
+            groups[location_label]["subtotal_in"] += unit_in
+            groups[location_label]["subtotal_out"] += unit_out
+            grand_in += unit_in
+            grand_out += unit_out
+
+        group_list = [
+            {
+                "location": loc_label,
+                "rows": g["rows"],
+                "subtotal_in": g["subtotal_in"],
+                "subtotal_out": g["subtotal_out"],
+                "subtotal_balance": g["subtotal_in"] - g["subtotal_out"],
+            }
+            for loc_label, g in sorted(groups.items())
+        ]
+
+        totals = {
+            "unit_qty_in": grand_in,
+            "unit_qty_out": grand_out,
+            "balance": grand_in - grand_out,
+        }
+
+        return super().get_context_data(
+            groups=group_list,
+            totals=totals,
+            show_assignment=show_assignment,
+            **kwargs,
+        )


### PR DESCRIPTION
- Container balance report (/edc_pharmacy/container-balance-report/):
  unit qty in/out/balance grouped by container type, container and
  location; PHARMACIST_ROLE adds assignment column and grouping;
  DataTables with live-updating footer totals

- Site stock report (/edc_pharmacy/site-stock-report/):
  stock currently held at site locations (non-Central), excluding
  dispensed and zero-unit items; same grouping and role-based
  assignment column as container balance report

Both reports linked from central_home.html reads panel.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
