### PR TITLE
ui: audit-trail buttons on receive panels + mobile-responsive tables

### DIFF
--- a/src/edc_pharmacy/admin/list_filters.py
+++ b/src/edc_pharmacy/admin/list_filters.py
@@ -95,9 +95,9 @@ class StockItemAllocationListFilter(SimpleListFilter):
         qs = None
         if self.value():
             if self.value() == YES:
-                qs = queryset.filter(allocation__isnull=False)
+                qs = queryset.filter(current_allocation__isnull=False)
             elif self.value() == NO:
-                qs = queryset.filter(allocation__isnull=True)
+                qs = queryset.filter(current_allocation__isnull=True)
         return qs
 
 

--- a/src/edc_pharmacy/forms/stock/__init__.py
+++ b/src/edc_pharmacy/forms/stock/__init__.py
@@ -15,10 +15,13 @@ from .receive_form import ReceiveForm, ReceiveFormSuper
 from .receive_header_form import ReceiveHeaderForm
 from .receive_item_add_form import ReceiveItemAddForm
 from .receive_item_form import ReceiveItemForm
+from .repack_edit_form import RepackEditForm
+from .stock_request_edit_form import StockRequestEditForm
 from .repack_request_form import RepackRequestForm
 from .stock_form import StockForm
 from .stock_request_form import StockRequestForm
 from .stock_request_item_form import StockRequestItemForm
+from .stock_transfer_edit_form import StockTransferEditForm
 from .stock_transfer_form import StockTransferForm
 from .storage_bin_form import StorageBinForm
 from .storage_bin_item_form import StorageBinItemForm

