### PR TITLE
feat(edc-pharmacy): make StockTransferEditView dual-mode (create + edit)

### DIFF
--- a/src/edc_pharmacy/forms/stock/stock_transfer_edit_form.py
+++ b/src/edc_pharmacy/forms/stock/stock_transfer_edit_form.py
@@ -28,6 +28,27 @@ class StockTransferEditForm(forms.ModelForm):
             and cleaned_data["from_location"] == cleaned_data["to_location"]
         ):
             raise forms.ValidationError("From and To locations cannot be the same.")
+        # Once items have been scanned/transferred, lock from/to locations
+        # and don't let item_count drop below the scanned count.
+        if self.instance and self.instance.pk:
+            scanned = self.instance.stocktransferitem_set.count()
+            if scanned > 0:
+                if cleaned_data.get("from_location") != self.instance.from_location:
+                    self.add_error(
+                        "from_location",
+                        "Cannot change once items have been transferred.",
+                    )
+                if cleaned_data.get("to_location") != self.instance.to_location:
+                    self.add_error(
+                        "to_location",
+                        "Cannot change once items have been transferred.",
+                    )
+                item_count = cleaned_data.get("item_count")
+                if item_count is not None and item_count < scanned:
+                    self.add_error(
+                        "item_count",
+                        f"May not be less than the number already scanned ({scanned}).",
+                    )
         return cleaned_data
 
     class Meta:

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_transfer_edit.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_transfer_edit.html
@@ -9,11 +9,18 @@
             <div style="padding:10px;">
                 <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
                 <a href="{% url "edc_pharmacy:stock_transfer_home_url" %}">Transfer stock to site</a> &rsaquo;
-                New transfer
+                {% if stock_transfer %}
+                    <a href="{% url "edc_pharmacy:transfer_stock_url" stock_transfer=stock_transfer.pk %}">{{ stock_transfer.transfer_identifier }}</a> &rsaquo;
+                    Edit
+                {% else %}
+                    New transfer
+                {% endif %}
             </div>
 
             <div class="panel panel-default">
-                <div class="panel-heading"><b>New stock transfer</b></div>
+                <div class="panel-heading">
+                    <b>{% if stock_transfer %}Edit stock transfer <code>{{ stock_transfer.transfer_identifier }}</code>{% else %}New stock transfer{% endif %}</b>
+                </div>
                 <div class="panel-body">
                     <form method="post">
                         {% csrf_token %}
@@ -36,8 +43,13 @@
                         {% endif %}
                         <button type="submit" class="btn btn-primary btn-sm">Save</button>
                         &nbsp;
+                        {% if stock_transfer %}
+                        <a href="{% url "edc_pharmacy:transfer_stock_url" stock_transfer=stock_transfer.pk %}"
+                           class="btn btn-default btn-sm">Cancel</a>
+                        {% else %}
                         <a href="{% url "edc_pharmacy:stock_transfer_home_url" %}"
                            class="btn btn-default btn-sm">Cancel</a>
+                        {% endif %}
                     </form>
                 </div>
             </div>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_transfer_home.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_transfer_home.html
@@ -97,6 +97,11 @@
                                     <i class="fas fa-barcode"></i> Scan
                                 </a>
                             {% endif %}
+                            <a href="{% url "edc_pharmacy:stock_transfer_edit_url" stock_transfer=t.pk %}"
+                               class="btn btn-default btn-xs" style="margin-left:4px;"
+                               title="Edit transfer header">
+                                <i class="fa fa-pencil"></i> Edit
+                            </a>
                             <a href="{% url "edc_pharmacy:generate_manifest" stock_transfer=t.pk %}"
                                class="btn btn-default btn-xs" style="margin-left:4px;" target="_blank">
                                 Manifest

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/transfer_stock.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/transfer_stock.html
@@ -44,6 +44,11 @@
                     {{ stock_transfer.from_location.display_name }}
                     &nbsp;&rsaquo;&rsaquo;&nbsp;
                     {{ stock_transfer.to_location.display_name }}
+                    <a href="{% url "edc_pharmacy:stock_transfer_edit_url" stock_transfer=stock_transfer.pk %}"
+                       class="btn btn-default btn-xs pull-right"
+                       title="Edit transfer header">
+                        <i class="fa fa-pencil"></i> Edit header
+                    </a>
                 </div>
                 <div class="panel-body">
 

