### PR TITLE
Add 4.0.0 upgrade verification runbook

### DIFF
--- a/src/edc_pharmacy/docs/UPGRADE_4.0_runbook.md
+++ b/src/edc_pharmacy/docs/UPGRADE_4.0_runbook.md
@@ -1,0 +1,408 @@
+# edc-pharmacy 4.0.0 — upgrade verification runbook
+
+A practical runbook for verifying a 4.0.0 upgrade against a staging copy of production data **before** running it for real on production.
+
+Companion to `UPGRADE_4.0.md`, which documents *what* changed. This file is *how to confirm the change is safe in your data*.
+
+The expected output of this runbook is a short go/no-go report (template at the bottom).
+
+---
+
+## 0. Prerequisites
+
+- Most recent production database backup, restored to a **staging** database.
+- A staging deployment running the 4.0.0 code, pointed at that database.
+- Network/auth set up so you can run `manage.py` commands and `manage.py shell` against the staging DB.
+- Substitute `<your.settings>` below with your settings module (e.g. `meta_edc.settings.staging`).
+
+---
+
+## 1. Pre-upgrade invariant snapshot
+
+Run this **before** any migration. The output is your baseline for the diff in step 5.
+
+```python
+# scripts/pre_upgrade_invariants.py
+# Run via: manage.py shell --settings=<your.settings> < scripts/pre_upgrade_invariants.py
+import json
+from decimal import Decimal
+from django.db.models import Sum
+
+from edc_pharmacy.models import (
+    Allocation,
+    DispenseItem,
+    Stock,
+    StockTransferItem,
+    StorageBinItem,
+    ConfirmationAtLocationItem,
+)
+
+
+def _as_int(x):
+    return int(x or 0)
+
+
+def _as_str_dec(x):
+    return str(x or Decimal("0"))
+
+
+snapshot = {
+    # Totals — must NOT change across upgrade.
+    "stocks_total": Stock.objects.count(),
+    "dispense_items": DispenseItem.objects.count(),
+    "stock_transfer_items": StockTransferItem.objects.count(),
+    "storage_bin_items": StorageBinItem.objects.count(),
+    "confirmation_at_location_items": ConfirmationAtLocationItem.objects.count(),
+
+    # Stock cache columns — must NOT change across upgrade (the whole point
+    # of `fix_historical_stock_state` is that the corrections are idempotent
+    # *given the current data*).
+    "stocks_confirmed": Stock.objects.filter(confirmed=True).count(),
+    "stocks_confirmed_at_location": Stock.objects.filter(confirmed_at_location=True).count(),
+    "stocks_in_transit": Stock.objects.filter(in_transit=True).count(),
+    "stocks_stored_at_location": Stock.objects.filter(stored_at_location=True).count(),
+    "stocks_dispensed": Stock.objects.filter(dispensed=True).count(),
+    "stocks_allocated": Stock.objects.filter(allocation__isnull=False).count(),
+
+    # Aggregate qty — must NOT change.
+    "qty_in_total": _as_str_dec(Stock.objects.aggregate(s=Sum("qty_in"))["s"]),
+    "qty_out_total": _as_str_dec(Stock.objects.aggregate(s=Sum("qty_out"))["s"]),
+    "unit_qty_in_total": _as_str_dec(Stock.objects.aggregate(s=Sum("unit_qty_in"))["s"]),
+    "unit_qty_out_total": _as_str_dec(Stock.objects.aggregate(s=Sum("unit_qty_out"))["s"]),
+
+    # Allocation counts. Note: in 3.1.5 Allocation was a OneToOneField and
+    # the row was deleted when stock was dispensed. In 4.0.0 it's a sticky
+    # ForeignKey and rows may accumulate (ended_datetime IS NOT NULL). The
+    # pre-snapshot number is therefore a LOWER bound on the post-snapshot.
+    "allocations": Allocation.objects.count(),
+
+    # Subjects with at least one allocated stock — should not change.
+    "subjects_with_allocations": (
+        Allocation.objects.values("subject_identifier").distinct().count()
+    ),
+
+    # Allocation back-pointer health — pre-upgrade many will be NULL; that's
+    # the legacy bug. Post-upgrade should be zero.
+    "allocations_with_null_stock": Allocation.objects.filter(stock__isnull=True).count(),
+}
+
+with open("upgrade_invariants_pre.json", "w") as f:
+    json.dump(snapshot, f, indent=2, sort_keys=True)
+print(json.dumps(snapshot, indent=2, sort_keys=True))
+```
+
+```bash
+mkdir -p scripts
+# Save the script above as scripts/pre_upgrade_invariants.py, then:
+uv run --dev manage.py shell --settings=<your.settings> < scripts/pre_upgrade_invariants.py
+```
+
+Outputs `upgrade_invariants_pre.json` in the project working directory and prints the same to stdout.
+
+---
+
+## 2. Dry-runs
+
+Before mutating anything, see what's coming.
+
+```bash
+uv run --dev manage.py migrate --plan --settings=<your.settings>
+uv run --dev manage.py fix_historical_stock_state --dry-run --settings=<your.settings>
+uv run --dev manage.py bootstrap_stock_transactions --dry-run --settings=<your.settings>
+```
+
+Record:
+- [ ] Migrations listed (expect `0139`–`0157`)
+- [ ] `fix_historical_stock_state` per-rule counts:
+  - [ ] `[in_transit]` count
+  - [ ] `[allocation]` count
+  - [ ] `[stored_at_location]` count
+  - [ ] `[qty_delta]` count
+  - [ ] `[repack_consumed]` count
+  - [ ] `[repack_consumed_qty_delta]` count
+  - [ ] `[invalid]` count
+  - [ ] `[bulk_location]` count
+  - [ ] `[repack_child_location]` count
+  - [ ] `[bootstrapped_txn_locations]` count
+  - [ ] `[allocation_backpointer]` count
+- [ ] `bootstrap_stock_transactions` "would create N transactions" count
+
+Counts that are surprising (e.g. all zeros, or wildly larger than expected) are a flag to investigate before running for real.
+
+---
+
+## 3. The upgrade sequence
+
+Time each step. On any non-zero exit, **stop and investigate** — don't run the next step.
+
+```bash
+time uv run --dev manage.py migrate --settings=<your.settings> && \
+time uv run --dev manage.py fix_historical_stock_state --settings=<your.settings> && \
+time uv run --dev manage.py bootstrap_stock_transactions --settings=<your.settings> && \
+time uv run --dev manage.py fix_historical_stock_state --settings=<your.settings> && \
+time uv run --dev manage.py check_stock_ledger --settings=<your.settings>
+```
+
+Record wall-clock times — they bound your production maintenance window.
+
+`check_stock_ledger` exit 0 is the **gate**. On non-zero exit, run with `--stock-code <code>` for each reported code to debug.
+
+---
+
+## 4. Post-upgrade invariant snapshot
+
+```python
+# scripts/post_upgrade_invariants.py
+# Same script as pre, but writes to a different file. Just copy and
+# change the output filename, or refactor into one script with a CLI arg.
+import json
+from decimal import Decimal
+from django.db.models import Sum
+
+from edc_pharmacy.models import (
+    Allocation,
+    DispenseItem,
+    Stock,
+    StockTransaction,
+    StockTransferItem,
+    StorageBinItem,
+    ConfirmationAtLocationItem,
+)
+
+
+def _as_str_dec(x):
+    return str(x or Decimal("0"))
+
+
+snapshot = {
+    # Same fields as pre.
+    "stocks_total": Stock.objects.count(),
+    "dispense_items": DispenseItem.objects.count(),
+    "stock_transfer_items": StockTransferItem.objects.count(),
+    "storage_bin_items": StorageBinItem.objects.count(),
+    "confirmation_at_location_items": ConfirmationAtLocationItem.objects.count(),
+    "stocks_confirmed": Stock.objects.filter(confirmed=True).count(),
+    "stocks_confirmed_at_location": Stock.objects.filter(confirmed_at_location=True).count(),
+    "stocks_in_transit": Stock.objects.filter(in_transit=True).count(),
+    "stocks_stored_at_location": Stock.objects.filter(stored_at_location=True).count(),
+    "stocks_dispensed": Stock.objects.filter(dispensed=True).count(),
+    "stocks_allocated": Stock.objects.filter(allocation__isnull=False).count(),
+    "qty_in_total": _as_str_dec(Stock.objects.aggregate(s=Sum("qty_in"))["s"]),
+    "qty_out_total": _as_str_dec(Stock.objects.aggregate(s=Sum("qty_out"))["s"]),
+    "unit_qty_in_total": _as_str_dec(Stock.objects.aggregate(s=Sum("unit_qty_in"))["s"]),
+    "unit_qty_out_total": _as_str_dec(Stock.objects.aggregate(s=Sum("unit_qty_out"))["s"]),
+    "allocations": Allocation.objects.count(),
+    "subjects_with_allocations": (
+        Allocation.objects.values("subject_identifier").distinct().count()
+    ),
+    "allocations_with_null_stock": Allocation.objects.filter(stock__isnull=True).count(),
+
+    # Post-upgrade additions: ledger health.
+    "stock_transactions_total": StockTransaction.objects.count(),
+    "stocks_with_ledger": (
+        Stock.objects.filter(transactions__isnull=False).distinct().count()
+    ),
+    "stocks_without_ledger": (
+        Stock.objects.filter(transactions__isnull=True).count()
+    ),
+    "allocations_active": Allocation.objects.filter(ended_datetime__isnull=True).count(),
+    "allocations_ended": Allocation.objects.filter(ended_datetime__isnull=False).count(),
+}
+
+with open("upgrade_invariants_post.json", "w") as f:
+    json.dump(snapshot, f, indent=2, sort_keys=True)
+print(json.dumps(snapshot, indent=2, sort_keys=True))
+```
+
+```bash
+uv run --dev manage.py shell --settings=<your.settings> < scripts/post_upgrade_invariants.py
+```
+
+---
+
+## 5. Diff the snapshots
+
+```python
+# scripts/diff_upgrade_invariants.py
+# Run: python scripts/diff_upgrade_invariants.py
+import json
+
+with open("upgrade_invariants_pre.json") as f:
+    pre = json.load(f)
+with open("upgrade_invariants_post.json") as f:
+    post = json.load(f)
+
+MUST_NOT_CHANGE = (
+    "stocks_total",
+    "dispense_items",
+    "stock_transfer_items",
+    "storage_bin_items",
+    "confirmation_at_location_items",
+    "qty_in_total",
+    "qty_out_total",
+    "unit_qty_in_total",
+    "unit_qty_out_total",
+    "subjects_with_allocations",
+)
+EXPECTED_TO_ZERO = ("allocations_with_null_stock",)
+EXPECTED_TO_GROW = ("allocations",)  # sticky-pointer accumulation
+EXPECTED_TO_APPEAR = ("stock_transactions_total",)  # was ~0 pre-bootstrap
+
+print("=== MUST_NOT_CHANGE ===")
+for k in MUST_NOT_CHANGE:
+    pre_v, post_v = pre.get(k), post.get(k)
+    marker = "OK" if pre_v == post_v else "*** DRIFT ***"
+    print(f"  {marker:14s} {k}: pre={pre_v} post={post_v}")
+
+print("\n=== EXPECTED_TO_ZERO post-upgrade ===")
+for k in EXPECTED_TO_ZERO:
+    post_v = post.get(k)
+    marker = "OK" if post_v == 0 else "*** NOT ZERO ***"
+    print(f"  {marker:18s} {k}: post={post_v}")
+
+print("\n=== EXPECTED_TO_GROW ===")
+for k in EXPECTED_TO_GROW:
+    pre_v, post_v = pre.get(k), post.get(k)
+    marker = "OK" if post_v >= pre_v else "*** SHRANK ***"
+    print(f"  {marker:16s} {k}: pre={pre_v} post={post_v}")
+
+print("\n=== EXPECTED_TO_APPEAR ===")
+for k in EXPECTED_TO_APPEAR:
+    post_v = post.get(k)
+    marker = "OK" if post_v > 0 else "*** STILL ZERO ***"
+    print(f"  {marker:18s} {k}: post={post_v}")
+
+print("\n=== Cached-column counts (compare visually) ===")
+for k in (
+    "stocks_confirmed",
+    "stocks_confirmed_at_location",
+    "stocks_in_transit",
+    "stocks_stored_at_location",
+    "stocks_dispensed",
+    "stocks_allocated",
+):
+    print(f"  {k}: pre={pre.get(k)} post={post.get(k)}")
+```
+
+Eyeball the cached-column counts. They *may* change slightly if `fix_historical_stock_state` corrected stuck-true flags (e.g. `in_transit`). Cross-reference any change against the `fix_historical_stock_state` output from step 3 — if the rule fired, the delta is expected and quantifiable.
+
+---
+
+## 6. Spot-check sample stocks
+
+For each of these lifecycle shapes, pick a couple of stock codes and walk the ledger in `manage.py shell`. Use codes you recognize.
+
+```python
+from edc_pharmacy.models import Stock
+def walk(code):
+    s = Stock.objects.get(code=code)
+    print(f"\n=== {code} ===")
+    print(f"  state: confirmed={s.confirmed} in_transit={s.in_transit} "
+          f"stored={s.stored_at_location} dispensed={s.dispensed} "
+          f"location={s.location} allocation={s.allocation_id}")
+    for t in s.transactions.order_by("transaction_datetime"):
+        print(f"  {t.transaction_datetime:%Y-%m-%d %H:%M}  {t.transaction_type:24s} "
+              f"qty_delta={t.qty_delta} unit_qty_delta={t.unit_qty_delta}")
+```
+
+Shapes worth picking on purpose:
+- [ ] A stock currently at central, confirmed, never dispensed — expect only `TXN_RECEIVED`
+- [ ] A stock dispensed at a site — expect RECEIVED → ALLOCATED → TRANSFER_DISPATCHED → TRANSFER_RECEIVED → STORED → DISPENSED
+- [ ] A stock transferred more than once (central → site → central → site if your study has this)
+- [ ] A child of a repack (`stock.repack_request_id IS NOT NULL`) — expect TXN_REPACK_PRODUCED
+- [ ] A bulk parent of a repack — expect TXN_REPACK_CONSUMED on the parent
+- [ ] A stock marked `invalid_state=True` (the three known cases UGNXMR, 4992XB, 94UQKG, or however many your DB has)
+- [ ] A stock with `damaged`/`expired`/`lost`/`voided` set — expect a corresponding `TXN_*` adjustment row
+
+---
+
+## 7. UI smoke test on staging
+
+Each row = one workflow exercise. Tick when you've completed it on staging and verified the listed expectations.
+
+| # | Flow | Action | Expect |
+|---|---|---|---|
+| [ ] | Receive | Confirm a labelled stock via "Confirm labelled stock" | `TXN_RECEIVED` row written, `Stock.confirmed=True`, success message |
+| [ ] | Receive — already confirmed | Re-scan a code that was just confirmed | Bucketed as `already_confirmed`, NOT counted as invalid |
+| [ ] | Receive — invalid | Scan a foreign barcode | Bucketed as `invalid` |
+| [ ] | Allocate | Allocate via AllocateToSubjectView | `TXN_ALLOCATED`, `Allocation.stock` populated (not NULL) |
+| [ ] | Transfer dispatch | Dispatch a transfer | `TXN_TRANSFER_DISPATCHED`, `in_transit=True` |
+| [ ] | Transfer receive | Scan at receiving site | `TXN_TRANSFER_RECEIVED`, `confirmed_at_location=True`, `in_transit=False` |
+| [ ] | Store in bin | Add to storage bin | `TXN_STORED`, `stored_at_location=True`, `StorageBinItem` created |
+| [ ] | Store — already stored | Re-scan into the same bin | Bucketed as `already_stored` (NEW: separate from `invalid`) |
+| [ ] | Move bin | Move from bin A to bin B | `TXN_BIN_MOVED`, old `StorageBinItem` deleted, new one in bin B |
+| [ ] | Dispense | Scan to a subject | `TXN_DISPENSED`, ledger qty_delta=-1 |
+| [ ] | Dispense — wrong subject | Scan a stock allocated to a different subject | Whole batch aborts (NEW safety policy) |
+| [ ] | Dispense — already dispensed | Re-scan an already-dispensed code | Bucketed as `already_dispensed` |
+| [ ] | Adjust — lost | Mark a stock as lost via the stock-adjustment view | `TXN_LOST`, `Stock.lost=True` |
+| [ ] | Adjust — qty | Apply a quantity adjustment | `TXN_ADJUSTED`, ledger qty/unit_qty deltas right |
+| [ ] | Return — request | Mark stock for return | `TXN_RETURN_REQUESTED`, `Stock.return_requested=True` |
+| [ ] | Return — dispatch | Site dispatches return | `TXN_RETURN_DISPATCHED`, `in_transit=True`, `ReturnItem` created |
+| [ ] | Return — receive | Central confirms receipt | `TXN_RETURN_RECEIVED` |
+| [ ] | Return — repool | Disposition as repool | `TXN_RETURN_DISPOSITION_REPOOLED`, `Stock.allocation` cleared, ready for re-allocate |
+| [ ] | Return — quarantine | Disposition as quarantine | `TXN_RETURN_DISPOSITION_QUARANTINED`, `Stock.quarantined=True` |
+| [ ] | Return — destroy | Disposition as destroy | `TXN_RETURN_DISPOSITION_DESTROYED`, `Stock.destroyed=True` |
+| [ ] | Stock-take | Run a stock take on a bin with a mix of expected and missing codes | StockTake/StockTakeItem rows; results page renders matched/missing/unexpected counts |
+| [ ] | Guard redirects (NEW fix) | POST add-to-bin with duplicate codes in form | Redirect actually fires (was a silent error in 3.1.x) |
+| [ ] | Ledger viewer | Open `LedgerView` for one of your spot-check stocks | Reads the full ledger you walked in step 6 |
+
+---
+
+## 8. Performance findings
+
+Capture wall-clock times from step 3 here. These define your production maintenance window.
+
+| Step | Time | Notes |
+|---|---|---|
+| `migrate` | _____ | |
+| `fix_historical_stock_state` (1st) | _____ | |
+| `bootstrap_stock_transactions` | _____ | Single longest step. If > deploy window, consider `--stock-code` slicing. |
+| `fix_historical_stock_state` (2nd) | _____ | |
+| `check_stock_ledger` | _____ | |
+| Total | _____ | |
+
+---
+
+## 9. Go/no-go report template
+
+Copy and fill before production deploy.
+
+```
+edc-pharmacy 4.0.0 staging verification — <DATE>
+=================================================
+
+DB snapshot:                <prod backup tag/date>
+Staging environment:        <hostname / branch>
+Staging upgrade run by:     <name>
+
+1. Pre-upgrade invariants captured:           [ ] Y / [ ] N
+2. Dry-runs ran cleanly:                      [ ] Y / [ ] N
+3. Upgrade sequence completed (all 5 steps):  [ ] Y / [ ] N
+   - check_stock_ledger exit code:            _____
+4. Post-upgrade invariants captured:          [ ] Y / [ ] N
+5. Invariant diff:
+   - MUST_NOT_CHANGE rows drift:              [ ] none / [ ] see notes
+   - allocations_with_null_stock post:        _____
+   - stock_transactions_total post:           _____
+6. Spot-check sample (>= 5 lifecycle shapes): [ ] Y / [ ] N
+7. UI smoke test rows passed:                 _____ / _____
+8. Performance acceptable for prod window:    [ ] Y / [ ] N
+
+Anomalies found / resolved:
+  - …
+
+Outstanding concerns (must clear before prod):
+  - …
+
+GO / NO-GO:        [ ] GO    [ ] NO-GO
+Signed:            ________________________
+Date:              ____ - ____ - ________
+```
+
+---
+
+## See also
+
+- `UPGRADE_4.0.md` — what changed in 4.0.0 and why
+- `DESIGN_transaction_log.md` — architecture rationale
+- `workflow.md` — pharmacy operational flows


