### PR TITLE
Fix discarded redirect returns and misleading transfer error

### DIFF
--- a/src/edc_pharmacy/utils/transfer_stock_to_location.py
+++ b/src/edc_pharmacy/utils/transfer_stock_to_location.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from copy import copy
 from typing import TYPE_CHECKING
 
 from django.apps import apps as django_apps
@@ -26,9 +25,7 @@ def transfer_stock_to_location(
         "edc_pharmacy.stocktransferitem"
     )
     transferred, dispensed_codes, skipped_codes, invalid_codes = ([], [], [], [])
-    unprocessed_codes = copy(stock_codes)
     for stock_code in stock_codes:
-        unprocessed_codes.remove(stock_code)
         if not stock_model_cls.objects.filter(code=stock_code).exists():
             invalid_codes.append(stock_code)
             continue
@@ -84,19 +81,19 @@ def transfer_stock_to_location(
                     else:
                         transferred.append(stock_code)
 
-                    if len(stock_codes) != (
-                        len(unprocessed_codes)
-                        + len(transferred)
-                        + len(dispensed_codes)
-                        + len(skipped_codes)
-                        + len(invalid_codes)
-                    ):
-                        codes = transferred + dispensed_codes + skipped_codes + invalid_codes
-                        suspect_codes = [c for c in stock_codes if c not in codes]
-                        raise StockTransferError(
-                            f"Some codes were not accounted for. Got {suspect_codes} "
-                            "Cancelling transfer"
-                        )
+    # Final accounting check. Each code should land in exactly one bucket;
+    # if the totals don't add up, that's a bucketing-logic bug. Raise after
+    # the loop so the message is honest about partial commits — per-iteration
+    # atomicity means earlier transfers cannot be rolled back from here.
+    accounted = transferred + dispensed_codes + skipped_codes + invalid_codes
+    if len(stock_codes) != len(accounted):
+        suspect_codes = [c for c in stock_codes if c not in accounted]
+        raise StockTransferError(
+            f"Some codes were not accounted for during transfer: "
+            f"{suspect_codes}. Earlier successful transfers may have "
+            f"already committed (per-iteration atomicity)."
+        )
+
     return transferred, dispensed_codes, skipped_codes, invalid_codes
 
 

--- a/src/edc_pharmacy/views/add_to_storage_bin_view.py
+++ b/src/edc_pharmacy/views/add_to_storage_bin_view.py
@@ -193,9 +193,17 @@ class AddToStorageBinView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, T
         if items_to_scan:
             items_to_scan = int(items_to_scan)
 
-        self.redirect_on_has_duplicates(stock_codes, storage_bin)
-        self.redirect_on_invalid_subject_for_location(stock_codes, storage_bin)
-        self.redirect_on_stock_already_in_bin(stock_codes, storage_bin)
+        # Each guard helper returns an HttpResponseRedirect or None;
+        # short-circuit on the first redirect so the guard actually fires.
+        redirect = self.redirect_on_has_duplicates(stock_codes, storage_bin)
+        if redirect:
+            return redirect
+        redirect = self.redirect_on_invalid_subject_for_location(stock_codes, storage_bin)
+        if redirect:
+            return redirect
+        redirect = self.redirect_on_stock_already_in_bin(stock_codes, storage_bin)
+        if redirect:
+            return redirect
         if items_to_scan and not stock_codes:
             url = reverse(
                 "edc_pharmacy:add_to_storage_bin_url",

--- a/src/edc_pharmacy/views/move_to_storage_bin_view.py
+++ b/src/edc_pharmacy/views/move_to_storage_bin_view.py
@@ -118,8 +118,14 @@ class MoveToStorageBinView(AddToStorageBinView):
         if items_to_scan:
             items_to_scan = int(items_to_scan)
 
-        self.redirect_on_has_duplicates(stock_codes, storage_bin)
-        self.redirect_on_stock_not_already_in_a_bin(stock_codes, storage_bin)
+        # Each guard helper returns an HttpResponseRedirect or None;
+        # short-circuit on the first redirect so the guard actually fires.
+        redirect = self.redirect_on_has_duplicates(stock_codes, storage_bin)
+        if redirect:
+            return redirect
+        redirect = self.redirect_on_stock_not_already_in_a_bin(stock_codes, storage_bin)
+        if redirect:
+            return redirect
         if items_to_scan and not stock_codes:
             url = reverse(
                 "edc_pharmacy:move_to_storage_bin_url",


### PR DESCRIPTION
## Summary

Two related post-flow correctness issues surfaced during the `apply_transaction` caller audit (PR #85).

## Changes

### 1. Storage-bin view guard redirects actually fire

`AddToStorageBinView.post` and `MoveToStorageBinView.post` called their `redirect_on_*` guard helpers without using the returned `HttpResponseRedirect`. Each helper added a flash error message *and* returned a redirect — but the redirect was discarded, so the user proceeded past the check while seeing the error message. Now: assign the return value and short-circuit on the first truthy one.

Affects:
- `AddToStorageBinView.post` — three guards (`redirect_on_has_duplicates`, `redirect_on_invalid_subject_for_location`, `redirect_on_stock_already_in_bin`)
- `MoveToStorageBinView.post` — two guards (`redirect_on_has_duplicates`, `redirect_on_stock_not_already_in_a_bin`)

### 2. Honest `StockTransferError` in `transfer_stock_to_location`

The consistency check raised `StockTransferError("Cancelling transfer")` from **inside** the per-iteration `transaction.atomic()`. Because each iteration is its own atomic, the raise only rolled back the current iteration — earlier successful transfers were already committed. The "Cancelling transfer" wording was a lie.

Fix: move the check to run once **after** the loop ends, and reword the error to acknowledge that partial commits may exist. Drop the now-unused `unprocessed_codes` bookkeeping and the `from copy import copy` import.

The check is still useful as a defensive bucketing-bug detector (each code should land in exactly one of `transferred`/`dispensed_codes`/`skipped_codes`/`invalid_codes`); it just no longer claims to do something it can't.

## Test plan

- [x] `python runtests.py edc_pharmacy` — 1615 passed, 37 skipped, 0 failures
- [ ] Smoke test add-to-bin / move-to-bin flows: trigger each guard (duplicates, wrong location, already in bin / not in any bin) and verify the user is actually redirected, not just shown a flash message
- [ ] Smoke test stock transfer with a deliberately bogus code in the batch to confirm the post-loop error message correctly identifies the bucket gap (if it ever triggers in practice)

## Related

- PR #85 — apply_transaction caller contract audit (origin of both findings)
- PR #87 — `move_to_bin` wired through `TXN_BIN_MOVED` (independent; both touch `MoveToStorageBinView` but in disjoint spots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)