--- a/src/edc_pharmacy/urls.py
+++ b/src/edc_pharmacy/urls.py
@@ -125,6 +125,11 @@ urlpatterns = [
         name="stock_transfer_add_url",
     ),
     path(
+        "stock-transfer/<uuid:stock_transfer>/edit/",
+        StockTransferEditView.as_view(),
+        name="stock_transfer_edit_url",
+    ),
+    path(
         "transfer-stock/<uuid:stock_transfer>/",
         TransferStockView.as_view(),
         name="transfer_stock_url",

--- a/src/edc_pharmacy/views/stock_transfer_edit_view.py
+++ b/src/edc_pharmacy/views/stock_transfer_edit_view.py
@@ -1,4 +1,11 @@
-"""Stock transfer workflow — create a new StockTransfer."""
+"""Stock transfer workflow — create or edit a StockTransfer header.
+
+Modes:
+  - Create: ``/stock-transfer/add/`` (no URL kwarg). Saves and redirects to
+    the home page.
+  - Edit:   ``/stock-transfer/<uuid>/edit/`` (uuid kwarg). Saves and
+    redirects back to the transfer-stock page.
+"""
 
 from __future__ import annotations
 
@@ -6,6 +13,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
@@ -15,6 +23,7 @@ from edc_navbar import NavbarViewMixin
 from edc_protocol.view_mixins import EdcProtocolViewMixin
 
 from ..forms.stock import StockTransferEditForm
+from ..models import StockTransfer
 from .auths_view_mixin import PharmacistRequiredMixin
 
 
@@ -26,18 +35,40 @@ class StockTransferEditView(
     navbar_name = settings.APP_NAME
     navbar_selected_item = "pharmacy"
 
+    def get_stock_transfer(self):
+        pk = self.kwargs.get("stock_transfer")
+        if pk:
+            return get_object_or_404(StockTransfer, pk=pk)
+        return None
+
     def get_context_data(self, form=None, **kwargs):
-        form = form or StockTransferEditForm()
-        return super().get_context_data(form=form, **kwargs)
+        kwargs.pop("stock_transfer", None)
+        stock_transfer = self.get_stock_transfer()
+        form = form or StockTransferEditForm(instance=stock_transfer)
+        return super().get_context_data(
+            form=form, stock_transfer=stock_transfer, **kwargs
+        )
 
     def post(self, request, *args, **kwargs):  # noqa: ARG002
-        form = StockTransferEditForm(request.POST)
+        stock_transfer = self.get_stock_transfer()
+        form = StockTransferEditForm(request.POST, instance=stock_transfer)
         if form.is_valid():
             obj = form.save(commit=False)
-            obj.user_created = request.user.username
+            if not obj.id:
+                obj.user_created = request.user.username
             obj.user_modified = request.user.username
             obj.save()
-            messages.success(request, f"Stock transfer {obj.transfer_identifier} created.")
+            verb = "updated" if stock_transfer else "created"
+            messages.success(
+                request, f"Stock transfer {obj.transfer_identifier} {verb}."
+            )
+            if stock_transfer:
+                return HttpResponseRedirect(
+                    reverse(
+                        "edc_pharmacy:transfer_stock_url",
+                        kwargs={"stock_transfer": obj.pk},
+                    )
+                )
             return HttpResponseRedirect(reverse("edc_pharmacy:stock_transfer_home_url"))
         context = self.get_context_data(form=form)
         return self.render_to_response(context)


### PR DESCRIPTION
## Summary

Closes the asymmetry between \`StockTransferEditView\` (creation-only) and the order / repack edit views, which already handle both create and edit. Once a transfer exists, you can now fix a typo'd from/to or comment without deleting and recreating.

## What changed

| URL | Mode |
|---|---|
| \`/stock-transfer/add/\` *(existing)* | Create new transfer → redirect to home |
| \`/stock-transfer/<uuid>/edit/\` *(new)* | Edit existing → redirect to \`transfer_stock_url\` |

- **`StockTransferEditView`** — accepts optional \`stock_transfer\` URL kwarg. Mirrors \`OrderEditView\`'s dual-mode pattern.
- **`StockTransferEditForm.clean()`** — refuses changes to \`from_location\` / \`to_location\` once any \`StockTransferItem\` exists, and refuses \`item_count < scanned_count\`.
- **Templates** —
  - \`stock_transfer_edit.html\`: heading + breadcrumb + cancel target toggle on mode
  - \`stock_transfer_home.html\`: per-row \`[Edit]\` button next to Manifest
  - \`transfer_stock.html\`: \`[Edit header]\` button (pull-right) in the scan panel heading

## Test plan

- [ ] \`/stock-transfer/add/\` still creates and redirects to home (regression check)
- [ ] Per-row \`[Edit]\` on home opens the edit form pre-populated; save returns to scan page
- [ ] \`[Edit header]\` on the scan page opens the edit form; cancel returns to scan page
- [ ] Editing from/to before any item scanned: works
- [ ] Editing from/to after at least one item scanned: form rejects with \"Cannot change once items have been transferred\"
- [ ] Reducing \`item_count\` below scanned count: rejected
- [ ] PHARMACIST_ROLE gate still applies (inherited via \`PharmacistRequiredMixin\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)