### PR TITLE
Backfill Allocation.stock back-pointer for legacy rows

### DIFF
--- a/src/edc_pharmacy/migrations/0157_backfill_allocation_stock_backpointer.py
+++ b/src/edc_pharmacy/migrations/0157_backfill_allocation_stock_backpointer.py
@@ -1,0 +1,52 @@
+"""Backfill Allocation.stock back-pointer for legacy rows.
+
+Stocks created via the pre-2026-05-07 ``allocate_stock`` util set
+``Stock.allocation`` but never set ``Allocation.stock`` (the reverse
+back-pointer). The forward FK is the authoritative side, so historical
+data is consistent — but readers that traverse ``allocation.stock`` see
+``None`` for any Allocation written by that code path.
+
+This migration walks every Stock whose ``allocation`` is set and whose
+linked Allocation has ``stock_id IS NULL``, then copies the back-pointer
+in via a bulk-friendly ``UPDATE``.
+
+Forward is idempotent: running it twice is a no-op on the second pass.
+Reverse is a no-op — re-NULLing rows would be unsafe once new code
+(post-2026-05-07) has correctly populated them.
+"""
+
+from django.db import migrations
+from tqdm import tqdm
+
+
+def backfill_allocation_stock(apps, schema_editor):
+    Stock = apps.get_model("edc_pharmacy", "stock")
+    Allocation = apps.get_model("edc_pharmacy", "allocation")
+
+    pairs = list(
+        Stock.objects.filter(
+            allocation__isnull=False, allocation__stock__isnull=True
+        ).values_list("allocation_id", "id")
+    )
+    if not pairs:
+        return
+
+    for allocation_id, stock_id in tqdm(pairs, total=len(pairs)):
+        Allocation.objects.filter(pk=allocation_id, stock__isnull=True).update(
+            stock_id=stock_id
+        )
+
+
+def reverse_noop(apps, schema_editor):
+    # Reversing this backfill would re-NULL rows that may be correctly
+    # set by post-migration code. Safer to be a no-op.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("edc_pharmacy", "0156_alter_historicalorder_status_and_more"),
+    ]
+
+    operations = [migrations.RunPython(backfill_allocation_stock, reverse_noop)]


### PR DESCRIPTION
## Summary

Data migration `0157_backfill_allocation_stock_backpointer.py` populates `Allocation.stock` for rows where it was left `NULL` by the pre-fix `allocate_stock` util.

Before PR #85, `utils/allocate_stock.py` created `Allocation` rows without setting the `stock=` back-pointer. The forward FK (`Stock.allocation`) was set, so domain logic worked — but any code traversing `allocation.stock` saw `None`. PR #85 fixed the create side; this PR catches up the existing rows.

## How it works

- Selects every `Stock` whose `allocation_id IS NOT NULL` and whose linked `Allocation.stock_id IS NULL`.
- For each pair, runs `Allocation.objects.filter(pk=…, stock__isnull=True).update(stock_id=…)`.
- Bulk `UPDATE` bypasses `Allocation.save()` — no `assignment` recomputation, no signal side-effects.
- Idempotent: re-running is a no-op (the `stock__isnull=True` filter on the update guards against clobbering correctly-populated rows).
- Reverse is a no-op (re-NULLing rows that post-fix code populated would corrupt them).

## Companion PR

PR #85 — `Tighten apply_transaction caller contract for scan-driven flows`. That PR fixes the create-side so new rows get the back-pointer. This migration handles the legacy data.

Order doesn't strictly matter — they're independent — but landing #85 first ensures no further `NULL` rows are produced after the migration runs.

## Test plan

- [ ] Apply migration on a copy of production data; verify no errors and `Allocation.objects.filter(stock__isnull=True, …).count()` drops to zero (modulo allocations that genuinely have no stock).
- [ ] Re-run migration; confirm idempotency (zero updates on second pass).
- [ ] Spot-check a handful of backfilled rows: `allocation.stock_id == stock.id` and `stock.allocation_id == allocation.id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)