### PR TITLE
ui: rename receive page section to 'Order items' for parity with order page

### DIFF
--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/receive_order.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/receive_order.html
@@ -182,12 +182,12 @@
 
                 </div>
 
-                {# ── Items received against this order ── #}
+                {# ── Order items (with receive progress) ── #}
                 <div class="panel-body" style="border-top:1px solid #e7e7e7;">
                     <h4 style="margin-top:0;margin-bottom:12px;">
-                        Items
+                        Order items
                         <small class="text-muted">
-                            &nbsp;&mdash; received against this order
+                            &nbsp;&mdash; receive progress for this order
                         </small>
                     </h4>
 


### PR DESCRIPTION
The section that lists per-OrderItem panels (each with its receive
progress) was labelled 'Items — received against this order', which
read like a list of ReceiveItems rather than OrderItems. Now matches
the 'Order items' label used on /edc_pharmacy/order/<order>/.

Sub-heading: 'receive progress for this order' (kept on a small line so
it's clear the section also surfaces receive activity per item).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
