### PR TITLE
ui: dedicated edit page for the Receive record header

### DIFF
--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/receive_edit.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/receive_edit.html
@@ -1,0 +1,55 @@
+{% extends edc_base_template %}
+{% load static %}
+
+{% block main %}
+    {{ block.super }}
+    <div class="container">
+        <div class="col-sm-8">
+
+            <div style="padding:10px;">
+                <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
+                <a href="{% url "edc_pharmacy:receive_home_url" %}">Receive</a> &rsaquo;
+                <a href="{% url "edc_pharmacy:receive_order_url" order=order.pk %}">{{ order.order_identifier }}</a> &rsaquo;
+                Edit receive record
+            </div>
+
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <b>Edit Receive record <code>{{ receive.receive_identifier }}</code></b>
+                </div>
+                <div class="panel-body">
+                    <form method="post">
+                        {% csrf_token %}
+                        <div class="row">
+                            {% for field in form %}
+                            <div class="col-sm-6" style="margin-bottom:12px;">
+                                <div class="form-group{% if field.errors %} has-error{% endif %}">
+                                    <label class="control-label" for="{{ field.id_for_label }}">
+                                        {{ field.label }}
+                                        {% if field.field.required %}<span style="color:red;">*</span>{% endif %}
+                                    </label>
+                                    {{ field }}
+                                    {% if field.help_text %}
+                                        <span class="help-block">{{ field.help_text }}</span>
+                                    {% endif %}
+                                    {% if field.errors %}
+                                        <span class="help-block">{{ field.errors|join:", " }}</span>
+                                    {% endif %}
+                                </div>
+                            </div>
+                            {% endfor %}
+                        </div>
+                        {% if form.non_field_errors %}
+                            <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+                        {% endif %}
+                        <button type="submit" class="btn btn-primary btn-sm">Save</button>
+                        &nbsp;
+                        <a href="{% url "edc_pharmacy:receive_order_url" order=order.pk %}"
+                           class="btn btn-default btn-sm">Cancel</a>
+                    </form>
+                </div>
+            </div>
+
+        </div>
+    </div>
+{% endblock main %}

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/receive_order.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/receive_order.html
@@ -119,7 +119,8 @@
                         </tr>
                         {% endif %}
                     </table>
-                    <a href="?edit=1#receive-panel" class="btn btn-primary btn-sm">Edit</a>
+                    <a href="{% url "edc_pharmacy:receive_edit_url" order=order.pk %}"
+                       class="btn btn-primary btn-sm">Edit</a>
                     {% if unconfirmed_count > 0 %}
                     &nbsp;
                     <form method="post" style="display:inline;">