--- a/src/edc_pharmacy/forms/stock/repack_edit_form.py
+++ b/src/edc_pharmacy/forms/stock/repack_edit_form.py
@@ -1,0 +1,126 @@
+"""Form for creating/editing a RepackRequest from the repack workflow page.
+
+from_stock is entered as a stock code (scan or type); the form resolves it
+to a Stock FK on clean. container is a filtered ModelChoiceField restricted
+to containers with may_repack_as=True.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from django import forms
+
+from ...models import Container, RepackRequest, Stock
+
+
+class RepackEditForm(forms.Form):
+    stock_code = forms.CharField(
+        label="Bulk stock code",
+        max_length=36,
+        help_text="Scan or type the stock code of the bulk item to repack.",
+    )
+    container = forms.ModelChoiceField(
+        queryset=Container.objects.filter(may_repack_as=True).order_by("name"),
+        label="Container",
+        empty_label="Select container …",
+    )
+    container_unit_qty = forms.DecimalField(
+        label="Units per container",
+        min_value=Decimal("1.0"),
+        decimal_places=2,
+        max_digits=10,
+        required=False,
+        help_text="Leave blank to use the container default.",
+    )
+    override_container_unit_qty = forms.BooleanField(
+        label="Override container unit qty",
+        required=False,
+    )
+    item_qty_repack = forms.IntegerField(
+        label="Containers to repack",
+        min_value=1,
+    )
+
+    def __init__(self, *args, instance: RepackRequest | None = None, **kwargs):
+        self.instance = instance
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            if not isinstance(field.widget, forms.CheckboxInput):
+                existing = field.widget.attrs.get("class", "")
+                if "form-control" not in existing:
+                    field.widget.attrs["class"] = (existing + " form-control").strip()
+        if instance and instance.pk:
+            self.fields["stock_code"].initial = instance.from_stock.code
+            self.fields["stock_code"].widget.attrs["readonly"] = "readonly"
+            self.fields["container"].initial = instance.container
+            self.fields["container_unit_qty"].initial = instance.container_unit_qty
+            self.fields["override_container_unit_qty"].initial = (
+                instance.override_container_unit_qty
+            )
+            self.fields["item_qty_repack"].initial = instance.item_qty_repack
+            if (instance.item_qty_processed or 0) > 0:
+                self.fields["stock_code"].widget.attrs["readonly"] = "readonly"
+                self.fields["item_qty_repack"].widget.attrs["readonly"] = "readonly"
+                self.fields["container"].widget.attrs["style"] = (
+                    self.fields["container"].widget.attrs.get("style", "") + " pointer-events:none;"
+                ).strip()
+
+    def clean_stock_code(self):
+        code = self.cleaned_data.get("stock_code", "").strip().upper()
+        if self.instance and self.instance.pk:
+            return code
+        qs = Stock.objects.filter(code=code, confirmed=True, repack_request__isnull=True)
+        if not qs.exists():
+            raise forms.ValidationError(
+                "No confirmed, available bulk stock found with this code."
+            )
+        return code
+
+    def clean(self):
+        cleaned_data = super().clean()
+        code = cleaned_data.get("stock_code", "").strip().upper()
+
+        if self.instance and self.instance.pk:
+            stock = self.instance.from_stock
+        else:
+            try:
+                stock = Stock.objects.get(code=code, confirmed=True, repack_request__isnull=True)
+            except Stock.DoesNotExist:
+                return cleaned_data
+
+        cleaned_data["from_stock"] = stock
+
+        container = cleaned_data.get("container")
+        container_unit_qty = cleaned_data.get("container_unit_qty")
+        override = cleaned_data.get("override_container_unit_qty", False)
+        item_qty_repack = cleaned_data.get("item_qty_repack")
+
+        if container:
+            if container == stock.container:
+                self.add_error("container", "Stock is already packed in this container.")
+
+            effective_qty = container_unit_qty or container.unit_qty_default
+            cleaned_data["container_unit_qty"] = effective_qty
+
+            if not override and container_unit_qty and container_unit_qty != container.unit_qty_default:
+                self.add_error(
+                    "container_unit_qty",
+                    f"Expected default of {container.unit_qty_default}. "
+                    "Tick 'Override' to use a different value.",
+                )
+            if container_unit_qty and container.unit_qty_max and container_unit_qty > container.unit_qty_max:
+                self.add_error("container_unit_qty", "Cannot exceed container maximum unit quantity.")
+            if container_unit_qty and container_unit_qty > stock.container_unit_qty:
+                self.add_error("container", "Cannot pack into a larger container.")
+
+        if container and item_qty_repack and not (self.instance and self.instance.pk):
+            effective_qty = cleaned_data.get("container_unit_qty") or container.unit_qty_default
+            if effective_qty and item_qty_repack * effective_qty > stock.unit_qty:
+                self.add_error(
+                    "item_qty_repack",
+                    f"Insufficient stock. Need {item_qty_repack * effective_qty} units "
+                    f"but only {stock.unit_qty} available.",
+                )
+
+        return cleaned_data

--- a/src/edc_pharmacy/forms/stock/stock_request_edit_form.py
+++ b/src/edc_pharmacy/forms/stock/stock_request_edit_form.py
@@ -1,0 +1,131 @@
+"""Form for creating/editing a StockRequest from the workflow page.
+
+Date fields are date-only; the server appends time on save.
+Validation logic mirrors StockRequestForm but adapted for workflow use.
+"""
+
+from __future__ import annotations
+
+from clinicedc_constants import CANCEL
+from django import forms
+from django.utils import timezone
+
+from ...models import Allocation, Container, StockRequest
+from ...models.stock.location import Location
+
+
+class StockRequestEditForm(forms.ModelForm):
+    request_date = forms.DateField(
+        label="Request date",
+        widget=forms.DateInput(attrs={"type": "date"}, format="%Y-%m-%d"),
+        input_formats=["%Y-%m-%d"],
+    )
+    start_date = forms.DateField(
+        label="Start date",
+        required=False,
+        widget=forms.DateInput(attrs={"type": "date"}, format="%Y-%m-%d"),
+        input_formats=["%Y-%m-%d"],
+        help_text="Exclude appointments before this date. Leave blank to include all.",
+    )
+    cutoff_date = forms.DateField(
+        label="Cutoff date",
+        widget=forms.DateInput(attrs={"type": "date"}, format="%Y-%m-%d"),
+        input_formats=["%Y-%m-%d"],
+        help_text="Exclude appointments after this date.",
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["location"].queryset = Location.objects.filter(
+            site_id__isnull=False
+        ).order_by("display_name")
+        self.fields["container"].queryset = Container.objects.filter(
+            may_request_as=True
+        ).order_by("name")
+        for field in self.fields.values():
+            if not isinstance(field.widget, (forms.CheckboxInput, forms.Textarea)):
+                existing = field.widget.attrs.get("class", "")
+                if "form-control" not in existing:
+                    field.widget.attrs["class"] = (existing + " form-control").strip()
+        # Pre-fill date fields from instance datetimes
+        if self.instance and self.instance.pk:
+            if self.instance.request_datetime:
+                self.initial["request_date"] = timezone.localtime(
+                    self.instance.request_datetime
+                ).date()
+            if self.instance.start_datetime:
+                self.initial["start_date"] = timezone.localtime(
+                    self.instance.start_datetime
+                ).date()
+            if self.instance.cutoff_datetime:
+                self.initial["cutoff_date"] = timezone.localtime(
+                    self.instance.cutoff_datetime
+                ).date()
+        else:
+            self.initial.setdefault("request_date", timezone.localtime(timezone.now()).date())
+
+    def clean_request_date(self):
+        date = self.cleaned_data.get("request_date")
+        if date and date > timezone.localtime(timezone.now()).date():
+            raise forms.ValidationError("Request date may not be a future date.")
+        return date
+
+    def clean(self):
+        cleaned_data = super().clean()
+        request_date = cleaned_data.get("request_date")
+        start_date = cleaned_data.get("start_date")
+        cutoff_date = cleaned_data.get("cutoff_date")
+
+        if request_date and cutoff_date and cutoff_date <= request_date:
+            self.add_error("cutoff_date", "Must be after the request date.")
+        if start_date and request_date and start_date > request_date:
+            self.add_error("start_date", "Must be on or before the request date.")
+        if start_date and cutoff_date and start_date >= cutoff_date:
+            self.add_error("cutoff_date", "Must be at least 1 day after start date.")
+
+        if cleaned_data.get("subject_identifiers") and cleaned_data.get(
+            "excluded_subject_identifiers"
+        ):
+            raise forms.ValidationError(
+                "Cannot include and exclude subject identifiers in the same request."
+            )
+
+        container = cleaned_data.get("container")
+        containers_per_subject = cleaned_data.get("containers_per_subject")
+        if container and containers_per_subject and containers_per_subject > container.max_items_per_subject:  # noqa: E501
+            self.add_error(
+                "containers_per_subject",
+                f"May not exceed {container.max_items_per_subject} for this container.",
+            )
+
+        if (
+            self.instance
+            and self.instance.pk
+            and cleaned_data.get("cancel") == CANCEL
+            and Allocation.objects.filter(
+                stock_request_item__stock_request=self.instance
+            ).exists()
+        ):
+            raise forms.ValidationError(
+                "May not be cancelled — stock has already been allocated."
+            )
+
+        return cleaned_data
+
+    class Meta:
+        model = StockRequest
+        fields = (
+            "request_date",
+            "start_date",
+            "cutoff_date",
+            "location",
+            "formulation",
+            "container",
+            "containers_per_subject",
+            "subject_identifiers",
+            "excluded_subject_identifiers",
+        )
+        widgets = {  # noqa: RUF012
+            "subject_identifiers": forms.Textarea(attrs={"rows": 4}),
+            "excluded_subject_identifiers": forms.Textarea(attrs={"rows": 4}),
+        }

--- a/src/edc_pharmacy/forms/stock/stock_transfer_edit_form.py
+++ b/src/edc_pharmacy/forms/stock/stock_transfer_edit_form.py
@@ -1,0 +1,36 @@
+"""Form for creating a StockTransfer from the workflow page."""
+
+from __future__ import annotations
+
+from django import forms
+
+from ...models import Location, StockTransfer
+
+
+class StockTransferEditForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["from_location"].queryset = Location.objects.order_by("display_name")
+        self.fields["to_location"].queryset = Location.objects.filter(
+            site_id__isnull=False
+        ).order_by("display_name")
+        for field in self.fields.values():
+            if not isinstance(field.widget, forms.Textarea):
+                existing = field.widget.attrs.get("class", "")
+                if "form-control" not in existing:
+                    field.widget.attrs["class"] = (existing + " form-control").strip()
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if (
+            cleaned_data.get("from_location")
+            and cleaned_data.get("to_location")
+            and cleaned_data["from_location"] == cleaned_data["to_location"]
+        ):
+            raise forms.ValidationError("From and To locations cannot be the same.")
+        return cleaned_data
+
+    class Meta:
+        model = StockTransfer
+        fields = ("from_location", "to_location", "item_count", "comment")
+        widgets = {"comment": forms.Textarea(attrs={"rows": 3})}  # noqa: RUF012

--- a/src/edc_pharmacy/templates/edc_pharmacy/central_home.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/central_home.html
@@ -9,8 +9,8 @@
                 <a id="home_list_group_order" href="{% url 'edc_pharmacy:order_home_url' %}" class="list-group-item"><b>Orders:</b> Manage orders and order items</a>
                 <a id="home_list_group_receive_home" href="{% url 'edc_pharmacy:receive_home_url' %}" class="list-group-item"><b>Receive:</b> Record and confirm received stock</a>
                 <a id="home_list_group_receive" href="{% url 'edc_pharmacy_admin:edc_pharmacy_receive_changelist' %}" class="list-group-item"><B>Receiving:</B> Label and confirm received stock</a>
-                <a id="home_list_group_repack" href="{% url 'edc_pharmacy_admin:edc_pharmacy_repackrequest_changelist' %}" class="list-group-item"><b>Repack:</b> Decant, label and confirm</a>
-                <a id="home_list_group_stockrequest" href="{% url 'edc_pharmacy_admin:edc_pharmacy_stockrequest_changelist' %}" class="list-group-item"><B>Manage Requests:</B> Allocate stock to subjects</a>
+                <a id="home_list_group_repack" href="{% url 'edc_pharmacy:repack_home_url' %}" class="list-group-item"><b>Repack:</b> Decant, label and confirm</a>
+                <a id="home_list_group_stockrequest" href="{% url 'edc_pharmacy:stock_request_home_url' %}" class="list-group-item"><b>Manage Requests:</b> Allocate stock to subjects</a>
                 <a id="home_list_group_stocktransfer" href="{% url 'edc_pharmacy:stock_transfer_home_url' %}" class="list-group-item"><b>Transfer stock to site</b></a>
                 <a id="home_list_group_return_central" href="{% url 'edc_pharmacy:return_central_url' %}" class="list-group-item"><b>Returns: Receive and disposition</b></a>
                 <a id="home_list_group_stock_adjustments" href="{% url 'edc_pharmacy:stock_adjustments_url' %}" class="list-group-item"><b>Stock adjustments</b></a>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/allocate_to_subject.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/allocate_to_subject.html
@@ -9,39 +9,39 @@
     <div class="col-sm-6">
 
       <div style="padding:10px">
-        <a href="{% url "edc_pharmacy:home_url" %}">Pharmacy</a> >
-        <a href="{% url "edc_pharmacy_admin:edc_pharmacy_stockrequest_changelist" %}?q={{ stock_request.request_identifier }}">Stock Request</a> >
-        {% if assignment %}<a href="{% url "edc_pharmacy:allocate_url" stock_request.pk %}">{{ assignment }}</a>{% else %}Assignment{% endif %} >
+        <a href="{% url "edc_pharmacy:home_url" %}">Pharmacy</a> &rsaquo;
+        <a href="{% url "edc_pharmacy:stock_request_url" stock_request=stock_request.pk %}">Stock Request {{ stock_request.request_identifier }}</a> &rsaquo;
+        {% if assignment %}{{ assignment }}{% else %}Assignment{% endif %} &rsaquo;
         Allocate to subject
       </div>
 
       <div class="panel panel-default">
         <div class="panel-heading">Allocate stock to subjects from stock request <a href="{{ stock_request_changelist_url }}">{{ stock_request.request_identifier }}</a>
-          {% if  subject_identifiers and assignment %}<span class="pull-right">{{ show_count }}/{{ remaining_count }} [{{ total_count }}]</span>{% endif %}</div>
+          {% if subject_identifiers and assignment %}<span class="pull-right">{{ show_count }}/{{ remaining_count }} [{{ total_count }}]</span>{% endif %}</div>
         <div class="panel-body">
           <form class="form-horizontal" action="{{ url }}" method="post" onSubmit="document.getElementById('submit').disabled=true;">
             {% csrf_token %}
             <div class="form-group">
 
-              {% if  subject_identifiers and assignment %}
+              {% if subject_identifiers and assignment %}
                 <div style="text-align: center"><p class="bg-primary">{{ assignment.name|upper }}</p></div>
                 {% for subject_identifier in subject_identifiers %}
                 <label class="control-label col-sm-5" for="codes">{{ forloop.counter }}. {{ subject_identifier }}</label>
                 <div class="col-sm-5">
-                  <input type="text" class="form-control" id="codes" name="codes" placeholder="stock # {{ i }} " value=""  pattern="[A-Z0-9]{6}" required autofocus>
+                  <input type="text" class="form-control" id="codes" name="codes" placeholder="stock # {{ forloop.counter }}" value="" pattern="[A-Z0-9]{6}" required autofocus>
                 </div>
                 {% endfor %}
-                <input type="hidden" class="form-control" id="assignment" name="assignment"  value="{{ assignment.id }}">
+                <input type="hidden" class="form-control" id="assignment" name="assignment" value="{{ assignment.id }}">
 
               {% else %}
 
                 <div class="col-sm-5">
                   <label class="control-label" for="assignment">Select assignment</label>
-                  <select class="form-control" id="assignment" name="assignment" required autofocus >
-                      <option value="" selected> ----- </option>
-                      {% for assignment in assignments %}
-                        <option value="{{ assignment.id }}">{{ assignment.name }}</option>
-                      {% endfor %}
+                  <select class="form-control" id="assignment" name="assignment" required autofocus>
+                    <option value="" selected> ----- </option>
+                    {% for assignment in assignments %}
+                      <option value="{{ assignment.id }}">{{ assignment.name }}</option>
+                    {% endfor %}
                   </select>
                 </div>
 
@@ -52,7 +52,7 @@
             {% if subject_identifiers and assignment %}
               <div style="text-align: center"><p class="bg-primary">{{ assignment.name|upper }}</p></div>
             {% endif %}
-              <input type="hidden" name="subject_identifiers" id="subject_identifiers" value="{{ subject_identifiers }}">
+            <input type="hidden" name="subject_identifiers" id="subject_identifiers" value="{{ subject_identifiers }}">
             <button type="submit" class="btn btn-default" name="submit" id="submit">Submit</button>
             <button class="btn btn-default" onclick="window.location.href='{{ stock_request_changelist_url }}'">Done</button>
           </form>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/order.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/order.html
@@ -88,7 +88,6 @@
                     {% endif %}
                     <a href="{% url "edc_pharmacy_admin:edc_pharmacy_order_history" order.pk %}"
                        class="btn btn-default btn-sm pull-right"
-                       target="_blank"
                        style="margin-top:6px;"
                        title="View audit trail">
                         <i class="fa fa-history"></i> Audit trail
@@ -172,7 +171,6 @@
                             {% endif %}
                             <a href="{% url "edc_pharmacy_admin:edc_pharmacy_orderitem_history" oi.pk %}"
                                class="btn btn-default btn-sm pull-right"
-                               target="_blank"
                                title="View audit trail">
                                 <i class="fa fa-history"></i> Audit trail
                             </a>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/receive_order.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/receive_order.html
@@ -65,6 +65,12 @@
                     &nbsp;
                     <a href="{% url "edc_pharmacy:order_url" order=order.pk %}"
                        class="btn btn-default btn-sm" style="margin-top:6px;">Go to ordering</a>
+                    <a href="{% url "edc_pharmacy_admin:edc_pharmacy_order_history" order.pk %}"
+                       class="btn btn-default btn-sm pull-right"
+                       style="margin-top:6px;"
+                       title="View audit trail">
+                        <i class="fa fa-history"></i> Audit trail
+                    </a>
                 </div>
             </div>
 
@@ -129,6 +135,11 @@
                         </button>
                     </form>
                     {% endif %}
+                    <a href="{% url "edc_pharmacy_admin:edc_pharmacy_receive_history" receive.pk %}"
+                       class="btn btn-default btn-sm pull-right"
+                       title="View audit trail">
+                        <i class="fa fa-history"></i> Audit trail
+                    </a>
 
                     {% else %}
                     {# ── Edit / create form ── #}
@@ -223,6 +234,7 @@
 
                     {# Existing receive items #}
                     {% if row.receive_items %}
+                    <div class="table-responsive">
                     <table class="table table-condensed table-bordered" style="margin-bottom:8px;">
                         <thead>
                             <tr>
@@ -270,21 +282,32 @@
                                         <i class="fa fa-lock"></i>
                                     </span>
                                     {% endif %}
+                                    <a href="{% url "edc_pharmacy_admin:edc_pharmacy_receiveitem_history" ri.pk %}"
+                                       class="btn btn-default btn-xs"
+                                       title="View audit trail">
+                                        <i class="fa fa-history"></i>
+                                    </a>
                                 </td>
                             </tr>
                             {% endwith %}
                             {% endfor %}
                         </tbody>
                     </table>
+                    </div>
                     {% endif %}
 
                     {# Receive button — navigates to dedicated receive-item page #}
-                    {% if row.can_add %}
                     <div style="border-top:1px solid #ddd;padding-top:10px;margin-top:4px;">
+                        {% if row.can_add %}
                         <a href="{% url "edc_pharmacy:receive_order_item_url" order=order.pk order_item=oi.pk %}"
                            class="btn btn-primary btn-sm">Receive</a>
+                        {% endif %}
+                        <a href="{% url "edc_pharmacy_admin:edc_pharmacy_orderitem_history" oi.pk %}"
+                           class="btn btn-default btn-sm pull-right"
+                           title="View audit trail">
+                            <i class="fa fa-history"></i> Audit trail
+                        </a>
                     </div>
-                    {% endif %}
 
                 </div>
             </div>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/receive_order_item.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/receive_order_item.html
@@ -61,6 +61,7 @@
             <div class="panel panel-default">
                 <div class="panel-heading"><b>Received so far</b></div>
                 <div class="panel-body" style="padding:0;">
+                    <div class="table-responsive">
                     <table class="table table-condensed table-bordered" style="margin-bottom:0;">
                         <thead>
                             <tr>
@@ -93,6 +94,7 @@
                             {% endfor %}
                         </tbody>
                     </table>
+                    </div>
                 </div>
             </div>
             {% endif %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/repack.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/repack.html
@@ -1,0 +1,157 @@
+{% extends edc_base_template %}
+{% load static %}
+
+{% block main %}
+    {{ block.super }}
+    <div class="container">
+        <div class="col-sm-12">
+
+            <div style="padding:10px;">
+                <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
+                <a href="{% url "edc_pharmacy:repack_home_url" %}">Repack</a> &rsaquo;
+                {{ repack_request.repack_identifier }}
+            </div>
+
+            {# ── Repack request summary ── #}
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <b>Repack request <code>{{ repack_request.repack_identifier }}</code></b>
+                    &nbsp;
+                    {% if confirmed_qty == repack_request.item_qty_repack and repack_request.item_qty_repack %}
+                        <span class="label label-success">All confirmed</span>
+                    {% elif repack_request.item_qty_processed > 0 and confirmed_qty > 0 %}
+                        <span class="label label-warning">{{ confirmed_qty }} confirmed, {{ unconfirmed_qty }} unconfirmed</span>
+                    {% elif repack_request.item_qty_processed > 0 %}
+                        <span class="label label-info">Processed — awaiting confirmation</span>
+                    {% elif repack_request.task_id %}
+                        <span class="label label-info">Processing…</span>
+                    {% else %}
+                        <span class="label label-default">New</span>
+                    {% endif %}
+                </div>
+                <div class="panel-body">
+                    <table class="table table-condensed" style="margin-bottom:8px;">
+                        <tr>
+                            <th style="width:180px;">Bulk stock code</th>
+                            <td><code>{{ repack_request.from_stock.code }}</code></td>
+                            <th style="width:180px;">Product</th>
+                            <td>{{ repack_request.from_stock.product.name }}</td>
+                        </tr>
+                        <tr>
+                            <th>Assignment</th>
+                            <td>{{ repack_request.from_stock.product.assignment.display_name|default:"—" }}</td>
+                            <th>Lot / Batch</th>
+                            <td>{{ repack_request.from_stock.lot.lot_no|default:"—" }}</td>
+                        </tr>
+                        <tr>
+                            <th>Target container</th>
+                            <td>{{ repack_request.container }}</td>
+                            <th>Units per container</th>
+                            <td>{{ repack_request.container_unit_qty }}</td>
+                        </tr>
+                        <tr>
+                            <th>Containers requested</th>
+                            <td>{{ repack_request.item_qty_repack }}</td>
+                            <th>Containers processed</th>
+                            <td>{{ repack_request.item_qty_processed }}</td>
+                        </tr>
+                        <tr>
+                            <th>Units processed</th>
+                            <td>{{ repack_request.unit_qty_processed }}</td>
+                            <th>Confirmed</th>
+                            <td>{{ confirmed_qty }} / {{ repack_request.item_qty_repack }}</td>
+                        </tr>
+                        <tr>
+                            <th>Date</th>
+                            <td>{{ repack_request.repack_datetime|date:"d-M-Y H:i" }}</td>
+                            <th>Created by</th>
+                            <td>{{ repack_request.user_created|default:"—" }}</td>
+                        </tr>
+                    </table>
+
+                    {# ── Action buttons ── #}
+                    <div style="margin-top:6px;">
+                        {# Edit — only before processing #}
+                        {% if not repack_request.item_qty_processed %}
+                        <a href="{% url "edc_pharmacy:repack_edit_url" repack_request=repack_request.pk %}"
+                           class="btn btn-primary btn-sm">Edit</a>
+                        {% endif %}
+
+                        {# Process — only if not yet processed and no pending task #}
+                        {% if not repack_request.item_qty_processed and not repack_request.task_id %}
+                        <form method="post" style="display:inline;">
+                            {% csrf_token %}
+                            <input type="hidden" name="action" value="process">
+                            <button type="submit" class="btn btn-success btn-sm">
+                                <i class="fa fa-cogs"></i> Process
+                            </button>
+                        </form>
+                        {% elif repack_request.task_id and not repack_request.item_qty_processed %}
+                        <span class="btn btn-default btn-sm disabled">
+                            <i class="fa fa-spinner fa-spin"></i> Processing…
+                        </span>
+                        {% endif %}
+
+                        {# Print labels + Confirm — once stock rows exist #}
+                        {% if repack_request.item_qty_processed %}
+                        <a href="{% url "edc_pharmacy:repack_edit_url" repack_request=repack_request.pk %}"
+                           class="btn btn-primary btn-sm">Edit</a>
+                        <form method="post" style="display:inline;">
+                            {% csrf_token %}
+                            <input type="hidden" name="action" value="print_labels">
+                            <button type="submit" class="btn btn-default btn-sm">
+                                <i class="fa fa-print"></i> Print labels ({{ repack_request.item_qty_processed }})
+                            </button>
+                        </form>
+                        {% if unconfirmed_qty > 0 %}
+                        <form method="post" style="display:inline;">
+                            {% csrf_token %}
+                            <input type="hidden" name="action" value="confirm_stock">
+                            <button type="submit" class="btn btn-success btn-sm">
+                                <i class="fa fa-check"></i> Confirm labelled stock ({{ unconfirmed_qty }} unconfirmed)
+                            </button>
+                        </form>
+                        {% else %}
+                        <span class="btn btn-success btn-sm disabled">
+                            <i class="fa fa-check"></i> All confirmed
+                        </span>
+                        {% endif %}
+                        {% endif %}
+
+                        <a href="{% url "edc_pharmacy_admin:edc_pharmacy_repackrequest_history" repack_request.pk %}"
+                           class="btn btn-default btn-sm pull-right"
+                           title="View audit trail">
+                            <i class="fa fa-history"></i> Audit trail
+                        </a>
+                    </div>
+
+                </div>
+            </div>
+
+            {# ── Instructions ── #}
+            <div class="panel panel-info">
+                <div class="panel-heading"><b>Instructions</b></div>
+                <div class="panel-body" style="font-size:13px;">
+                    <ol style="margin-bottom:0; padding-left:18px;">
+                        <li>Fill in a repack request and <b>Save</b>.</li>
+                        <li>Click <b>Process</b> — the system creates one stock record per container. Allow a moment if processing in background.</li>
+                        <li>Click <b>Print labels</b> and print at <b>100% scale</b> (do not fit to page).</li>
+                        <li>Affix each printed label to its physical container.</li>
+                        <li>Click <b>Confirm labelled stock</b> and scan each barcode to confirm.</li>
+                    </ol>
+                    <p class="text-muted" style="margin-top:8px; margin-bottom:0;">
+                        <i class="fa fa-exclamation-triangle"></i>
+                        Process only one medication type (Active <em>or</em> Placebo) at a time in the work area.
+                    </p>
+                </div>
+            </div>
+
+            <p style="margin-top:8px;">
+                <a href="{% url "edc_pharmacy:repack_home_url" %}" class="btn btn-default btn-sm">
+                    &larr; All repack requests
+                </a>
+            </p>
+
+        </div>
+    </div>
+{% endblock main %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/repack_edit.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/repack_edit.html
@@ -1,0 +1,76 @@
+{% extends edc_base_template %}
+{% load static %}
+
+{% block main %}
+    {{ block.super }}
+    <div class="container">
+        <div class="col-sm-8">
+
+            <div style="padding:10px;">
+                <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
+                <a href="{% url "edc_pharmacy:repack_home_url" %}">Repack</a> &rsaquo;
+                {% if instance %}
+                    <a href="{% url "edc_pharmacy:repack_url" repack_request=instance.pk %}">{{ instance.repack_identifier }}</a> &rsaquo;
+                    Edit
+                {% else %}
+                    New repack request
+                {% endif %}
+            </div>
+
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    {% if instance %}
+                        <b>Edit Repack Request <code>{{ instance.repack_identifier }}</code></b>
+                    {% else %}
+                        <b>New Repack Request</b>
+                    {% endif %}
+                </div>
+                <div class="panel-body">
+
+                    <div class="alert alert-info" style="font-size:13px;">
+                        <i class="fa fa-info-circle"></i>
+                        Scan or type the stock code of the <strong>bulk item</strong> to repack,
+                        select the target container, and enter the number of containers to produce.
+                    </div>
+
+                    <form method="post">
+                        {% csrf_token %}
+                        <div class="row">
+                            {% for field in form %}
+                            <div class="col-sm-6" style="margin-bottom:12px;">
+                                <div class="form-group{% if field.errors %} has-error{% endif %}">
+                                    <label class="control-label" for="{{ field.id_for_label }}">
+                                        {{ field.label }}
+                                        {% if field.field.required %}<span style="color:red;">*</span>{% endif %}
+                                    </label>
+                                    {{ field }}
+                                    {% if field.help_text %}
+                                        <span class="help-block">{{ field.help_text }}</span>
+                                    {% endif %}
+                                    {% if field.errors %}
+                                        <span class="help-block">{{ field.errors|join:", " }}</span>
+                                    {% endif %}
+                                </div>
+                            </div>
+                            {% endfor %}
+                        </div>
+                        {% if form.non_field_errors %}
+                            <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+                        {% endif %}
+                        <button type="submit" class="btn btn-primary btn-sm">Save</button>
+                        &nbsp;
+                        {% if instance %}
+                            <a href="{% url "edc_pharmacy:repack_url" repack_request=instance.pk %}"
+                               class="btn btn-default btn-sm">Cancel</a>
+                        {% else %}
+                            <a href="{% url "edc_pharmacy:repack_home_url" %}"
+                               class="btn btn-default btn-sm">Cancel</a>
+                        {% endif %}
+                    </form>
+
+                </div>
+            </div>
+
+        </div>
+    </div>
+{% endblock main %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/repack_home.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/repack_home.html
@@ -1,0 +1,109 @@
+{% extends edc_base_template %}
+{% load static %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.11.5/css/jquery.dataTables.min.css">
+{% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <script src="https://cdn.datatables.net/1.11.5/js/jquery.dataTables.min.js"></script>
+{% endblock %}
+
+{% block document_ready %}
+    <script>
+        $(document).ready(function() {
+            $('#repack_home_table').DataTable({
+                order: [[0, 'desc']],
+                pageLength: 25,
+                columnDefs: [
+                    { orderable: false, targets: -1 },
+                ],
+            });
+        });
+    </script>
+{% endblock %}
+
+{% block main %}
+    {{ block.super }}
+    <div class="container">
+        <div class="col-sm-12">
+
+            <div style="padding:10px;">
+                <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
+                Repack
+            </div>
+
+            <div style="margin-bottom:10px;">
+                <a href="{% url "edc_pharmacy:repack_add_url" %}"
+                   class="btn btn-primary btn-sm">
+                    <i class="fa fa-plus"></i> New repack request
+                </a>
+            </div>
+
+            {% if rows %}
+            <div class="table-responsive">
+            <table id="repack_home_table" class="table table-condensed table-hover">
+                <thead>
+                    <tr>
+                        <th>Repack #</th>
+                        <th>Date</th>
+                        <th>Stock code</th>
+                        <th>Product</th>
+                        {% if show_assignment %}<th>Assignment</th>{% endif %}
+                        <th>Container</th>
+                        <th style="text-align:right;">Requested</th>
+                        <th style="text-align:right;">Processed</th>
+                        <th style="text-align:right;">Confirmed</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in rows %}
+                    {% with rr=row.rr %}
+                    <tr>
+                        <td><code>{{ rr.repack_identifier }}</code></td>
+                        <td data-order="{{ rr.repack_datetime|date:"Y-m-d" }}">
+                            {{ rr.repack_datetime|date:"d-M-Y" }}
+                        </td>
+                        <td><code>{{ rr.from_stock.code }}</code></td>
+                        <td>{{ rr.from_stock.product.name }}</td>
+                        {% if show_assignment %}
+                        <td>{{ rr.from_stock.product.assignment.display_name|default:"—" }}</td>
+                        {% endif %}
+                        <td>{{ rr.container }}</td>
+                        <td style="text-align:right;">{{ rr.item_qty_repack|default:"—" }}</td>
+                        <td style="text-align:right;">
+                            {% if rr.task_id and rr.item_qty_processed == 0 %}
+                                <span class="label label-info">Processing…</span>
+                            {% else %}
+                                {{ rr.item_qty_processed|default:"0" }}
+                            {% endif %}
+                        </td>
+                        <td style="text-align:right;">
+                            {% if row.confirmed_qty == rr.item_qty_repack and rr.item_qty_repack %}
+                                <span class="label label-success">{{ row.confirmed_qty }}</span>
+                            {% elif row.confirmed_qty > 0 %}
+                                <span class="label label-warning">{{ row.confirmed_qty }}</span>
+                            {% else %}
+                                <span class="label label-danger">{{ row.confirmed_qty }}</span>
+                            {% endif %}
+                        </td>
+                        <td style="white-space:nowrap;">
+                            <a href="{% url "edc_pharmacy:repack_url" repack_request=rr.pk %}"
+                               class="btn btn-primary btn-xs">Manage</a>
+                        </td>
+                    </tr>
+                    {% endwith %}
+                    {% endfor %}
+                </tbody>
+            </table>
+            </div>
+            {% else %}
+                <p class="text-muted">No repack requests yet. Click <b>New repack request</b> to start.</p>
+            {% endif %}
+
+        </div>
+    </div>
+{% endblock main %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_request_edit.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_request_edit.html
@@ -1,0 +1,71 @@
+{% extends edc_base_template %}
+{% load static %}
+
+{% block main %}
+    {{ block.super }}
+    <div class="container">
+        <div class="col-sm-12">
+
+            <div style="padding:10px;">
+                <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
+                <a href="{% url "edc_pharmacy:stock_request_home_url" %}">Stock requests</a> &rsaquo;
+                {% if instance %}{{ instance.request_identifier }}{% else %}New request{% endif %}
+            </div>
+
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <b>{% if instance %}Edit stock request {{ instance.request_identifier }}{% else %}New stock request{% endif %}</b>
+                </div>
+                <div class="panel-body">
+                    <div class="alert alert-info" style="font-size:13px;">
+                        <i class="fa fa-info-circle"></i>
+                        Select the site location, formulation, and container type for this request.
+                        The system will identify subjects with upcoming appointments
+                        who need stock allocated.
+                    </div>
+                    <form method="post">
+                        {% csrf_token %}
+                        {% for field in form %}
+                        <div class="form-group {% if field.errors %}has-error{% endif %}">
+                            <label class="control-label col-sm-3" for="{{ field.id_for_label }}">
+                                {{ field.label }}{% if field.field.required %} <span class="text-danger">*</span>{% endif %}
+                            </label>
+                            <div class="col-sm-7">
+                                {{ field }}
+                                {% if field.help_text %}
+                                    <p class="help-block">{{ field.help_text }}</p>
+                                {% endif %}
+                                {% for error in field.errors %}
+                                    <p class="help-block text-danger">{{ error }}</p>
+                                {% endfor %}
+                            </div>
+                        </div>
+                        {% endfor %}
+                        {% if form.non_field_errors %}
+                        <div class="form-group has-error">
+                            <div class="col-sm-offset-3 col-sm-7">
+                                {% for error in form.non_field_errors %}
+                                    <p class="help-block text-danger">{{ error }}</p>
+                                {% endfor %}
+                            </div>
+                        </div>
+                        {% endif %}
+                        <div class="form-group">
+                            <div class="col-sm-offset-3 col-sm-7">
+                                <button type="submit" class="btn btn-primary">Save</button>
+                                {% if instance %}
+                                <a href="{% url "edc_pharmacy:stock_request_url" stock_request=instance.pk %}"
+                                   class="btn btn-default">Cancel</a>
+                                {% else %}
+                                <a href="{% url "edc_pharmacy:stock_request_home_url" %}"
+                                   class="btn btn-default">Cancel</a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+        </div>
+    </div>
+{% endblock main %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_request_home.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_request_home.html
@@ -1,0 +1,111 @@
+{% extends edc_base_template %}
+{% load static %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.11.5/css/jquery.dataTables.min.css">
+{% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <script src="https://cdn.datatables.net/1.11.5/js/jquery.dataTables.min.js"></script>
+{% endblock %}
+
+{% block document_ready %}
+    <script>
+        $(document).ready(function() {
+            $('#stock_request_home_table').DataTable({
+                order: [[0, 'desc']],
+                pageLength: 25,
+                columnDefs: [
+                    { orderable: false, targets: -1 },
+                ],
+            });
+        });
+    </script>
+{% endblock %}
+
+{% block main %}
+    {{ block.super }}
+    <div class="container">
+        <div class="col-sm-12">
+
+            <div style="padding:10px;">
+                <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
+                Stock requests
+            </div>
+
+            <div style="margin-bottom:10px;">
+                <a href="{% url "edc_pharmacy:stock_request_add_url" %}"
+                   class="btn btn-primary btn-sm">
+                    <i class="fa fa-plus"></i> New stock request
+                </a>
+            </div>
+
+            {% if rows %}
+            <div class="table-responsive">
+            <table id="stock_request_home_table" class="table table-condensed table-hover">
+                <thead>
+                    <tr>
+                        <th>Request #</th>
+                        <th>Date</th>
+                        <th>Location</th>
+                        <th>Formulation</th>
+                        <th>Container</th>
+                        <th style="text-align:right;">Containers/subject</th>
+                        <th style="text-align:right;">Items</th>
+                        <th style="text-align:right;">Allocated</th>
+                        <th>Status</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in rows %}
+                    {% with sr=row.sr %}
+                    <tr>
+                        <td><code>{{ sr.request_identifier }}</code></td>
+                        <td data-order="{{ sr.request_datetime|date:"Y-m-d" }}">
+                            {{ sr.request_datetime|date:"d-M-Y" }}
+                        </td>
+                        <td>{{ sr.location }}</td>
+                        <td>{{ sr.formulation }}</td>
+                        <td>{{ sr.container }}</td>
+                        <td style="text-align:right;">{{ sr.containers_per_subject }}</td>
+                        <td style="text-align:right;">{{ row.total|default:"0" }}</td>
+                        <td style="text-align:right;">
+                            {% if row.total > 0 and row.allocated == row.total %}
+                                <span class="label label-success">{{ row.allocated }}</span>
+                            {% elif row.allocated > 0 %}
+                                <span class="label label-warning">{{ row.allocated }}</span>
+                            {% else %}
+                                <span class="label label-danger">{{ row.allocated }}</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if sr.cancel %}
+                                <span class="label label-danger">Cancelled</span>
+                            {% elif row.total == 0 %}
+                                <span class="label label-default">New</span>
+                            {% elif row.allocated == row.total %}
+                                <span class="label label-success">Allocated</span>
+                            {% else %}
+                                <span class="label label-info">Open</span>
+                            {% endif %}
+                        </td>
+                        <td style="white-space:nowrap;">
+                            <a href="{% url "edc_pharmacy:stock_request_url" stock_request=sr.pk %}"
+                               class="btn btn-primary btn-xs">Manage</a>
+                        </td>
+                    </tr>
+                    {% endwith %}
+                    {% endfor %}
+                </tbody>
+            </table>
+            </div>
+            {% else %}
+                <p class="text-muted">No stock requests yet. Click <b>New stock request</b> to start.</p>
+            {% endif %}
+
+        </div>
+    </div>
+{% endblock main %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_request_manage.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_request_manage.html
@@ -1,0 +1,217 @@
+{% extends edc_base_template %}
+{% load static %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.11.5/css/jquery.dataTables.min.css">
+{% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <script src="https://cdn.datatables.net/1.11.5/js/jquery.dataTables.min.js"></script>
+{% endblock %}
+
+{% block document_ready %}
+    <script>
+        $(document).ready(function() {
+            var tbl = document.getElementById('allocations_table');
+            var dateColIdx = tbl ? tbl.rows[0].cells.length - 1 : 3;
+            $('#allocations_table').DataTable({
+                order: [[dateColIdx, 'asc']],
+                pageLength: 25,
+            });
+        });
+    </script>
+{% endblock %}
+
+{% block main %}
+    {{ block.super }}
+    <div class="container">
+        <div class="col-sm-12">
+
+            <div style="padding:10px;">
+                <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
+                <a href="{% url "edc_pharmacy:stock_request_home_url" %}">Stock requests</a> &rsaquo;
+                {{ stock_request.request_identifier }}
+            </div>
+
+            {# ── Stock request summary ── #}
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <b>Stock request <code>{{ stock_request.request_identifier }}</code></b>
+                    &nbsp;
+                    {% if stock_request.cancel %}
+                        <span class="label label-danger">Cancelled</span>
+                    {% elif total == 0 %}
+                        <span class="label label-default">New</span>
+                    {% elif allocated == total %}
+                        <span class="label label-success">Fully allocated</span>
+                    {% elif allocated > 0 %}
+                        <span class="label label-warning">Partially allocated ({{ allocated }}/{{ total }})</span>
+                    {% else %}
+                        <span class="label label-info">Items created — awaiting allocation</span>
+                    {% endif %}
+                </div>
+                <div class="panel-body">
+                    <table class="table table-condensed" style="margin-bottom:8px;">
+                        <tr>
+                            <th style="width:200px;">Request date</th>
+                            <td>{{ stock_request.request_datetime|date:"d-M-Y" }}</td>
+                            <th style="width:200px;">Location</th>
+                            <td>{{ stock_request.location }}</td>
+                        </tr>
+                        <tr>
+                            <th>Formulation</th>
+                            <td>{{ stock_request.formulation }}</td>
+                            <th>Container</th>
+                            <td>{{ stock_request.container }}</td>
+                        </tr>
+                        <tr>
+                            <th>Containers per subject</th>
+                            <td>{{ stock_request.containers_per_subject }}</td>
+                            <th>Request items</th>
+                            <td>{{ total }}</td>
+                        </tr>
+                        <tr>
+                            <th>Start date</th>
+                            <td>{{ stock_request.start_datetime|date:"d-M-Y"|default:"—" }}</td>
+                            <th>Cutoff date</th>
+                            <td>{{ stock_request.cutoff_datetime|date:"d-M-Y"|default:"—" }}</td>
+                        </tr>
+                        <tr>
+                            <th>Allocated</th>
+                            <td>{{ allocated }}</td>
+                            <th>Pending allocation</th>
+                            <td>{{ pending }}</td>
+                        </tr>
+                        {% if stock_request.subject_identifiers %}
+                        <tr>
+                            <th>Include only</th>
+                            <td colspan="3"><pre style="margin:0; font-size:12px;">{{ stock_request.subject_identifiers }}</pre></td>
+                        </tr>
+                        {% endif %}
+                        {% if stock_request.excluded_subject_identifiers %}
+                        <tr>
+                            <th>Excluded</th>
+                            <td colspan="3"><pre style="margin:0; font-size:12px;">{{ stock_request.excluded_subject_identifiers }}</pre></td>
+                        </tr>
+                        {% endif %}
+                        <tr>
+                            <th>Created by</th>
+                            <td>{{ stock_request.user_created|default:"—" }}</td>
+                            <th></th>
+                            <td></td>
+                        </tr>
+                    </table>
+
+                    {# ── Action buttons ── #}
+                    <div style="margin-top:6px;">
+                        {% if not stock_request.cancel %}
+                        {# Edit — always available while not cancelled #}
+                        <a href="{% url "edc_pharmacy:stock_request_edit_url" stock_request=stock_request.pk %}"
+                           class="btn btn-primary btn-sm">Edit</a>
+
+                        {# Prepare — only before items are created #}
+                        {% if total == 0 %}
+                        <a href="{% url "edc_pharmacy:review_stock_request_url" stock_request=stock_request.pk %}"
+                           class="btn btn-success btn-sm">
+                            <i class="fa fa-list"></i> Prepare items
+                        </a>
+                        {% endif %}
+
+                        {# Allocate — once items exist #}
+                        {% if total > 0 %}
+                            {% if pending > 0 %}
+                            <a href="{% url "edc_pharmacy:allocate_url" stock_request=stock_request.pk %}"
+                               class="btn btn-warning btn-sm">Allocate</a>
+                            {% else %}
+                            <span class="btn btn-success btn-sm disabled">Allocate</span>
+                            {% endif %}
+                        {% endif %}
+
+                        {# Cancel — only if no allocations #}
+                        {% if allocated == 0 %}
+                        <form method="post" style="display:inline;"
+                              onsubmit="return confirm('Cancel stock request {{ stock_request.request_identifier }}? This cannot be undone.');">
+                            {% csrf_token %}
+                            <input type="hidden" name="action" value="cancel">
+                            <button type="submit" class="btn btn-danger btn-sm pull-right">
+                                <i class="fa fa-times"></i> Cancel request
+                            </button>
+                        </form>
+                        {% endif %}
+
+                        {% endif %}{# end not cancelled #}
+
+                        <a href="{% url "edc_pharmacy_admin:edc_pharmacy_stockrequest_history" stock_request.pk %}"
+                           class="btn btn-default btn-sm pull-right"
+                           title="View audit trail">
+                            <i class="fa fa-history"></i> Audit trail
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            {# ── Allocated stock ── #}
+            {% if allocations %}
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <b>Allocated stock</b>
+                    <span class="pull-right text-muted">{{ allocations|length }} item{{ allocations|length|pluralize }}</span>
+                </div>
+                <div class="panel-body" style="padding:0;">
+                    <div class="table-responsive">
+                    <table id="allocations_table" class="table table-condensed table-hover" style="margin-bottom:0;">
+                        <thead>
+                            <tr>
+                                <th>Allocation #</th>
+                                <th>Stock code</th>
+                                <th>Subject</th>
+                                {% if show_assignment %}<th>Assignment</th>{% endif %}
+                                <th>Date</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for alloc in allocations %}
+                            <tr>
+                                <td><code>{{ alloc.allocation_identifier }}</code></td>
+                                <td><code>{{ alloc.code|default:"—" }}</code></td>
+                                <td>{{ alloc.subject_identifier }}</td>
+                                {% if show_assignment %}
+                                <td>{{ alloc.assignment.display_name|default:"—" }}</td>
+                                {% endif %}
+                                <td data-order="{{ alloc.allocation_datetime|date:"Y-m-d H:i" }}">
+                                    {{ alloc.allocation_datetime|date:"d-M-Y H:i" }}
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    </div>
+                </div>
+            </div>
+            {% endif %}
+
+            {# ── Instructions ── #}
+            {% if not stock_request.cancel %}
+            <div class="panel panel-info">
+                <div class="panel-heading"><b>Instructions</b></div>
+                <div class="panel-body" style="font-size:13px;">
+                    <ol style="margin-bottom:0; padding-left:18px;">
+                        <li>Click <b>Prepare items</b> — the system identifies subjects with upcoming appointments who need stock.</li>
+                        <li>Review the proposed items and click <b>Create items</b> to confirm.</li>
+                        <li>Click <b>Allocate</b> for each treatment assignment — scan stock barcodes to pair stock with subjects.</li>
+                    </ol>
+                </div>
+            </div>
+            {% endif %}
+
+            <p style="margin-top:8px;">
+                <a href="{% url "edc_pharmacy:stock_request_home_url" %}" class="btn btn-default btn-sm">
+                    &larr; All stock requests
+                </a>
+            </p>
+
+        </div>
+    </div>
+{% endblock main %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_transfer_edit.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_transfer_edit.html
@@ -1,0 +1,47 @@
+{% extends edc_base_template %}
+{% load static %}
+
+{% block main %}
+    {{ block.super }}
+    <div class="container">
+        <div class="col-sm-7">
+
+            <div style="padding:10px;">
+                <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
+                <a href="{% url "edc_pharmacy:stock_transfer_home_url" %}">Transfer stock to site</a> &rsaquo;
+                New transfer
+            </div>
+
+            <div class="panel panel-default">
+                <div class="panel-heading"><b>New stock transfer</b></div>
+                <div class="panel-body">
+                    <form method="post">
+                        {% csrf_token %}
+                        {% for field in form %}
+                        <div class="form-group{% if field.errors %} has-error{% endif %}" style="margin-bottom:14px;">
+                            <label class="control-label" for="{{ field.id_for_label }}">
+                                {{ field.label }}{% if field.field.required %} <span style="color:red;">*</span>{% endif %}
+                            </label>
+                            {{ field }}
+                            {% if field.help_text %}
+                                <span class="help-block">{{ field.help_text }}</span>
+                            {% endif %}
+                            {% if field.errors %}
+                                <span class="help-block">{{ field.errors|join:", " }}</span>
+                            {% endif %}
+                        </div>
+                        {% endfor %}
+                        {% if form.non_field_errors %}
+                            <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+                        {% endif %}
+                        <button type="submit" class="btn btn-primary btn-sm">Save</button>
+                        &nbsp;
+                        <a href="{% url "edc_pharmacy:stock_transfer_home_url" %}"
+                           class="btn btn-default btn-sm">Cancel</a>
+                    </form>
+                </div>
+            </div>
+
+        </div>
+    </div>
+{% endblock main %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_transfer_home.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_transfer_home.html
@@ -1,6 +1,31 @@
 {% extends edc_base_template %}
 {% load static %}
 
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.11.5/css/jquery.dataTables.min.css">
+{% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <script src="https://cdn.datatables.net/1.11.5/js/jquery.dataTables.min.js"></script>
+{% endblock %}
+
+{% block document_ready %}
+    {{ block.super }}
+    <script>
+        $(document).ready(function () {
+            {% if transfers %}
+            $('#transfers-tbl').DataTable({
+                order: [[1, 'desc']],
+                pageLength: 25,
+                columnDefs: [{orderable: false, targets: -1}],
+            });
+            {% endif %}
+        });
+    </script>
+{% endblock %}
+
 {% block main %}
     {{ block.super }}
     <div class="container">
@@ -13,7 +38,7 @@
             </div>
 
             <div style="margin-bottom:12px;">
-                <a href="{% url "edc_pharmacy_admin:edc_pharmacy_stocktransfer_add" %}"
+                <a href="{% url "edc_pharmacy:stock_transfer_add_url" %}"
                    class="btn btn-primary btn-sm">
                     <i class="fas fa-plus"></i> New transfer
                 </a>
@@ -24,7 +49,7 @@
             </div>
 
             {% if transfers %}
-            <table class="table table-condensed table-hover">
+            <table id="transfers-tbl" class="table table-condensed table-hover">
                 <thead>
                     <tr>
                         <th>Transfer #</th>
@@ -61,14 +86,19 @@
                             {% endif %}
                         </td>
                         <td>
-                            {% if not row.complete %}
+                            {% if row.complete %}
+                                <a href="{% url "edc_pharmacy:transfer_stock_url" stock_transfer=t.pk %}"
+                                   class="btn btn-default btn-xs">
+                                    View
+                                </a>
+                            {% else %}
                                 <a href="{% url "edc_pharmacy:transfer_stock_url" stock_transfer=t.pk %}"
                                    class="btn btn-primary btn-xs">
                                     <i class="fas fa-barcode"></i> Scan
                                 </a>
                             {% endif %}
                             <a href="{% url "edc_pharmacy:generate_manifest" stock_transfer=t.pk %}"
-                               class="btn btn-default btn-xs" target="_blank" style="margin-left:4px;">
+                               class="btn btn-default btn-xs" style="margin-left:4px;" target="_blank">
                                 Manifest
                             </a>
                         </td>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/transfer_stock.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/transfer_stock.html
@@ -1,6 +1,30 @@
 {% extends edc_base_template %}
 {% load static %}
 
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.11.5/css/jquery.dataTables.min.css">
+{% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <script src="https://cdn.datatables.net/1.11.5/js/jquery.dataTables.min.js"></script>
+{% endblock %}
+
+{% block document_ready %}
+    {{ block.super }}
+    <script>
+        $(document).ready(function () {
+            {% if transfer_items %}
+            $('#scanned-tbl').DataTable({
+                order: [[5, 'desc']],
+                pageLength: 25,
+            });
+            {% endif %}
+        });
+    </script>
+{% endblock %}
+
 {% block main %}
     {{ block.super }}
     <div class="container">
@@ -28,23 +52,25 @@
                         Transfer <strong>{{ stock_transfer.transfer_identifier }}</strong>:
                         <strong>{{ transferred_count }}</strong> of
                         <strong>{{ stock_transfer.item_count }}</strong> scanned
-                        {% if transferred_count < stock_transfer.item_count %}
+                        {% if remaining_count > 0 %}
                             &mdash; <strong>{{ remaining_count }}</strong> remaining
                         {% else %}
                             &mdash; <span class="label label-success">Complete</span>
                         {% endif %}
                     </p>
 
-                    {# ── Scan input ────────────────────────────────── #}
+                    {# ── Scan input (disabled when complete) ──────── #}
                     <div class="input-group" style="max-width:360px; margin-bottom:10px;">
                         <input type="text" id="scan-input"
                                class="form-control"
                                placeholder="Scan stock code"
                                autocomplete="off" autofocus
                                pattern="[A-Z0-9]+"
+                               {% if remaining_count == 0 %}disabled{% endif %}
                                onkeydown="if(event.key==='Enter'){event.preventDefault();addCode();}">
                         <span class="input-group-btn">
-                            <button type="button" class="btn btn-default" onclick="addCode()">Add</button>
+                            <button type="button" class="btn btn-default" onclick="addCode()"
+                                    {% if remaining_count == 0 %}disabled{% endif %}>Add</button>
                         </span>
                     </div>
 
@@ -73,12 +99,39 @@
                 </div>
             </div>
 
-            {# ── Django messages ───────────────────────────────────── #}
-            {% if messages %}
-            <div style="margin-top:10px;">
-                {% for message in messages %}
-                <div class="alert alert-{{ message.tags|default:"info" }}">{{ message }}</div>
-                {% endfor %}
+            {# ── Scanned items panel ───────────────────────────────── #}
+            {% if transfer_items %}
+            <div class="panel panel-default" style="margin-top:16px;">
+                <div class="panel-heading">
+                    <strong>Scanned items</strong>
+                    <span class="badge" style="margin-left:6px;">{{ transferred_count }}</span>
+                </div>
+                <div class="panel-body" style="padding:0;">
+                    <table id="scanned-tbl" class="table table-condensed table-hover" style="margin:0;">
+                        <thead>
+                            <tr>
+                                <th>#</th>
+                                <th>Code</th>
+                                <th>Subject</th>
+                                <th>To location</th>
+                                <th>Scanned by</th>
+                                <th>Scanned</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for item in transfer_items %}
+                            <tr>
+                                <td>{{ forloop.counter }}</td>
+                                <td style="font-family:monospace;">{{ item.code }}</td>
+                                <td>{{ item.stock.current_allocation.registered_subject.subject_identifier|default:"—" }}</td>
+                                <td>{{ item.stock_transfer.to_location.display_name }}</td>
+                                <td>{{ item.user_created }}</td>
+                                <td style="white-space:nowrap;">{{ item.transfer_item_datetime|date:"d-M-Y H:i" }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
             </div>
             {% endif %}
 
@@ -122,7 +175,7 @@
 
             codes.forEach(function (c) {
                 var li = document.createElement('li');
-                li.innerHTML = '<code>' + c + '</code> '
+                li.innerHTML = '<span style="background:#e8e8e8;color:#333;padding:1px 5px;border-radius:3px;font-family:monospace;">' + c + '</span> '
                     + '<a href="#" onclick="removeCode(\'' + c + '\'); return false;"'
                     + ' style="color:#c00; font-size:0.85em;">&times;</a>';
                 list.appendChild(li);

--- a/src/edc_pharmacy/urls.py
+++ b/src/edc_pharmacy/urls.py
@@ -26,15 +26,22 @@ from .views import (
     ReceiveOrderView,
     ReceiveSupplierAddView,
     ReceiveSupplierEditView,
+    RepackEditView,
+    RepackHomeView,
+    RepackView,
     ReturnCentralView,
     ReturnDispositionView,
     ReturnReceiveView,
     ReturnRequestView,
     SiteStockReportView,
     StockAdjustmentView,
+    StockRequestEditView,
+    StockRequestHomeView,
+    StockRequestView,
     StockTakeHomeView,
     StockTakeResultsView,
     StockTakeScanView,
+    StockTransferEditView,
     StockTransferHomeView,
     TransferStockView,
     get_stock_transfers_view,
@@ -111,6 +118,11 @@ urlpatterns = [
         "stock-transfer/",
         StockTransferHomeView.as_view(),
         name="stock_transfer_home_url",
+    ),
+    path(
+        "stock-transfer/add/",
+        StockTransferEditView.as_view(),
+        name="stock_transfer_add_url",
     ),
     path(
         "transfer-stock/<uuid:stock_transfer>/",
@@ -254,6 +266,48 @@ urlpatterns = [
         "receive/supplier/<uuid:pk>/edit/",
         ReceiveSupplierEditView.as_view(),
         name="receive_supplier_edit_url",
+    ),
+    # ── Stock request / allocation workflow ───────────────────────────────
+    path(
+        "stock-request/",
+        StockRequestHomeView.as_view(),
+        name="stock_request_home_url",
+    ),
+    path(
+        "stock-request/add/",
+        StockRequestEditView.as_view(),
+        name="stock_request_add_url",
+    ),
+    path(
+        "stock-request/<uuid:stock_request>/",
+        StockRequestView.as_view(),
+        name="stock_request_url",
+    ),
+    path(
+        "stock-request/<uuid:stock_request>/edit/",
+        StockRequestEditView.as_view(),
+        name="stock_request_edit_url",
+    ),
+    # ── Repack workflow ────────────────────────────────────────────────────
+    path(
+        "repack/",
+        RepackHomeView.as_view(),
+        name="repack_home_url",
+    ),
+    path(
+        "repack/add/",
+        RepackEditView.as_view(),
+        name="repack_add_url",
+    ),
+    path(
+        "repack/<uuid:repack_request>/",
+        RepackView.as_view(),
+        name="repack_url",
+    ),
+    path(
+        "repack/<uuid:repack_request>/edit/",
+        RepackEditView.as_view(),
+        name="repack_edit_url",
     ),
     # ── Return workflow ────────────────────────────────────────────────────
     path(

--- a/src/edc_pharmacy/utils/allocate_stock.py
+++ b/src/edc_pharmacy/utils/allocate_stock.py
@@ -48,7 +48,7 @@ def allocate_stock(
         )
         stock_request_item = stock_request.stockrequestitem_set.filter(
             registered_subject=rs_obj,
-            current_allocation__isnull=True,
+            allocation__isnull=True,
         ).first()
         if not stock_request_item:
             skipped.append(f"{subject_identifier}: N/A")

--- a/src/edc_pharmacy/utils/transfer_stock_to_location.py
+++ b/src/edc_pharmacy/utils/transfer_stock_to_location.py
@@ -53,13 +53,16 @@ def transfer_stock_to_location(
         except ObjectDoesNotExist:
             skipped_codes.append(stock_code)
         else:
+            # Gate 2: stock must be allocated via a request whose destination is the
+            # site being transferred to/from. Use StockRequestItem→StockRequest→location
+            # rather than registered_subject.site, which can diverge in multi-site DBs.
             if stock_transfer.to_location.name == CENTRAL_LOCATION:
                 opts.update(
-                    current_allocation__registered_subject__site=stock_transfer.from_location.site,
+                    current_allocation__stock_request_item__stock_request__location=stock_transfer.from_location,
                 )
             else:
                 opts.update(
-                    current_allocation__registered_subject__site=stock_transfer.to_location.site
+                    current_allocation__stock_request_item__stock_request__location=stock_transfer.to_location,
                 )
             try:
                 stock_obj = stock_model_cls.objects.get(**opts)

--- a/src/edc_pharmacy/views/__init__.py
+++ b/src/edc_pharmacy/views/__init__.py
@@ -15,6 +15,12 @@ from .order_home_view import OrderHomeView
 from .order_item_edit_view import OrderItemEditView
 from .order_view import OrderView
 from .prepare_and_review_stock_request_view import PrepareAndReviewStockRequestView
+from .repack_edit_view import RepackEditView
+from .repack_home_view import RepackHomeView
+from .repack_view import RepackView
+from .stock_request_edit_view import StockRequestEditView
+from .stock_request_home_view import StockRequestHomeView
+from .stock_request_view import StockRequestView
 from .print_labels_view import PrintLabelsView
 from .print_order_view import print_order_view
 from .print_return_manifest_view import print_return_manifest_view
@@ -36,5 +42,6 @@ from .stock_adjustment_view import StockAdjustmentView
 from .stock_take_home_view import StockTakeHomeView
 from .stock_take_results_view import StockTakeResultsView
 from .stock_take_scan_view import StockTakeScanView
+from .stock_transfer_edit_view import StockTransferEditView
 from .stock_transfer_home_view import StockTransferHomeView
 from .transfer_stock_view import TransferStockView

--- a/src/edc_pharmacy/views/allocate_to_subject_view.py
+++ b/src/edc_pharmacy/views/allocate_to_subject_view.py
@@ -95,8 +95,10 @@ class AllocateToSubjectView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin,
     @property
     def stock_request_changelist_url(self) -> str:
         if self.stock_request:
-            url = reverse("edc_pharmacy_admin:edc_pharmacy_stockrequest_changelist")
-            return f"{url}?q={self.stock_request.request_identifier}"
+            return reverse(
+                "edc_pharmacy:stock_request_url",
+                kwargs={"stock_request": self.stock_request.pk},
+            )
         return "/"
 
     @staticmethod

--- a/src/edc_pharmacy/views/prepare_and_review_stock_request_view.py
+++ b/src/edc_pharmacy/views/prepare_and_review_stock_request_view.py
@@ -212,7 +212,10 @@ class PrepareAndReviewStockRequestView(
                     f"{stock_request.request_identifier}"
                 ),
             )
-            url = f"{self.source_changelist_url}?q={stock_request.request_identifier}"
+            url = reverse(
+                "edc_pharmacy:stock_request_url",
+                kwargs={"stock_request": stock_request.pk},
+            )
         else:
             if session_uuid:
                 del request.session[session_uuid]
@@ -221,5 +224,8 @@ class PrepareAndReviewStockRequestView(
                 messages.INFO,
                 "Cancelled. No stock request items were created.",
             )
-            url = f"{self.source_changelist_url}"
+            url = reverse(
+                "edc_pharmacy:stock_request_url",
+                kwargs={"stock_request": stock_request.pk},
+            )
         return HttpResponseRedirect(url)

--- a/src/edc_pharmacy/views/print_labels_view.py
+++ b/src/edc_pharmacy/views/print_labels_view.py
@@ -82,7 +82,7 @@ class PrintLabelsView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Templ
                 pk=request.POST.get("label_configuration")
             )
             if label_configuration.requires_allocation and queryset.filter(
-                allocation__isnull=True
+                current_allocation__isnull=True
             ):
                 messages.add_message(
                     request,

--- a/src/edc_pharmacy/views/repack_edit_view.py
+++ b/src/edc_pharmacy/views/repack_edit_view.py
@@ -1,0 +1,86 @@
+"""Repack workflow — create or edit a RepackRequest."""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView
+
+from edc_dashboard.view_mixins import EdcViewMixin
+from edc_navbar import NavbarViewMixin
+from edc_protocol.view_mixins import EdcProtocolViewMixin
+
+from ..forms.stock import RepackEditForm
+from ..models import RepackRequest
+from .auths_view_mixin import PharmacistRequiredMixin
+
+
+@method_decorator(login_required, name="dispatch")
+class RepackEditView(
+    PharmacistRequiredMixin, EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateView
+):
+    template_name = "edc_pharmacy/stock/repack_edit.html"
+    navbar_name = settings.APP_NAME
+    navbar_selected_item = "pharmacy"
+
+    def _get_instance(self) -> RepackRequest | None:
+        pk = self.kwargs.get("repack_request")
+        if pk:
+            return get_object_or_404(RepackRequest, pk=pk)
+        return None
+
+    def get_context_data(self, form=None, **kwargs):
+        kwargs.pop("repack_request", None)
+        instance = self._get_instance()
+        form = form or RepackEditForm(instance=instance)
+        return super().get_context_data(instance=instance, form=form, **kwargs)
+
+    def post(self, request, *args, **kwargs):  # noqa: ARG002
+        instance = self._get_instance()
+        data = request.POST.copy()
+        if instance and (instance.item_qty_processed or 0) > 0:
+            data["stock_code"] = instance.from_stock.code
+            data["container"] = str(instance.container.pk)
+            data["item_qty_repack"] = str(instance.item_qty_repack)
+        form = RepackEditForm(data, instance=instance)
+        if form.is_valid():
+            cd = form.cleaned_data
+            from_stock = cd["from_stock"]
+            container = cd["container"]
+            container_unit_qty = cd.get("container_unit_qty") or container.unit_qty_default
+            if instance is None:
+                obj = RepackRequest(
+                    from_stock=from_stock,
+                    container=container,
+                    container_unit_qty=container_unit_qty,
+                    override_container_unit_qty=cd.get("override_container_unit_qty", False),
+                    item_qty_repack=cd["item_qty_repack"],
+                    user_created=request.user.username,
+                    user_modified=request.user.username,
+                )
+                obj.save()
+                messages.success(
+                    request, f"Repack request {obj.repack_identifier} created."
+                )
+            else:
+                instance.container_unit_qty = container_unit_qty
+                instance.override_container_unit_qty = cd.get(
+                    "override_container_unit_qty", False
+                )
+                instance.item_qty_repack = cd["item_qty_repack"]
+                instance.user_modified = request.user.username
+                instance.save()
+                obj = instance
+                messages.success(
+                    request, f"Repack request {obj.repack_identifier} updated."
+                )
+            return HttpResponseRedirect(
+                reverse("edc_pharmacy:repack_url", kwargs={"repack_request": obj.pk})
+            )
+        context = self.get_context_data(form=form)
+        return self.render_to_response(context)

--- a/src/edc_pharmacy/views/repack_home_view.py
+++ b/src/edc_pharmacy/views/repack_home_view.py
@@ -1,0 +1,48 @@
+"""Repack workflow — landing page."""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView
+
+from edc_dashboard.view_mixins import EdcViewMixin
+from edc_navbar import NavbarViewMixin
+from edc_protocol.view_mixins import EdcProtocolViewMixin
+
+from ..auth_objects import PHARMACIST_ROLE
+from ..models import RepackRequest, Stock
+from .auths_view_mixin import PharmacistRequiredMixin
+
+
+@method_decorator(login_required, name="dispatch")
+class RepackHomeView(
+    PharmacistRequiredMixin, EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateView
+):
+    template_name = "edc_pharmacy/stock/repack_home.html"
+    navbar_name = settings.APP_NAME
+    navbar_selected_item = "pharmacy"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        roles = context.get("roles", [])
+        show_assignment = PHARMACIST_ROLE in roles
+        repack_requests = RepackRequest.objects.select_related(
+            "from_stock__product", "from_stock__product__assignment",
+            "from_stock__lot", "container",
+        ).order_by("-repack_identifier")
+        confirmed_map = {
+            rr.pk: Stock.objects.filter(repack_request=rr, confirmed=True).count()
+            for rr in repack_requests
+        }
+        rows = [
+            {
+                "rr": rr,
+                "confirmed_qty": confirmed_map.get(rr.pk, 0),
+            }
+            for rr in repack_requests
+        ]
+        context["rows"] = rows
+        context["show_assignment"] = show_assignment
+        return context

--- a/src/edc_pharmacy/views/repack_view.py
+++ b/src/edc_pharmacy/views/repack_view.py
@@ -1,0 +1,132 @@
+"""Repack workflow — per-request page with Process / Print labels / Confirm actions."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView
+
+from edc_dashboard.view_mixins import EdcViewMixin
+from edc_navbar import NavbarViewMixin
+from edc_protocol.view_mixins import EdcProtocolViewMixin
+from edc_utils.celery import run_task_sync_or_async
+
+from ..models import RepackRequest, Stock
+from ..utils import process_repack_request_queryset
+from .auths_view_mixin import PharmacistRequiredMixin
+
+
+@method_decorator(login_required, name="dispatch")
+class RepackView(
+    PharmacistRequiredMixin, EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateView
+):
+    template_name = "edc_pharmacy/stock/repack.html"
+    navbar_name = settings.APP_NAME
+    navbar_selected_item = "pharmacy"
+
+    def _get_repack_request(self) -> RepackRequest:
+        return get_object_or_404(RepackRequest, pk=self.kwargs["repack_request"])
+
+    @staticmethod
+    def _stock_counts(rr: RepackRequest) -> tuple[int, int]:
+        qs = Stock.objects.filter(repack_request=rr)
+        confirmed = qs.filter(confirmed=True).count()
+        unconfirmed = qs.filter(confirmed=False).count()
+        return confirmed, unconfirmed
+
+    def get_context_data(self, **kwargs):
+        kwargs.pop("repack_request", None)
+        context = super().get_context_data(**kwargs)
+        rr = self._get_repack_request()
+        confirmed_qty, unconfirmed_qty = self._stock_counts(rr)
+        context.update(
+            repack_request=rr,
+            confirmed_qty=confirmed_qty,
+            unconfirmed_qty=unconfirmed_qty,
+        )
+        return context
+
+    def post(self, request, *args, **kwargs):  # noqa: ARG002
+        rr = self._get_repack_request()
+        action = request.POST.get("action")
+        redirect_url = reverse(
+            "edc_pharmacy:repack_url", kwargs={"repack_request": rr.pk}
+        )
+
+        if action == "process":
+            return self._handle_process(request, rr, redirect_url)
+        if action == "print_labels":
+            return self._handle_print_labels(request, rr, redirect_url)
+        if action == "confirm_stock":
+            return self._handle_confirm_stock(request, rr, redirect_url)
+
+        return HttpResponseRedirect(redirect_url)
+
+    @staticmethod
+    def _handle_process(request, rr: RepackRequest, redirect_url: str) -> HttpResponseRedirect:
+        if (rr.item_qty_processed or 0) > 0:
+            messages.warning(request, "This repack request has already been processed.")
+            return HttpResponseRedirect(redirect_url)
+        task = run_task_sync_or_async(
+            process_repack_request_queryset,
+            repack_request_pks=[rr.pk],
+            username=request.user.username,
+        )
+        task_id = getattr(task, "id", None)
+        RepackRequest.objects.filter(pk=rr.pk).update(task_id=task_id)
+        if task_id:
+            messages.info(request, f"Processing in background (task {task_id}).")
+        else:
+            messages.success(request, f"Repack request {rr.repack_identifier} processed.")
+        return HttpResponseRedirect(redirect_url)
+
+    @staticmethod
+    def _handle_print_labels(
+        request, rr: RepackRequest, redirect_url: str
+    ) -> HttpResponseRedirect:
+        stock_pks = list(
+            Stock.objects.filter(repack_request=rr).values_list("pk", flat=True)
+        )
+        if not stock_pks:
+            messages.warning(request, "No stock items found. Process the request first.")
+            return HttpResponseRedirect(redirect_url)
+        session_uuid = str(uuid4())
+        request.session[session_uuid] = [str(pk) for pk in stock_pks]
+        return HttpResponseRedirect(
+            reverse(
+                "edc_pharmacy:print_labels_url",
+                kwargs={"session_uuid": session_uuid, "model": "stock"},
+            )
+        )
+
+    @staticmethod
+    def _handle_confirm_stock(
+        request, rr: RepackRequest, redirect_url: str
+    ) -> HttpResponseRedirect:
+        stock_qs = Stock.objects.filter(repack_request=rr, confirmed=False)
+        stock_codes = list(stock_qs.values_list("code", flat=True))
+        if not stock_codes:
+            messages.warning(request, "All stock items are already confirmed.")
+            return HttpResponseRedirect(redirect_url)
+        session_uuid = str(uuid4())
+        request.session[session_uuid] = {
+            "stock_codes": stock_codes,
+            "source_pk": str(rr.pk),
+            "source_identifier": rr.repack_identifier,
+            "source_label_lower": rr._meta.label_lower,
+            "source_model_name": rr._meta.verbose_name,
+            "transaction_word": "confirmed",
+        }
+        return HttpResponseRedirect(
+            reverse(
+                "edc_pharmacy:confirm_stock_from_queryset_url",
+                kwargs={"session_uuid": session_uuid},
+            )
+        )