### PR DESCRIPTION
## Summary

Adds `src/edc_pharmacy/docs/UPGRADE_4.0_runbook.md` — a practical pre-prod verification runbook to complement the upgrade guide in PR #92.

`UPGRADE_4.0.md` (PR #92) answers "what changed and what needs updating."
`UPGRADE_4.0_runbook.md` (this PR) answers "how do I confirm it's safe in *my* data before running it on production."

## Contents

- Pre-upgrade invariant snapshot script — captures baseline counts, sums, NULL back-pointer count.
- Dry-run section — what to record from each `--dry-run` so surprises are flagged before commit.
- The full upgrade sequence with `time` around each step.
- Post-upgrade invariant snapshot script + diff script that classifies each metric as MUST_NOT_CHANGE / EXPECTED_TO_ZERO / EXPECTED_TO_GROW / EXPECTED_TO_APPEAR.
- Spot-check lifecycle shapes worth picking deliberately (multi-transfer, repack parent/child, invalid_state, damaged/expired/lost/voided).
- UI smoke-test checklist (~25 rows) covering every scan-driven workflow plus the new safety policies (whole-batch dispense abort, three-bucket counts) and the redirect-fires fix.
- Performance findings template.
- Go/no-go report template for the final sign-off.

## Test plan

- [ ] Reviewer walks through the runbook against a staging copy of production data and reports any step that's unclear or missing context.
- [ ] After running once for real, capture any fixes or additions back into this doc.

## Related

- PR #92 — UPGRADE_4.0.md (the "what changed" guide)
- PR #93 — back-pointer check added to `check_stock_ledger` (used in step 3 of this runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)