--- a/src/edc_pharmacy/urls.py
+++ b/src/edc_pharmacy/urls.py
@@ -19,6 +19,7 @@ from .views import (
     OrderView,
     PrepareAndReviewStockRequestView,
     PrintLabelsView,
+    ReceiveEditView,
     ReceiveHomeView,
     ReceiveLotAddView,
     ReceiveOrderEditView,
@@ -246,6 +247,11 @@ urlpatterns = [
         "receive/<uuid:order>/edit/",
         ReceiveOrderEditView.as_view(),
         name="receive_order_edit_url",
+    ),
+    path(
+        "receive/<uuid:order>/header/edit/",
+        ReceiveEditView.as_view(),
+        name="receive_edit_url",
     ),
     path(
         "receive/<uuid:order>/<uuid:order_item>/",

--- a/src/edc_pharmacy/views/__init__.py
+++ b/src/edc_pharmacy/views/__init__.py
@@ -26,6 +26,7 @@ from .print_order_view import print_order_view
 from .print_return_manifest_view import print_return_manifest_view
 from .print_stock_transfer_manifest_view import print_stock_transfer_manifest_view
 from .print_stock_view import print_stock_view
+from .receive_edit_view import ReceiveEditView
 from .receive_home_view import ReceiveHomeView
 from .receive_lot_add_view import ReceiveLotAddView
 from .receive_order_edit_view import ReceiveOrderEditView

--- a/src/edc_pharmacy/views/receive_edit_view.py
+++ b/src/edc_pharmacy/views/receive_edit_view.py
@@ -1,0 +1,95 @@
+"""Receive workflow — dedicated page for editing the Receive header.
+
+Mirrors the order-edit page (clean form, nothing else on the page) so the
+[Edit] button on the Receive record panel doesn't expand into the panel
+alongside read-only data.
+
+URL:  /receive/<order>/header/edit/   name: receive_edit_url
+On save: redirect back to the per-order receive page.
+On cancel: same.
+
+Creation of a Receive record is still handled inline by ReceiveOrderView
+(when no Receive record exists), via action=save_receive POST.
+"""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.utils import timezone
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView
+
+from edc_dashboard.view_mixins import EdcViewMixin
+from edc_navbar import NavbarViewMixin
+from edc_protocol.view_mixins import EdcProtocolViewMixin
+
+from ..forms.stock import ReceiveHeaderForm
+from ..models import Order, Receive
+from .auths_view_mixin import PharmacistRequiredMixin
+
+
+@method_decorator(login_required, name="dispatch")
+class ReceiveEditView(
+    PharmacistRequiredMixin, EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, TemplateView
+):
+    template_name = "edc_pharmacy/stock/receive_edit.html"
+    navbar_name = settings.APP_NAME
+    navbar_selected_item = "pharmacy"
+
+    def get_order(self):
+        return get_object_or_404(Order, pk=self.kwargs["order"])
+
+    @staticmethod
+    def get_receive(order):
+        try:
+            return Receive.objects.get(order=order)
+        except Receive.DoesNotExist:
+            return None
+
+    def get_context_data(self, form=None, **kwargs):
+        kwargs.pop("order", None)
+        order = self.get_order()
+        receive = self.get_receive(order)
+        form = form or ReceiveHeaderForm(instance=receive)
+        return super().get_context_data(
+            order=order, receive=receive, form=form, **kwargs
+        )
+
+    def post(self, request, *args, **kwargs):  # noqa: ARG002
+        order = self.get_order()
+        receive = self.get_receive(order)
+        if receive is None:
+            messages.error(
+                request, "No receive record exists yet. Create one first."
+            )
+            return HttpResponseRedirect(
+                reverse("edc_pharmacy:receive_order_url", kwargs={"order": order.pk})
+            )
+        form = ReceiveHeaderForm(request.POST, instance=receive)
+        if form.is_valid():
+            obj = form.save(commit=False)
+            obj.order = order
+            obj.supplier = order.supplier
+            # User supplies the date; server appends the current time.
+            receive_date = form.cleaned_data["receive_date"]
+            now = timezone.localtime(timezone.now())
+            obj.receive_datetime = now.replace(
+                year=receive_date.year,
+                month=receive_date.month,
+                day=receive_date.day,
+                microsecond=0,
+            )
+            obj.user_modified = request.user.username
+            obj.save()
+            messages.success(
+                request, f"Receive record {obj.receive_identifier} updated."
+            )
+            return HttpResponseRedirect(
+                reverse("edc_pharmacy:receive_order_url", kwargs={"order": order.pk})
+            )
+        return self.render_to_response(self.get_context_data(form=form))

--- a/src/edc_pharmacy/views/receive_order_view.py
+++ b/src/edc_pharmacy/views/receive_order_view.py
@@ -116,11 +116,10 @@ class ReceiveOrderView(
         confirmed_count = stock_qs.filter(confirmed=True).count() if stock_qs else 0
         unconfirmed_count = stock_qs.filter(confirmed=False).count() if stock_qs else 0
 
-        # edit_receive=True when: no receive yet (must fill form), or ?edit=1 in URL,
-        # or the form was re-rendered after a failed POST.
-        edit_receive = (
-            receive is None or self.request.GET.get("edit") == "1" or receive_form.errors
-        )
+        # edit_receive=True when: no receive yet (must fill the create form),
+        # or the create form was re-rendered after a failed POST.
+        # (Editing an existing Receive lives on its own page — receive_edit_url.)
+        edit_receive = receive is None or receive_form.errors
 
         context.update(
             order=order,


### PR DESCRIPTION
Mirrors the order-edit pattern: the [Edit] button on the Receive record
panel now navigates to a clean form page instead of expanding inline
alongside read-only data.

- New ReceiveEditView at /receive/<order>/header/edit/ (receive_edit_url).
  Loads the existing Receive, validates via ReceiveHeaderForm, redirects
  back to the per-order receive page on save / cancel.
- New receive_edit.html — minimal layout, just the form, breadcrumb,
  Save / Cancel.
- receive_order.html: [Edit] button on the Receive record summary now
  links to receive_edit_url. Inline ?edit=1 mode dropped from the
  receive panel.
- ReceiveOrderView.edit_receive simplifies to 'no receive yet OR create
  form errors'. The query-string check is gone — editing an existing
  Receive happens on the dedicated page now.

The inline form still renders for the CREATE case (when no Receive
record exists yet) so the user can start receiving.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