--- a/src/edc_pharmacy/views/stock_request_edit_view.py
+++ b/src/edc_pharmacy/views/stock_request_edit_view.py
@@ -1,0 +1,75 @@
+"""Stock request workflow — create or edit a StockRequest."""
+
+from __future__ import annotations
+
+from datetime import datetime, time
+
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.utils import timezone
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView
+
+from edc_dashboard.view_mixins import EdcViewMixin
+from edc_navbar import NavbarViewMixin
+from edc_protocol.view_mixins import EdcProtocolViewMixin
+
+from ..forms.stock import StockRequestEditForm
+from ..models import StockRequest
+from .auths_view_mixin import PharmacistRequiredMixin
+
+
+@method_decorator(login_required, name="dispatch")
+class StockRequestEditView(
+    PharmacistRequiredMixin, EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateView
+):
+    template_name = "edc_pharmacy/stock/stock_request_edit.html"
+    navbar_name = settings.APP_NAME
+    navbar_selected_item = "pharmacy"
+
+    def _get_instance(self) -> StockRequest | None:
+        pk = self.kwargs.get("stock_request")
+        if pk:
+            return get_object_or_404(StockRequest, pk=pk)
+        return None
+
+    def get_context_data(self, form=None, **kwargs):
+        kwargs.pop("stock_request", None)
+        instance = self._get_instance()
+        form = form or StockRequestEditForm(instance=instance)
+        return super().get_context_data(instance=instance, form=form, **kwargs)
+
+    def post(self, request, *args, **kwargs):  # noqa: ARG002
+        instance = self._get_instance()
+        form = StockRequestEditForm(request.POST, instance=instance)
+        if form.is_valid():
+            cd = form.cleaned_data
+            tz = timezone.get_current_timezone()
+            obj = form.save(commit=False)
+            obj.request_datetime = datetime.combine(
+                cd["request_date"], time.min
+            ).replace(tzinfo=tz)
+            start_date = cd.get("start_date")
+            obj.start_datetime = (
+                datetime.combine(start_date, time.min).replace(tzinfo=tz)
+                if start_date
+                else None
+            )
+            obj.cutoff_datetime = datetime.combine(
+                cd["cutoff_date"], time.min
+            ).replace(tzinfo=tz)
+            if not instance:
+                obj.user_created = request.user.username
+            obj.user_modified = request.user.username
+            obj.save()
+            verb = "created" if not instance else "updated"
+            messages.success(request, f"Stock request {obj.request_identifier} {verb}.")
+            return HttpResponseRedirect(
+                reverse("edc_pharmacy:stock_request_url", kwargs={"stock_request": obj.pk})
+            )
+        context = self.get_context_data(form=form)
+        return self.render_to_response(context)

