### PR TITLE
fix(ui): align Scan/Edit/Manifest buttons on stock-transfer home

### DIFF
--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_transfer_home.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_transfer_home.html
@@ -85,11 +85,11 @@
                                 <span class="label label-warning">{{ row.remaining }}</span>
                             {% endif %}
                         </td>
-                        <td>
+                        <td style="white-space:nowrap;">
                             {% if row.complete %}
                                 <a href="{% url "edc_pharmacy:transfer_stock_url" stock_transfer=t.pk %}"
                                    class="btn btn-default btn-xs">
-                                    View
+                                    <i class="fas fa-barcode"></i> View
                                 </a>
                             {% else %}
                                 <a href="{% url "edc_pharmacy:transfer_stock_url" stock_transfer=t.pk %}"
@@ -100,11 +100,11 @@
                             <a href="{% url "edc_pharmacy:stock_transfer_edit_url" stock_transfer=t.pk %}"
                                class="btn btn-default btn-xs" style="margin-left:4px;"
                                title="Edit transfer header">
-                                <i class="fa fa-pencil"></i> Edit
+                                <i class="fas fa-pencil-alt"></i> Edit
                             </a>
                             <a href="{% url "edc_pharmacy:generate_manifest" stock_transfer=t.pk %}"
                                class="btn btn-default btn-xs" style="margin-left:4px;" target="_blank">
-                                Manifest
+                                <i class="fas fa-file-pdf"></i> Manifest
                             </a>
                         </td>
                     </tr>


### PR DESCRIPTION
Two causes:
- The action <td> had no white-space:nowrap, so buttons wrapped onto multiple lines on narrow viewports (the order_home action cell already has this rule).
- 'fa fa-pencil' is FontAwesome 4 syntax. The rest of the file uses FontAwesome 5 ('fas fa-…'), so the pencil glyph silently rendered as empty, leaving the Edit button visually narrower than its siblings.

Fixes:
- Add white-space:nowrap to the cell.
- Switch to 'fas fa-pencil-alt'.
- Give View/Scan a barcode icon (View previously had none) and Manifest a PDF icon, so all three buttons share an icon for visual rhythm.