### PR TITLE
ui: add prev/next icons to [Go to ordering] / [Go to repack] buttons

### DIFF
--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/receive_order.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/receive_order.html
@@ -64,10 +64,16 @@
                        class="btn btn-primary btn-sm" style="margin-top:6px;">Edit</a>
                     &nbsp;
                     <a href="{% url "edc_pharmacy:order_url" order=order.pk %}"
-                       class="btn btn-default btn-sm" style="margin-top:6px;">Go to ordering</a>
+                       class="btn btn-default btn-sm" style="margin-top:6px;"
+                       title="Previous step: ordering">
+                        <i class="fas fa-angle-double-left"></i> Go to ordering
+                    </a>
                     &nbsp;
                     <a href="{% url "edc_pharmacy:repack_home_url" %}"
-                       class="btn btn-default btn-sm" style="margin-top:6px;">Go to repack</a>
+                       class="btn btn-default btn-sm" style="margin-top:6px;"
+                       title="Next step: repack">
+                        Go to repack <i class="fas fa-angle-double-right"></i>
+                    </a>
                     <a href="{% url "edc_pharmacy_admin:edc_pharmacy_order_history" order.pk %}"
                        class="btn btn-default btn-sm pull-right"
                        style="margin-top:6px;"


### PR DESCRIPTION
Reflects the ordering → receiving → repack workflow direction. From the
receiving page:
  - 'Go to ordering' is the previous step → << on the left
  - 'Go to repack'  is the next step      → >> on the right

Uses FontAwesome 5 fa-angle-double-{left,right}, matching the rest of
the file's icon convention. Also adds title="..." tooltips so the
intent is explicit on hover.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