--- a/src/edc_pharmacy/views/stock_request_home_view.py
+++ b/src/edc_pharmacy/views/stock_request_home_view.py
@@ -1,0 +1,41 @@
+"""Stock request workflow — landing page."""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView
+
+from edc_dashboard.view_mixins import EdcViewMixin
+from edc_navbar import NavbarViewMixin
+from edc_protocol.view_mixins import EdcProtocolViewMixin
+
+from ..auth_objects import PHARMACIST_ROLE
+from ..models import StockRequest
+from .auths_view_mixin import PharmacistRequiredMixin
+
+
+@method_decorator(login_required, name="dispatch")
+class StockRequestHomeView(
+    PharmacistRequiredMixin, EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateView
+):
+    template_name = "edc_pharmacy/stock/stock_request_home.html"
+    navbar_name = settings.APP_NAME
+    navbar_selected_item = "pharmacy"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        roles = context.get("roles", [])
+        show_assignment = PHARMACIST_ROLE in roles
+        requests = StockRequest.objects.select_related(
+            "location", "formulation", "container",
+        ).order_by("-request_identifier")
+        rows = []
+        for sr in requests:
+            total = sr.stockrequestitem_set.count()
+            allocated = sr.stockrequestitem_set.filter(allocation__isnull=False).count()
+            rows.append({"sr": sr, "total": total, "allocated": allocated})
+        context["rows"] = rows
+        context["show_assignment"] = show_assignment
+        return context

