### PR TITLE
Tighten apply_transaction caller contract for scan-driven flows

### DIFF
--- a/src/edc_pharmacy/transaction_log/apply_transaction.py
+++ b/src/edc_pharmacy/transaction_log/apply_transaction.py
@@ -26,9 +26,7 @@ def _current_state(stock: Stock) -> CurrentState:
     storage_bin_item_cls = django_apps.get_model("edc_pharmacy", "StorageBinItem")
     has_allocation = stock.allocation is not None
     allocation_subject_identifier = (
-        stock.allocation.registered_subject.subject_identifier
-        if has_allocation
-        else ""
+        stock.allocation.registered_subject.subject_identifier if has_allocation else ""
     )
     try:
         stock.storagebinitem  # noqa: B018
@@ -79,7 +77,7 @@ def _apply_delta(stock: Stock, delta: StateDelta, **kwargs) -> dict:  # noqa: C9
     confirmation_at_location_item_cls = django_apps.get_model(
         "edc_pharmacy", "confirmationatlocationitem"
     )
-    dispense_cls = django_apps.get_model("edc_pharmacy", "dispense")
+    dispense_item_cls = django_apps.get_model("edc_pharmacy", "dispenseitem")
     storage_bin_item_cls = django_apps.get_model("edc_pharmacy", "StorageBinItem")
 
     with apply_delta_context():
@@ -186,7 +184,7 @@ def _apply_delta(stock: Stock, delta: StateDelta, **kwargs) -> dict:  # noqa: C9
         )
 
     if delta.dispense_item == "create":
