### PR TITLE
Add bidirectional Allocation back-pointer check to check_stock_ledger

### DIFF
--- a/src/edc_pharmacy/management/commands/check_stock_ledger.py
+++ b/src/edc_pharmacy/management/commands/check_stock_ledger.py
@@ -9,6 +9,12 @@ discrepancy.
 Quantity columns (qty_in / qty_out / unit_qty_in / unit_qty_out) are
 checked separately using ledger deltas.
 
+In addition, the bidirectional Stock <-> Allocation FK consistency is
+verified: for every Stock with ``allocation_id IS NOT NULL``, the
+linked ``Allocation.stock_id`` must point back at it.  This catches
+both the legacy NULL back-pointer (fixed by migration 0157) and any
+exotic divergence.
+
 Stocks with no transactions are reported as a distinct group; they
 indicate either genuinely inert stock (never confirmed) or a gap in the
 ledger that may need investigation.
@@ -232,6 +238,32 @@ def _compare(stock: Stock, expected: dict) -> dict[str, dict]:
     return mismatches
 
 
+def _check_allocation_backpointer(stock: Stock) -> dict | None:
+    """Verify bidirectional Stock <-> Allocation FK consistency.
+
+    Invariant: for every Stock whose ``allocation_id`` is not NULL, the
+    linked ``Allocation.stock_id`` must equal that Stock's id.  The
+    forward FK (``Stock.allocation``) is authoritative; the reverse
+    (``Allocation.stock``) is the back-pointer set inside
+    ``_apply_delta`` and (post-fix) in ``utils/allocate_stock``.
+
+    Catches:
+      * ``Allocation.stock_id IS NULL`` — the legacy regression backfilled
+        by migration 0157 and the create-side fix in PR #85.
+      * ``Allocation.stock_id`` pointing at a different Stock — a more
+        exotic divergence that would suggest a bug elsewhere.
+
+    Returns a discrepancy dict ``{expected, actual}`` if inconsistent,
+    else ``None``.
+    """
+    if stock.allocation_id is None:
+        return None
+    actual = stock.allocation.stock_id
+    if actual == stock.id:
+        return None
+    return {"expected": stock.id, "actual": actual}
+
+
 class Command(BaseCommand):
     help = (
         "Verify Stock cache columns are consistent with the StockTransaction "
@@ -284,6 +316,10 @@ class Command(BaseCommand):
 
             expected = _replay(txns)
             mismatches = _compare(stock, expected)
+
+            bp = _check_allocation_backpointer(stock)
+            if bp:
+                mismatches["allocation_backpointer"] = bp
 
             if mismatches:
                 discrepancy_count += 1


### PR DESCRIPTION
## Summary

Adds a defensive consistency check to `check_stock_ledger` that asserts: for every `Stock` with `allocation_id IS NOT NULL`, the linked `Allocation.stock_id` must point back at it.

Catches:
- `Allocation.stock_id IS NULL` — the legacy regression backfilled by migration 0157 (PR #86) and fixed at the create-side in PR #85.
- `Allocation.stock_id` pointing at a different `Stock` — an exotic divergence that would indicate a bug elsewhere.

This is the "nice-to-have" follow-up noted at the close of the audit work. Belt-and-suspenders: both the create-side fix and the migration are already in place; this just makes future regressions show up at deploy-time verification rather than as silent NULLs that readers trip on later.

## Changes

- New `_check_allocation_backpointer(stock)` helper returning a `{expected, actual}` discrepancy dict (or `None`).
- Wired into the main loop after `_compare`; any mismatch is merged into the existing `mismatches` dict under the key `"allocation_backpointer"`. The existing discrepancy printer handles arbitrary keys, so no output format changes were needed.
- Module docstring extended to advertise the new check.
- No extra queries: the queryset already `select_related("allocation")`.

## Test plan

- [x] `python runtests.py edc_pharmacy` — 1615 passed, 37 skipped, 0 failures
- [ ] Run `manage.py check_stock_ledger` against a production-shape database after deploy — should still exit 0
- [ ] Synthetic regression test: temporarily NULL one `Allocation.stock_id` row and confirm the check flags it with the expected vs. actual ids

## Related

- PR #85 — apply_transaction caller contract audit (fixed the create-side)
- PR #86 — Allocation.stock backfill migration
- PR #88 — `fix_historical_stock_state` companion (idempotent backfill)
- PR #92 — 4.0.0 upgrade guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)