--- a/src/edc_pharmacy/views/stock_request_view.py
+++ b/src/edc_pharmacy/views/stock_request_view.py
@@ -1,0 +1,84 @@
+"""Stock request workflow — per-request page with Prepare / Allocate / Cancel actions."""
+
+from __future__ import annotations
+
+from clinicedc_constants import CANCEL
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView
+
+from edc_dashboard.view_mixins import EdcViewMixin
+from edc_navbar import NavbarViewMixin
+from edc_protocol.view_mixins import EdcProtocolViewMixin
+
+from ..auth_objects import PHARMACIST_ROLE
+from ..models import Allocation, StockRequest
+from .auths_view_mixin import PharmacistRequiredMixin
+
+
+@method_decorator(login_required, name="dispatch")
+class StockRequestView(
+    PharmacistRequiredMixin, EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateView
+):
+    template_name = "edc_pharmacy/stock/stock_request_manage.html"
+    navbar_name = settings.APP_NAME
+    navbar_selected_item = "pharmacy"
+
+    def _get_stock_request(self) -> StockRequest:
+        return get_object_or_404(StockRequest, pk=self.kwargs["stock_request"])
+
+    def get_context_data(self, **kwargs):
+        kwargs.pop("stock_request", None)
+        context = super().get_context_data(**kwargs)
+        roles = context.get("roles", [])
+        sr = self._get_stock_request()
+        total = sr.stockrequestitem_set.count()
+        allocated = sr.stockrequestitem_set.filter(allocation__isnull=False).count()
+        pending = total - allocated
+        allocations = (
+            Allocation.objects.filter(stock_request_item__stock_request=sr)
+            .select_related("registered_subject", "assignment")
+            .order_by("allocation_datetime")
+        )
+        context.update(
+            stock_request=sr,
+            total=total,
+            allocated=allocated,
+            pending=pending,
+            allocations=allocations,
+            show_assignment=PHARMACIST_ROLE in roles,
+        )
+        return context
+
+    def post(self, request, *args, **kwargs):  # noqa: ARG002
+        sr = self._get_stock_request()
+        redirect_url = reverse(
+            "edc_pharmacy:stock_request_url", kwargs={"stock_request": sr.pk}
+        )
+        action = request.POST.get("action")
+        if action == "cancel":
+            return self._handle_cancel(request, sr, redirect_url)
+        return HttpResponseRedirect(redirect_url)
+
+    @staticmethod
+    def _handle_cancel(
+        request, sr: StockRequest, redirect_url: str
+    ) -> HttpResponseRedirect:
+        if Allocation.objects.filter(stock_request_item__stock_request=sr).exists():
+            messages.error(
+                request,
+                "Cannot cancel — stock has already been allocated for this request.",
+            )
+            return HttpResponseRedirect(redirect_url)
+        sr.cancel = CANCEL
+        sr.user_modified = request.user.username
+        sr.save()
+        messages.success(request, f"Stock request {sr.request_identifier} cancelled.")
+        return HttpResponseRedirect(
+            reverse("edc_pharmacy:stock_request_home_url")
+        )