-        dispense_item = dispense_cls.objects.create(
+        dispense_item = dispense_item_cls.objects.create(
             stock=stock,
             dispense=kwargs["dispense"],
         )

--- a/src/edc_pharmacy/utils/allocate_stock.py
+++ b/src/edc_pharmacy/utils/allocate_stock.py
@@ -8,7 +8,7 @@ from django.db import transaction
 from django.utils import timezone
 
 from ..constants import TXN_ALLOCATED
-from ..exceptions import AllocationError
+from ..exceptions import AllocationError, InvalidTransitionError
 from ..transaction_log import apply_transaction
 
 if TYPE_CHECKING:
@@ -64,30 +64,42 @@ def allocate_stock(
                 )
             except ObjectDoesNotExist:
                 skipped.append(f"{subject_identifier}: {code}")
-            else:
-                allocation = allocation_model_cls.objects.create(
-                    stock_request_item=stock_request_item,
-                    code=stock_obj.code,
-                    registered_subject=rs_obj,
-                    allocation_datetime=timezone.now(),
-                    allocated_by=allocated_by,
-                    user_created=user_created,
-                    created=created or timezone.now(),
-                )
-                if stock_obj.product.assignment != allocation.assignment:
-                    raise AllocationError(
-                        "Assignment mismatch. Stock must match subject assignment. "
-                        f"Allocation abandoned. See {subject_identifier} and {stock_obj}."
+                continue
+            try:
+                # Nested atomic = savepoint, so a rejected apply_transaction
+                # (or assignment mismatch) rolls back the Allocation row we
+                # just created.
+                with transaction.atomic():
+                    allocation = allocation_model_cls.objects.create(
+                        stock_request_item=stock_request_item,
+                        code=stock_obj.code,
+                        # Set the back-pointer; matches what _apply_delta
+                        # does when it creates the Allocation itself.
+                        stock=stock_obj,
+                        registered_subject=rs_obj,
+                        allocation_datetime=timezone.now(),
+                        allocated_by=allocated_by,
+                        user_created=user_created,
+                        created=created or timezone.now(),
                     )
-                apply_transaction(
-                    stock_obj,
-                    TXN_ALLOCATED,
-                    actor,
-                    allocation=allocation,
-                    registered_subject=rs_obj,
-                    stock_request_item=stock_request_item,
-                    allocated_by=allocated_by,
-                )
+                    if stock_obj.product.assignment != allocation.assignment:
+                        raise AllocationError(
+                            "Assignment mismatch. Stock must match subject "
+                            "assignment. "
+                            f"See {subject_identifier} and {stock_obj}."
+                        )
+                    apply_transaction(
+                        stock_obj,
+                        TXN_ALLOCATED,
+                        actor,
+                        allocation=allocation,
+                        registered_subject=rs_obj,
+                        stock_request_item=stock_request_item,
+                        allocated_by=allocated_by,
+                    )
+            except (InvalidTransitionError, AllocationError) as e:
+                skipped.append(f"{subject_identifier}: {code} ({e})")
+            else:
                 allocated.append(code)
     return allocated, skipped
 

--- a/src/edc_pharmacy/utils/confirm_stock_at_location.py
+++ b/src/edc_pharmacy/utils/confirm_stock_at_location.py
@@ -19,7 +19,6 @@ if TYPE_CHECKING:
     from ..models import (
         ConfirmationAtLocation,
         Location,
-        Stock,
         StockTransfer,
         StockTransferItem,
     )
@@ -35,9 +34,13 @@ def confirm_stock_at_location(
 
     Called from ConfirmStock view.
     Each code is processed independently (per-scan atomicity).
+
+    Returns ``(confirmed, already_confirmed, invalid)``.
+    Bucketing happens in-loop so a TOCTOU race (a code confirmed by a
+    concurrent request between an upfront pre-check and our select_for_update)
+    is correctly reported as ``already_confirmed`` rather than ``invalid``.
     """
     confirmed_by = request.user.username
-    stock_model_cls: type[Stock] = django_apps.get_model("edc_pharmacy.stock")
     stock_transfer_item_model_cls: type[StockTransferItem] = django_apps.get_model(
         "edc_pharmacy.stocktransferitem"
     )
@@ -53,19 +56,9 @@ def confirm_stock_at_location(
     )
 
     confirmed_codes, already_confirmed_codes, invalid_codes = [], [], []
-
     stock_codes = [s.strip() for s in stock_codes]
-    valid_codes = [obj.code for obj in stock_model_cls.objects.filter(code__in=stock_codes)]
-    invalid_codes = [c for c in stock_codes if c not in valid_codes]
-    already_confirmed_codes = [
-        obj.code
-        for obj in stock_model_cls.objects.filter(
-            stocktransferitem__stock_transfer=stock_transfer,
-            stocktransferitem__confirmationatlocationitem__isnull=False,
-        )
-        if obj.code in valid_codes
-    ]
-    for stock_code in [c for c in valid_codes if c not in already_confirmed_codes]:
+
+    for stock_code in stock_codes:
         with transaction.atomic():
             try:
                 stock_transfer_item = stock_transfer_item_model_cls.objects.select_for_update(
@@ -82,24 +75,31 @@ def confirm_stock_at_location(
                         ),
                     )
                 invalid_codes.append(stock_code)
+                continue
+            try:
+                apply_transaction(
+                    stock_transfer_item.stock,
+                    TXN_TRANSFER_RECEIVED,
+                    request.user,
+                    site_location_id=location_obj.pk,
+                    confirm_at_location=confirm_at_location,
+                    stock_transfer_item=stock_transfer_item,
+                    confirmed_datetime=timezone.now(),
+                    confirmed_by=confirmed_by,
+                )
+            except InvalidTransitionError:
+                # Stock state forbids TXN_TRANSFER_RECEIVED — typically
+                # because confirmed_at_location is already True (this code
+                # was already received, possibly by a concurrent scan).
+                already_confirmed_codes.append(stock_code)
+            except ConfirmAtLocationError as e:
+                # Domain guard failure (e.g. site/transfer mismatch). This
+                # is a genuinely invalid scan, not an already-confirmed one.
+                if request:
+                    messages.add_message(request, messages.ERROR, str(e))
+                invalid_codes.append(stock_code)
             else:
-                try:
-                    apply_transaction(
-                        stock_transfer_item.stock,
-                        TXN_TRANSFER_RECEIVED,
-                        request.user,
-                        site_location_id=location_obj.pk,
-                        confirm_at_location=confirm_at_location,
-                        stock_transfer_item=stock_transfer_item,
-                        confirmed_datetime=timezone.now(),
-                        confirmed_by=confirmed_by,
-                    )
-                except (InvalidTransitionError, ConfirmAtLocationError) as e:
-                    if request:
-                        messages.add_message(request, messages.ERROR, str(e))
-                    invalid_codes.append(stock_code)
-                else:
-                    confirmed_codes.append(stock_code)
+                confirmed_codes.append(stock_code)
     return confirmed_codes, already_confirmed_codes, invalid_codes
 
 

--- a/src/edc_pharmacy/utils/dispense.py
+++ b/src/edc_pharmacy/utils/dispense.py
@@ -5,14 +5,13 @@ from typing import TYPE_CHECKING
 from django.apps import apps as django_apps
 from django.contrib import messages
 from django.core.handlers.wsgi import WSGIRequest
-from django.db.models import QuerySet
 
 from ..constants import TXN_DISPENSED
 from ..exceptions import InvalidTransitionError
 from ..transaction_log import apply_transaction
 
 if TYPE_CHECKING:
-    from ..models import Dispense, DispenseItem, Location, Stock
+    from ..models import Dispense, Location, Stock
 
 
 def dispense(
@@ -21,56 +20,108 @@ def dispense(
     rx,
     dispensed_by: str,
     request: WSGIRequest,
-) -> QuerySet[DispenseItem]:
+) -> tuple[list[str], list[str], list[str]]:
+    """Dispense scanned stock to a subject.
+
+    Returns ``(dispensed, already_dispensed, invalid)``.
+
+    Safety policy (Option C):
+        - not-found codes are reported in ``invalid`` but do NOT abort the
+          batch (likely scan glitch / foreign barcode).
+        - unallocated stock, subject mismatch, and site mismatch are
+          clinical-safety violations and abort the entire batch — no
+          Dispense parent or DispenseItem rows are written.
+        - already-dispensed (caught from apply_transaction) is reported
+          in ``already_dispensed``.
+    """
     stock_model_cls: type[Stock] = django_apps.get_model("edc_pharmacy.stock")
     dispense_model_cls: type[Dispense] = django_apps.get_model("edc_pharmacy.dispense")
-    dispense_item_model_cls: type[DispenseItem] = django_apps.get_model(
-        "edc_pharmacy.dispenseitem"
-    )
 
-    dispense_cancelled = False
-    for stock in stock_model_cls.objects.filter(code__in=stock_codes):
-        if (
-            stock.allocation.registered_subject.subject_identifier
-            != rx.subject_identifier
-        ):
+    dispensed: list[str] = []
+    already_dispensed: list[str] = []
+    invalid: list[str] = []
+
+    stock_codes = [c.strip() for c in (stock_codes or [])]
+
+    # Phase 1: pre-flight safety check across the whole batch.
+    stocks_in_batch = list(stock_model_cls.objects.filter(code__in=stock_codes))
+    found = {s.code for s in stocks_in_batch}
+
+    # Not-found: report but do not abort.
+    for code in stock_codes:
+        if code not in found:
             messages.add_message(
                 request,
                 messages.ERROR,
-                f"Stock not allocated to subject. Got {stock.code}. Dispensing cancelled.",
+                f"Stock {code} not found. Skipped.",
             )
-            dispense_cancelled = True
-            break
-        if stock.allocation.registered_subject.site.id != stock.location.site.id:
+            invalid.append(code)
+
+    # Safety-critical checks: any failure aborts the entire batch.
+    abort_batch = False
+    for stock in stocks_in_batch:
+        allocation = stock.allocation
+        rs = getattr(allocation, "registered_subject", None) if allocation else None
+        if allocation is None or rs is None:
+            messages.add_message(
+                request,
+                messages.ERROR,
+                f"Stock {stock.code} is not allocated. Dispensing cancelled.",
+            )
+            invalid.append(stock.code)
+            abort_batch = True
+            continue
+        if rs.subject_identifier != rx.subject_identifier:
+            messages.add_message(
+                request,
+                messages.ERROR,
+                f"Stock not allocated to subject. Got {stock.code}. "
+                "Dispensing cancelled.",
+            )
+            invalid.append(stock.code)
+            abort_batch = True
+            continue
+        if stock.location is None or rs.site_id != stock.location.site_id:
             messages.add_message(
                 request,
                 messages.ERROR,
                 (
                     "Stock location does not match subject's site. "
-                    f"Stock item {stock.code} not at site "
-                    f"{stock.allocation.registered_subject.site.id}. "
+                    f"Stock item {stock.code} not at site {rs.site_id}. "
                     "Dispensing cancelled."
                 ),
             )
-            dispense_cancelled = True
-            break
+            invalid.append(stock.code)
+            abort_batch = True
+            continue
 
-    if not dispense_cancelled:
-        dispense_obj = dispense_model_cls.objects.create(
-            rx=rx, location=location, dispensed_by=dispensed_by
-        )
-        for stock in stock_model_cls.objects.filter(code__in=stock_codes):
-            try:
-                apply_transaction(stock, TXN_DISPENSED, request.user, dispense=dispense_obj)
-            except InvalidTransitionError:
-                messages.add_message(
-                    request,
-                    messages.ERROR,
-                    f"Stock already dispensed. Got {stock.code}.",
-                )
+    if abort_batch:
+        # Whole-batch abort — no Dispense parent, no items.
+        return dispensed, already_dispensed, invalid
 
-        return dispense_item_model_cls.objects.filter(dispense=dispense_obj)
-    return dispense_item_model_cls.objects.none()
+    # Phase 2: per-code apply_transaction. Only the safety-clean codes from
+    # stocks_in_batch reach here. Not-found codes are already in ``invalid``
+    # but Phase 2 proceeds for the rest.
+    if not stocks_in_batch:
+        return dispensed, already_dispensed, invalid
+
+    dispense_obj = dispense_model_cls.objects.create(
+        rx=rx, location=location, dispensed_by=dispensed_by
+    )
+    for stock in stocks_in_batch:
+        try:
+            apply_transaction(stock, TXN_DISPENSED, request.user, dispense=dispense_obj)
+        except InvalidTransitionError:
+            messages.add_message(
+                request,
+                messages.ERROR,
+                f"Stock already dispensed. Got {stock.code}.",
+            )
+            already_dispensed.append(stock.code)
+        else:
+            dispensed.append(stock.code)
+
+    return dispensed, already_dispensed, invalid
 
 
 __all__ = ["dispense"]

--- a/src/edc_pharmacy/utils/process_return_request.py
+++ b/src/edc_pharmacy/utils/process_return_request.py
@@ -66,9 +66,12 @@ def request_stock_return(
             except stock_model_cls.DoesNotExist:
                 skipped.append(code)
                 continue
-            txn = apply_transaction(stock, TXN_RETURN_REQUESTED, actor, reason=reason)
-            if txn:
-                requested.append(code)
+            try:
+                apply_transaction(stock, TXN_RETURN_REQUESTED, actor, reason=reason)
+            except InvalidTransitionError as e:
+                skipped.append(f"{code}: {e}")
+                continue
+            requested.append(code)
     return requested, skipped
 
 
@@ -189,25 +192,29 @@ def receive_return(
 
     received, skipped = [], []
     for code in stock_codes:
-        try:
-            stock = stock_model_cls.objects.get(
-                code=code,
-                invalid_state=False,
-                in_transit=True,
-                returnitem__return_request=return_request,
-            )
-        except stock_model_cls.DoesNotExist:
-            skipped.append(code)
-            continue
         with transaction.atomic():
-            apply_transaction(
-                stock,
-                TXN_RETURN_RECEIVED,
-                actor,
-                central_location_id=central_location.id,
-                reason=reason,
-            )
-        received.append(code)
+            try:
+                stock = stock_model_cls.objects.select_for_update().get(
+                    code=code,
+                    invalid_state=False,
+                    in_transit=True,
+                    returnitem__return_request=return_request,
+                )
+            except stock_model_cls.DoesNotExist:
+                skipped.append(code)
+                continue
+            try:
+                apply_transaction(
+                    stock,
+                    TXN_RETURN_RECEIVED,
+                    actor,
+                    central_location_id=central_location.id,
+                    reason=reason,
+                )
+            except InvalidTransitionError as e:
+                skipped.append(f"{code}: {e}")
+                continue
+            received.append(code)
     return received, skipped
 
 
@@ -244,19 +251,25 @@ def disposition_return(
     stock_model_cls: type[Stock] = django_apps.get_model("edc_pharmacy.stock")
     processed, skipped = [], []
     for code in stock_codes:
-        try:
-            stock = stock_model_cls.objects.get(code=code, invalid_state=False)
-        except stock_model_cls.DoesNotExist:
-            skipped.append(code)
-            continue
         with transaction.atomic():
-            apply_transaction(
-                stock,
-                txn_type,
-                actor,
-                reason=reason or f"disposition: {disposition}",
-            )
-        processed.append(code)
+            try:
+                stock = stock_model_cls.objects.select_for_update().get(
+                    code=code, invalid_state=False
+                )
+            except stock_model_cls.DoesNotExist:
+                skipped.append(code)
+                continue
+            try:
+                apply_transaction(
+                    stock,
+                    txn_type,
+                    actor,
+                    reason=reason or f"disposition: {disposition}",
+                )
+            except InvalidTransitionError as e:
+                skipped.append(f"{code}: {e}")
+                continue
+            processed.append(code)
     return processed, skipped
 
 

--- a/src/edc_pharmacy/utils/transfer_stock_to_location.py
+++ b/src/edc_pharmacy/utils/transfer_stock_to_location.py
@@ -10,7 +10,7 @@ from django.db import transaction
 from django.utils import timezone
 
 from ..constants import CENTRAL_LOCATION, TXN_TRANSFER_DISPATCHED
-from ..exceptions import StockTransferError
+from ..exceptions import InvalidTransitionError, StockTransferError
 from ..transaction_log import apply_transaction
 from ..utils import is_dispensed
 
@@ -59,20 +59,30 @@ def transfer_stock_to_location(
                 if stock_obj.dispensed:
                     dispensed_codes.append(stock_code)
                 else:
-                    stock_transfer_item = stock_transfer_item_model_cls.objects.create(
-                        stock=stock_obj,
-                        stock_transfer=stock_transfer,
-                        user_created=request.user.username,
-                        created=timezone.now(),
-                    )
-                    apply_transaction(
-                        stock_obj,
-                        TXN_TRANSFER_DISPATCHED,
-                        request.user,
-                        new_location_id=stock_transfer.to_location.id,
-                        stock_transfer_item=stock_transfer_item,
-                    )
-                    transferred.append(stock_code)
+                    try:
+                        # Nested atomic = savepoint, so a rejected
+                        # apply_transaction rolls back the StockTransferItem
+                        # row we just created.
+                        with transaction.atomic():
+                            stock_transfer_item = (
+                                stock_transfer_item_model_cls.objects.create(
+                                    stock=stock_obj,
+                                    stock_transfer=stock_transfer,
+                                    user_created=request.user.username,
+                                    created=timezone.now(),
+                                )
+                            )
+                            apply_transaction(
+                                stock_obj,
+                                TXN_TRANSFER_DISPATCHED,
+                                request.user,
+                                new_location_id=stock_transfer.to_location.id,
+                                stock_transfer_item=stock_transfer_item,
+                            )
+                    except InvalidTransitionError:
+                        skipped_codes.append(stock_code)
+                    else:
+                        transferred.append(stock_code)
 
                     if len(stock_codes) != (
                         len(unprocessed_codes)

--- a/src/edc_pharmacy/views/add_to_storage_bin_view.py
+++ b/src/edc_pharmacy/views/add_to_storage_bin_view.py
@@ -32,9 +32,14 @@ def update_bin(
     storage_bin: StorageBin,
     stock_codes: list[str],
     actor: AbstractUser | None = None,
-) -> tuple[list[str], list[str]]:
-    codes_created = []
-    codes_not_created = []
+) -> tuple[list[str], list[str], list[str]]:
+    """Add stock codes to a storage bin via TXN_STORED.
+
+    Returns ``(codes_created, codes_already_stored, codes_invalid)``.
+    """
+    codes_created: list[str] = []
+    codes_already_stored: list[str] = []
+    codes_invalid: list[str] = []
     for code in stock_codes:
         if storage_bin.location.name == CENTRAL_LOCATION:
             opts = dict(
@@ -58,20 +63,20 @@ def update_bin(
         try:
             stock_obj = Stock.objects.get(**opts)
         except ObjectDoesNotExist:
-            codes_not_created.append(code)
+            codes_invalid.append(code)
+            continue
+        try:
+            apply_transaction(
+                stock_obj,
+                TXN_STORED,
+                actor,
+                storage_bin=storage_bin,
+            )
+        except InvalidTransitionError:
+            codes_already_stored.append(code)
         else:
-            try:
-                apply_transaction(
-                    stock_obj,
-                    TXN_STORED,
-                    actor,
-                    storage_bin=storage_bin,
-                )
-            except InvalidTransitionError:
-                codes_not_created.append(code)
-            else:
-                codes_created.append(code)
-    return codes_created, codes_not_created
+            codes_created.append(code)
+    return codes_created, codes_already_stored, codes_invalid
 
 
 @method_decorator(login_required, name="dispatch")
@@ -202,7 +207,7 @@ class AddToStorageBinView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, T
             return HttpResponseRedirect(url)
         if items_to_scan and stock_codes:
             try:
-                codes_created, codes_not_created = update_bin(
+                codes_created, codes_already_stored, codes_invalid = update_bin(
                     storage_bin,
                     stock_codes,
                     actor=request.user,
@@ -215,7 +220,8 @@ class AddToStorageBinView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, T
                     messages.SUCCESS,
                     (
                         f"Updated {p.no('stock item', len(codes_created))} to bin. "
-                        f"Skipped {len(codes_not_created)}."
+                        f"Already stored: {len(codes_already_stored)}. "
+                        f"Invalid: {len(codes_invalid)}."
                     ),
                 )
             return HttpResponseRedirect(self.storage_bin_changelist_url)

--- a/src/edc_pharmacy/views/dispense_view.py
+++ b/src/edc_pharmacy/views/dispense_view.py
@@ -97,19 +97,21 @@ class DispenseView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Template
 
         if location and formulation and rx and container_count:
             if stock_codes:
-                dispense_qs = dispense(
+                dispensed, already_dispensed, invalid = dispense(
                     stock_codes,
                     location,
                     rx,
                     request.user.username,
                     request,
                 )
-                if dispense_qs:
+                if dispensed:
                     messages.add_message(
                         self.request,
                         messages.SUCCESS,
-                        f"Dispensed {dispense_qs.count()} item.",
+                        f"Dispensed {len(dispensed)} item(s).",
                     )
+                # already_dispensed and invalid emit their own ERROR
+                # messages from inside dispense(); no extra flash needed.
                 url = reverse(
                     "edc_pharmacy:dispense_url",
                     kwargs={


### PR DESCRIPTION
## Summary

Audit of scan-driven utils calling `apply_transaction` surfaced bucketing inconsistencies, uncaught `InvalidTransitionError` exceptions, and a missing `Allocation` → `Stock` back-pointer. Each finding fixed and verified against the full edc_pharmacy test suite (1615 passed, 37 skipped, 0 failures) after every change.

## Changes

- **`utils/confirm_stock_at_location.py`** — drop Phase A pre-filter, classify in-loop. `InvalidTransitionError` now correctly buckets as `already_confirmed` instead of `invalid` (also closes a TOCTOU race between the pre-filter and `select_for_update`).
- **`utils/dispense.py`** — return `(dispensed, already_dispensed, invalid)` tuple; guard `stock.allocation` / `registered_subject` dereferences against `None`; whole-batch abort on safety-critical mismatches (subject, site, unallocated) and per-code skip on not-found.
- **`utils/transfer_stock_to_location.py`** — catch `InvalidTransitionError` into `skipped_codes`; nested savepoint rolls back the orphan `StockTransferItem` on rejection.
- **`utils/process_return_request.py`** — catch `InvalidTransitionError` in `request_stock_return`, `receive_return`, and `disposition_return`; tighten `receive_return` / `disposition_return` reads with `select_for_update` inside `transaction.atomic`.
- **`views/add_to_storage_bin_view.py::update_bin`** — split 2-bucket return into `(created, already_stored, invalid)` and update view caller flash message accordingly.
- **`utils/allocate_stock.py`** — catch `InvalidTransitionError` and `AllocationError` into `skipped`; wrap in nested savepoint; set the `Allocation.stock` back-pointer on create (matches `_apply_delta`'s create path).
- **`transaction_log/apply_transaction.py`** — fix `Dispense` vs `DispenseItem` model mix-up (`get_model("dispense")` → `get_model("dispenseitem")`).

## Test plan

- [x] `python runtests.py edc_pharmacy` — 1615 passed, 37 skipped, 0 failures (re-run after each issue)
- [ ] Smoke test confirm-at-location, dispense, transfer-dispatch, return, allocate, add-to-bin flows in a staging UI
- [ ] Verify view-side flash messages render the new bucket counts (already-stored, invalid)

## Follow-ups (not in this PR)

Captured in project memory:
1. `MoveToStorageBinView::move_to_bin` bypasses `apply_transaction` (direct `StorageBinItem.save()` — no ledger entry).
2. `AddToStorageBinView.post` discards `redirect_on_*` return values, so guard redirects never fire.
3. `transfer_stock_to_location.py`'s `StockTransferError` is raised inside per-iter atomic — once a prior iteration commits, the "Cancelling transfer" wording is misleading.
4. One-shot backfill needed for legacy `Allocation.stock = NULL` rows created before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)