### PR TITLE
Wire move_to_bin through apply_transaction (TXN_BIN_MOVED)

### DIFF
--- a/src/edc_pharmacy/views/move_to_storage_bin_view.py
+++ b/src/edc_pharmacy/views/move_to_storage_bin_view.py
@@ -1,14 +1,24 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import inflect
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ObjectDoesNotExist
-from django.http import HttpRequest, HttpResponseRedirect
+from django.http import HttpResponseRedirect
 from django.urls import reverse
-from django.utils import timezone
 from django.utils.decorators import method_decorator
 
+from ..constants import TXN_BIN_MOVED
+from ..exceptions import InvalidTransitionError
 from ..models import Stock, StorageBin, StorageBinItem
+from ..transaction_log import apply_transaction
 from .add_to_storage_bin_view import AddToStorageBinView, StorageBinError
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import AbstractUser
+    from django.http import HttpRequest
 
 p = inflect.engine()
 MAX_STORAGE_BIN_CAPACITY = 50
@@ -17,12 +27,20 @@ MAX_STORAGE_BIN_CAPACITY = 50
 def move_to_bin(
     storage_bin: StorageBin,
     stock_codes: list[str],
-    user_modified: str,
+    actor: AbstractUser,
     request: HttpRequest,
 ) -> tuple[list[str], list[str]]:
-    codes_moved = []
-    codes_not_moved = []
-    # update storage bin capacity
+    """Move scanned stock codes into ``storage_bin`` via TXN_BIN_MOVED.
+
+    Returns ``(codes_moved, codes_not_moved)``. Each successful move goes
+    through ``apply_transaction`` so the ledger is written and the
+    StorageBinItem replace (delete-old + create-new) happens inside
+    ``_apply_delta``.
+    """
+    codes_moved: list[str] = []
+    codes_not_moved: list[str] = []
+
+    # Capacity check (bin metadata; not stock state).
     new_capacity = StorageBinItem.objects.filter(storage_bin=storage_bin).count() + len(
         stock_codes
     )
@@ -33,13 +51,13 @@ def move_to_bin(
         )
     if new_capacity > storage_bin.capacity:
         storage_bin.capacity = new_capacity
-        storage_bin.save()
+        storage_bin.save(update_fields=["capacity"])
         messages.add_message(
             request,
             messages.INFO,
             f"Storage bin {storage_bin.name} capacity has been increased to {new_capacity}.",
         )
-    # try to move codes to target bin
+
     for code in stock_codes:
         try:
             stock_obj = Stock.objects.get(
@@ -51,19 +69,19 @@ def move_to_bin(
                 location=storage_bin.location,
             )
         except ObjectDoesNotExist:
-            stock_obj = None
             codes_not_moved.append(code)
-        if stock_obj:
-            try:
-                obj = StorageBinItem.objects.get(stock=stock_obj)
-            except ObjectDoesNotExist:
-                codes_not_moved.append(code)
-            else:
-                obj.storage_bin = storage_bin
-                obj.user_modified = user_modified
-                obj.modified = timezone.now()
-                obj.save()
-                codes_moved.append(code)
+            continue
+        try:
+            apply_transaction(
+                stock_obj,
+                TXN_BIN_MOVED,
+                actor,
+                storage_bin=storage_bin,
+            )
+        except InvalidTransitionError:
+            codes_not_moved.append(code)
+        else:
+            codes_moved.append(code)
     return codes_moved, codes_not_moved
 
 
@@ -114,7 +132,7 @@ class MoveToStorageBinView(AddToStorageBinView):
         if items_to_scan and stock_codes:
             try:
                 codes_moved, codes_not_moved = move_to_bin(
-                    storage_bin, stock_codes, request.user.username, request
+                    storage_bin, stock_codes, request.user, request
                 )
             except StorageBinError as e:
                 messages.add_message(request, messages.ERROR, str(e))


### PR DESCRIPTION
## Summary

`MoveToStorageBinView::move_to_bin` mutated `StorageBinItem.storage_bin` directly and called `obj.save()` — bypassing `apply_transaction` entirely. No ledger entry was written for bin moves.

The transaction-log infrastructure already supports the move:
- `TXN_BIN_MOVED` constant exists in `constants.py`
- `_compute_bin_moved` returns `storage_bin_item="replace"` with proper preconditions
- `_apply_delta` handles `"replace"` as delete-old + create-new

Only the util needed wiring.

## Changes

- Replace direct `obj.storage_bin = …; obj.save()` mutation with `apply_transaction(stock, TXN_BIN_MOVED, actor, storage_bin=storage_bin)`.
- Catch `InvalidTransitionError` into `codes_not_moved`.
- Drop the inner `StorageBinItem.objects.get(stock=…)` lookup — `_apply_delta` handles delete-or-noop + create.
- Signature change: `user_modified: str` → `actor: AbstractUser` (matches `update_bin` in the sibling view).
- View caller now passes `request.user` instead of `request.user.username`.
- Capacity check + `StorageBin.save` preserved (bin metadata, not stock state); switched to `save(update_fields=["capacity"])`.
- Drop unused `timezone` import.

## Test plan

- [x] `python runtests.py edc_pharmacy` — 1615 passed, 37 skipped, 0 failures
- [ ] Smoke test the Move to Storage Bin flow in a staging UI:
  - Move stock from bin A to bin B and verify a `StockTransaction` row is written with `transaction_type='BIN_MOVED'`
  - Verify the old `StorageBinItem` is deleted and a new one for the target bin exists
  - Confirm capacity-bump message still appears when the target bin auto-grows

## Related

- PR #85 — apply_transaction caller contract audit (companion fixes for the other 6 callers)
- PR #86 — Allocation.stock backfill data migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)