--- a/src/edc_pharmacy/views/stock_transfer_edit_view.py
+++ b/src/edc_pharmacy/views/stock_transfer_edit_view.py
@@ -1,0 +1,43 @@
+"""Stock transfer workflow — create a new StockTransfer."""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView
+
+from edc_dashboard.view_mixins import EdcViewMixin
+from edc_navbar import NavbarViewMixin
+from edc_protocol.view_mixins import EdcProtocolViewMixin
+
+from ..forms.stock import StockTransferEditForm
+from .auths_view_mixin import PharmacistRequiredMixin
+
+
+@method_decorator(login_required, name="dispatch")
+class StockTransferEditView(
+    PharmacistRequiredMixin, EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateView
+):
+    template_name = "edc_pharmacy/stock/stock_transfer_edit.html"
+    navbar_name = settings.APP_NAME
+    navbar_selected_item = "pharmacy"
+
+    def get_context_data(self, form=None, **kwargs):
+        form = form or StockTransferEditForm()
+        return super().get_context_data(form=form, **kwargs)
+
+    def post(self, request, *args, **kwargs):  # noqa: ARG002
+        form = StockTransferEditForm(request.POST)
+        if form.is_valid():
+            obj = form.save(commit=False)
+            obj.user_created = request.user.username
+            obj.user_modified = request.user.username
+            obj.save()
+            messages.success(request, f"Stock transfer {obj.transfer_identifier} created.")
+            return HttpResponseRedirect(reverse("edc_pharmacy:stock_transfer_home_url"))
+        context = self.get_context_data(form=form)
+        return self.render_to_response(context)

--- a/src/edc_pharmacy/views/transfer_stock_view.py
+++ b/src/edc_pharmacy/views/transfer_stock_view.py
@@ -31,12 +31,17 @@ class TransferStockView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Tem
 
     def get_context_data(self, **kwargs):
         stock_transfer = StockTransfer.objects.get(pk=self.kwargs.get("stock_transfer"))
-        transferred_count = StockTransferItem.objects.filter(
+        transfer_items = StockTransferItem.objects.filter(
             stock_transfer=stock_transfer
-        ).count()
+        ).select_related(
+            "stock__current_allocation__registered_subject",
+            "stock_transfer__to_location",
+        ).order_by("transfer_item_datetime")
+        transferred_count = transfer_items.count()
         remaining_count = max(0, stock_transfer.item_count - transferred_count)
         kwargs.update(
             stock_transfer=stock_transfer,
+            transfer_items=transfer_items,
             transferred_count=transferred_count,
             remaining_count=remaining_count,
         )


### PR DESCRIPTION
## Summary

- Add **[Audit trail]** buttons to `receive_order.html`: Order summary panel (Order history), Receive record panel (Receive history), per-OrderItem panel (OrderItem history), and per-ReceiveItem row icon (ReceiveItem history)
- Remove `target="_blank"` from all audit-trail buttons in `order.html` and `receive_order.html` — links now navigate same-tab for mobile-friendly behaviour
- Wrap receive-items tables in `.table-responsive` on `receive_order.html` and `receive_order_item.html` so narrow viewports get horizontal scroll instead of overflow

## Test plan

- [ ] Open a receive record — verify Audit trail buttons appear on Order summary panel, Receive record panel, and each per-OrderItem panel
- [ ] Verify each ReceiveItem row shows a history icon button
- [ ] Click an Audit trail button — confirm it navigates same-tab (no new tab)
- [ ] On a narrow viewport (or browser devtools mobile emulation), verify the receive-items table scrolls horizontally rather than overflowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)