### PR TITLE
confirm-at-location: Number of items input + multi-page scan flow

### DIFF
--- a/src/edc_pharmacy/forms/stock/__init__.py
+++ b/src/edc_pharmacy/forms/stock/__init__.py
@@ -1,3 +1,7 @@
+from .confirm_at_location_entry_form import (
+    SCAN_GRID_PAGE_SIZE,
+    ConfirmAtLocationEntryForm,
+)
 from .confirmation_form import ConfirmationForm
 from .container_form import ContainerForm
 from .container_type_form import ContainerTypeForm

--- a/src/edc_pharmacy/forms/stock/confirm_at_location_entry_form.py
+++ b/src/edc_pharmacy/forms/stock/confirm_at_location_entry_form.py
@@ -1,0 +1,135 @@
+"""Form for the initial /confirm-at-location/ entry page.
+
+Captures Location + Reference (manifest identifier) + Number of items
+the user intends to receive in this session. The number cannot exceed
+the count of unconfirmed items still on the manifest.
+
+The scan workflow that follows is **multi-page**: the scan grid shows
+at most ``SCAN_GRID_PAGE_SIZE`` inputs per page. A "Number of items"
+of 53 therefore produces six pages (10 + 10 + 10 + 10 + 10 + 3).
+``SCAN_GRID_PAGE_SIZE`` is a UI page-size constant, not a cap on input.
+
+The caller passes a `location_queryset` so the form can be reused for
+both the site-context (user's sites only) and central-context flows.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django import forms
+
+from ...models import Location, StockTransfer
+
+if TYPE_CHECKING:
+    from django.db.models import QuerySet
+
+
+# Number of code-input rows rendered per scan-grid page.
+#
+# This is a UI/UX constant — the pharmacist scans physical bottles in
+# batches of this size, then the form submits, the server processes the
+# batch, and the next page renders with up to this many more inputs.
+#
+# It is NOT a cap on the total number of items a pharmacist may scan in
+# one workflow: a manifest of 53 items will produce 6 successive pages
+# (10 + 10 + 10 + 10 + 10 + 3).
+SCAN_GRID_PAGE_SIZE = 10
+
+
+class ConfirmAtLocationEntryForm(forms.Form):
+    """Entry form for /confirm-at-location/."""
+
+    location = forms.ModelChoiceField(
+        queryset=Location.objects.none(),
+        label="Location",
+        empty_label="-----",
+    )
+    stock_transfer_identifier = forms.CharField(
+        label="Reference",
+        max_length=36,
+    )
+    number_of_items = forms.IntegerField(
+        label="Number of items",
+        min_value=1,
+        help_text=(
+            "How many physical items do you intend to scan from this "
+            "manifest? Cannot exceed the number of items still unconfirmed."
+        ),
+    )
+    session_uuid = forms.CharField(
+        widget=forms.HiddenInput,
+        required=False,
+    )
+
+    def __init__(
+        self,
+        *args,
+        location_queryset: QuerySet[Location] | None = None,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        if location_queryset is not None:
+            self.fields["location"].queryset = location_queryset
+        # Add bootstrap form-control class to all visible widgets, matching
+        # the convention used elsewhere in src/edc_pharmacy/forms/stock/.
+        for field in self.fields.values():
+            if isinstance(field.widget, forms.HiddenInput):
+                continue
+            existing = field.widget.attrs.get("class", "")
+            if "form-control" not in existing:
+                field.widget.attrs["class"] = (existing + " form-control").strip()
+
+    def clean(self):
+        cleaned = super().clean()
+        location = cleaned.get("location")
+        identifier = cleaned.get("stock_transfer_identifier")
+        number = cleaned.get("number_of_items")
+
+        if not location or not identifier or number is None:
+            # Field-level errors already attached on at least one of the
+            # required fields; skip the cross-field DB lookup since we
+            # have no usable input.
+            return cleaned
+
+        try:
+            stock_transfer = StockTransfer.objects.get(
+                transfer_identifier=identifier,
+                to_location=location,
+            )
+        except StockTransfer.DoesNotExist:
+            self.add_error(
+                "stock_transfer_identifier",
+                (
+                    f"Invalid Reference. Please check the manifest reference and "
+                    f"delivery site. Got {identifier!r} at {location}."
+                ),
+            )
+            return cleaned
+
+        unconfirmed = stock_transfer.unconfirmed_items
+        if unconfirmed == 0:
+            self.add_error(
+                "stock_transfer_identifier",
+                "Nothing remains unconfirmed for this manifest.",
+            )
+            return cleaned
+
+        if number is not None and number > unconfirmed:
+            self.add_error(
+                "number_of_items",
+                (
+                    f"Number of items ({number}) exceeds the {unconfirmed} "
+                    "items still unconfirmed on the manifest."
+                ),
+            )
+            return cleaned
+
+        # Carry the resolved StockTransfer and the validated unconfirmed
+        # count through to the view.
+        cleaned["stock_transfer"] = stock_transfer
+        cleaned["max_allowed"] = unconfirmed
+        return cleaned
+
+
+__all__ = ["ConfirmAtLocationEntryForm", "SCAN_GRID_PAGE_SIZE"]

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/confirm_at_location.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/confirm_at_location.html
@@ -14,21 +14,37 @@
           <div class="panel panel-default">
             <div class="panel-heading">Confirm transferred stock</div>
             <div class="panel-body">
+              {% if entry_form.non_field_errors %}
+                <div class="alert alert-danger">
+                  {{ entry_form.non_field_errors }}
+                </div>
+              {% endif %}
               <form class="form-horizontal" action="{{ url }}" method="post" onSubmit="document.getElementById('submit').disabled=true;" >
                 {% csrf_token %}
                   <div class="col-sm-10">
                     <div class="form-group">
-                      <label class="control-label" for="location_id">Location</label>
-                      <select class="form-control" id="location_id" name="location_id" >
-                        <option value="" selected > ----- </option>
-                        {% for loc in locations %}
-                          <option value="{{ loc.id }}" >{{ loc.site.id }}: {{ loc.display_name }}</option>
-                        {% endfor %}
-                      </select>
+                      <label class="control-label" for="id_location">Location</label>
+                      {{ entry_form.location }}
+                      {% if entry_form.location.errors %}
+                        <div class="text-danger">{{ entry_form.location.errors }}</div>
+                      {% endif %}
                     </div>
                     <div class="form-group">
-                      <label class="control-label" for="stock_transfer_identifier">Reference</label>
-                      <select class="form-control" id="stock_transfer_identifier" name="stock_transfer_identifier"></select>
+                      <label class="control-label" for="id_stock_transfer_identifier">Reference</label>
+                      {{ entry_form.stock_transfer_identifier }}
+                      {% if entry_form.stock_transfer_identifier.errors %}
+                        <div class="text-danger">{{ entry_form.stock_transfer_identifier.errors }}</div>
+                      {% endif %}
+                    </div>
+                    <div class="form-group">
+                      <label class="control-label" for="id_number_of_items">Number of items</label>
+                      {{ entry_form.number_of_items }}
+                      <small id="number_of_items_hint" class="form-text text-muted">
+                        Select a reference to see how many items remain on the manifest.
+                      </small>
+                      {% if entry_form.number_of_items.errors %}
+                        <div class="text-danger">{{ entry_form.number_of_items.errors }}</div>
+                      {% endif %}
                     </div>
                   </div>
                 <input type="hidden" id="session_uuid" name="session_uuid"  value="{{ session_uuid }}">
@@ -48,23 +64,29 @@
             <div class="panel-heading">Confirm transferred stock: {{ stock_transfer }}</div>
             <div class="panel-body">
               {% if not item_count %}All done!{% endif  %}
-              <form class="form-horizontal" action="{{ url }}" method="post" onSubmit="document.getElementById('submit').disabled=true;" >
+              {% if items_to_scan and item_count %}
+                <p class="text-muted">
+                  Scan page: {{ item_count|length }} input(s) shown;
+                  {{ items_to_scan }} item(s) remaining in this workflow.
+                </p>
+              {% endif %}
+              <form id="scan-form" class="form-horizontal" action="{{ url }}" method="post" onSubmit="document.getElementById('submit').disabled=true;" >
                 {% csrf_token %}
                 <div class="form-group">
                   {% for i in item_count %}
-                    <label class="control-label col-sm-2" for="code{{ i  }}">{{ i }}.</label>
+                    <label class="control-label col-sm-2" for="stock_codes_{{ i }}">{{ i }}.</label>
                     <div class="col-sm-10">
-                      <input type="text" class="form-control" id="stock_codes" name="stock_codes" placeholder="code # {{ i }} " value="" pattern="[A-Z0-9]{6}" required autofocus>
+                      <input type="text" class="form-control stock-code-input" id="stock_codes_{{ i }}" name="stock_codes" placeholder="code # {{ i }} " value="" pattern="[A-Z0-9]{6}" required {% if forloop.first %}autofocus{% endif %}>
                     </div>
                   {% endfor %}
                 </div>
-                <input type="hidden" id="session_uuid" name="session_uuid"  value="{{ session_uuid }}">
-                <input type="hidden" id="stock_transfer_identifier" name="stock_transfer_identifier"  value="{{ stock_transfer_identifier }}">
-                <input type="hidden" id="location_id" name="location_id"  value="{{ location_id }}">
-                <input type="hidden" id="items_to_scan" name="items_to_scan"  value="{{ items_to_scan }}">
-                <input type="hidden" id="confirmed" name="confirmed"  value="{{ confirmed }}">
-                <input type="hidden" id="already_confirmed" name="already_confirmed"  value="{{ already_confirmed }}">
-                <input type="hidden" id="invalid" name="invalid"  value="{{ invalid }}">
+                <input type="hidden" id="session_uuid" name="session_uuid" value="{{ session_uuid }}">
+                <input type="hidden" id="stock_transfer_identifier" name="stock_transfer_identifier" value="{{ stock_transfer_identifier }}">
+                <input type="hidden" id="location_id" name="location_id" value="{{ location_id }}">
+                <input type="hidden" id="items_to_scan" name="items_to_scan" value="{{ items_to_scan }}">
+                <input type="hidden" id="confirmed" name="confirmed" value="{{ confirmed }}">
+                <input type="hidden" id="already_confirmed" name="already_confirmed" value="{{ already_confirmed }}">
+                <input type="hidden" id="invalid" name="invalid" value="{{ invalid }}">
                 <button type="submit" class="btn btn-default" name="submit" id="submit" {% if not item_count %}disabled{% endif %}>Submit</button>
                 <button type="button" class="btn btn-default" onclick="window.location.href='{% url "edc_pharmacy:home_url" %}'">Done</button>
             </form>
@@ -75,27 +97,31 @@
         <div class="col-sm-4">
           <div style="padding:10px">&nbsp;</div>
             <div class="panel panel-default">
-              <div class="panel-heading">Last scanned {{ confirmed_count }}</div>
+              <div class="panel-heading">Last scanned ({{ last_scanned_count|default:0 }})</div>
                 <div class="panel-body">
                   <div class="col-sm-10">
-                    <table class="table table-condensed">
-                      {% for code, comment in last_codes %}
-                        <tr>
-                          <td class="text text-{% if comment == CONFIRMED %}success{% elif comment == ALREADY_CONFIRMED %}warning{% elif comment == INVALID %}danger{% else %}default{% endif %}">
-                            {% if comment == CONFIRMED %}<i class="fa-solid fa-check fa-fw"></i>
-                            {% elif comment == ALREADY_CONFIRMED %}<i class="fa-solid fa-minus fa-fw"></i>
-                            {% elif comment == INVALID %}<i class="fa-solid fa-xmark fa-fw"></i>
-                            {% endif %}
-                          </td>
-                          <td class="text text-{% if comment == CONFIRMED %}success{% elif comment == ALREADY_CONFIRMED %}warning{% elif comment == INVALID %}danger{% else %}default{% endif %}">
-                            {{ code }}
-                          </td>
-                          <td class="text text-{% if comment == CONFIRMED %}success{% elif comment == ALREADY_CONFIRMED %}warning{% elif comment == INVALID %}danger{% else %}default{% endif %}">
-                            {{ comment }}
-                          </td>
-                        </tr>
-                      {% endfor %}
-                     </table>
+                    {% if last_codes %}
+                      <table class="table table-condensed">
+                        {% for code, comment in last_codes %}
+                          <tr>
+                            <td class="text text-{% if comment == CONFIRMED %}success{% elif comment == ALREADY_CONFIRMED %}warning{% elif comment == INVALID %}danger{% else %}default{% endif %}">
+                              {% if comment == CONFIRMED %}<i class="fa-solid fa-check fa-fw"></i>
+                              {% elif comment == ALREADY_CONFIRMED %}<i class="fa-solid fa-minus fa-fw"></i>
+                              {% elif comment == INVALID %}<i class="fa-solid fa-xmark fa-fw"></i>
+                              {% endif %}
+                            </td>
+                            <td class="text text-{% if comment == CONFIRMED %}success{% elif comment == ALREADY_CONFIRMED %}warning{% elif comment == INVALID %}danger{% else %}default{% endif %}">
+                              {{ code }}
+                            </td>
+                            <td class="text text-{% if comment == CONFIRMED %}success{% elif comment == ALREADY_CONFIRMED %}warning{% elif comment == INVALID %}danger{% else %}default{% endif %}">
+                              {{ comment }}
+                            </td>
+                          </tr>
+                        {% endfor %}
+                      </table>
+                    {% else %}
+                      <p class="text-muted"><em>No scans yet</em></p>
+                    {% endif %}
                   </div>
                 </div>
               </div>
@@ -112,25 +138,125 @@
 
 {% block extra-scripts-bottom %}
   <script>
-    document.getElementById('location_id').addEventListener('change', function() {
-      var locationId = this.value;
-      fetch(`/edc_pharmacy/get-stock-transfers/?location_id=${locationId}`)
-        .then(response => response.json())
-        .then(data => {
-            var stockTransferSelect = document.getElementById('stock_transfer_identifier');
-            stockTransferSelect.innerHTML = '';
-            var option = document.createElement('option');
-            option.value = '';
-            option.text = '---';
-            stockTransferSelect.appendChild(option);
+    // Scan-grid page size — informational only on this entry page; the
+    // scan loop is multi-page so the user may enter any number up to
+    // unconfirmed_items, not just SCAN_GRID_PAGE_SIZE.
+    const SCAN_GRID_PAGE_SIZE = {{ SCAN_GRID_PAGE_SIZE|default:10 }};
+
+    // transfer_identifier -> unconfirmed_items, populated on location change.
+    let unconfirmedByIdentifier = {};
+
+    const locationEl = document.getElementById('id_location');
+    const referenceEl = document.getElementById('id_stock_transfer_identifier');
+    const numberEl = document.getElementById('id_number_of_items');
+    const hintEl = document.getElementById('number_of_items_hint');
+
+    function updateNumberOfItemsHint() {
+      const identifier = referenceEl && referenceEl.value;
+      const unconfirmed = unconfirmedByIdentifier[identifier];
+      if (!identifier || unconfirmed === undefined) {
+        if (hintEl) {
+          hintEl.textContent = 'Select a reference to see how many items remain on the manifest.';
+        }
+        if (numberEl) { numberEl.removeAttribute('max'); }
+        return;
+      }
+      if (numberEl) { numberEl.setAttribute('max', unconfirmed); }
+      if (hintEl) {
+        const pages = Math.ceil(unconfirmed / SCAN_GRID_PAGE_SIZE);
+        hintEl.textContent = (
+          `Max: ${unconfirmed} (items remaining on manifest). ` +
+          `Scanning the full amount uses ${pages} grid page(s) of up to ` +
+          `${SCAN_GRID_PAGE_SIZE} bottles each.`
+        );
+      }
+    }
+
+    // Replace the bare-select reference dropdown rendered by Django form
+    // ({{ entry_form.stock_transfer_identifier }} is a CharField) with a
+    // populated <select> driven by the location_id AJAX endpoint.
+    function buildReferenceSelect() {
+      if (!referenceEl) { return; }
+      if (referenceEl.tagName !== 'SELECT') {
+        // The Django widget rendered a text input; swap it out for a select
+        // of the same id/name so reverse-form posts still work.
+        const select = document.createElement('select');
+        select.id = referenceEl.id;
+        select.name = referenceEl.name;
+        select.className = referenceEl.className || 'form-control';
+        referenceEl.parentNode.replaceChild(select, referenceEl);
+      }
+    }
+    buildReferenceSelect();
+
+    if (locationEl) {
+      locationEl.addEventListener('change', function() {
+        const locationId = this.value;
+        const refSel = document.getElementById('id_stock_transfer_identifier');
+        unconfirmedByIdentifier = {};
+        refSel.innerHTML = '';
+        const blank = document.createElement('option');
+        blank.value = '';
+        blank.text = '---';
+        refSel.appendChild(blank);
+        if (!locationId) {
+          updateNumberOfItemsHint();
+          return;
+        }
+        fetch(`/edc_pharmacy/get-stock-transfers/?location_id=${locationId}`)
+          .then(response => response.json())
+          .then(data => {
             data.forEach(function(item) {
-                var option = document.createElement('option');
-                option.value = item.transfer_identifier;
-                option.text = `${item.transfer_identifier} -- ${item.item_count} items`; // Use the correct key
-                stockTransferSelect.appendChild(option);
+              unconfirmedByIdentifier[item.transfer_identifier] = item.unconfirmed_items;
+              const option = document.createElement('option');
+              option.value = item.transfer_identifier;
+              option.text = `${item.transfer_identifier} -- ${item.item_count} items`;
+              refSel.appendChild(option);
             });
-        })
-        .catch(error => console.error('Error:', error));
+            updateNumberOfItemsHint();
+          })
+          .catch(error => console.error('Error:', error));
+      });
+    }
+
+    document.addEventListener('change', function(evt) {
+      if (evt.target && evt.target.id === 'id_stock_transfer_identifier') {
+        updateNumberOfItemsHint();
+      }
+    });
+
+    // ------------------------------------------------------------------
+    // Scan-page barcode flow
+    // ------------------------------------------------------------------
+    // Each .stock-code-input represents one physical bottle. Barcode
+    // scanners typically emit the code followed by Enter; this script
+    // catches the Enter, advances focus to the next input, and on the
+    // last input of the page auto-submits the form. The next page
+    // (rendered server-side) autofocuses its own first input via the
+    // `autofocus` HTML attribute set by the template on forloop.first.
+    (function() {
+      const scanInputs = document.querySelectorAll('.stock-code-input');
+      if (!scanInputs.length) { return; }
+      const submitBtn = document.getElementById('submit');
+      scanInputs.forEach(function(input, idx) {
+        input.addEventListener('keydown', function(evt) {
+          if (evt.key !== 'Enter') { return; }
+          evt.preventDefault();
+          // Trim and uppercase whatever the scanner delivered.
+          input.value = (input.value || '').trim().toUpperCase();
+          if (!input.value) { return; }
+          if (idx < scanInputs.length - 1) {
+            scanInputs[idx + 1].focus();
+          } else if (submitBtn && !submitBtn.disabled) {
+            submitBtn.click();
+          }
         });
-</script>
+      });
+      // Belt-and-suspenders: if the browser doesn't honor `autofocus`,
+      // explicitly focus the first input on page load.
+      if (document.activeElement === document.body || document.activeElement === null) {
+        scanInputs[0].focus();
+      }
+    })();
+  </script>
 {% endblock %}

--- a/src/edc_pharmacy/tests/tests/test_confirm_at_location_entry_form.py
+++ b/src/edc_pharmacy/tests/tests/test_confirm_at_location_entry_form.py
@@ -1,0 +1,137 @@
+"""Tests for ConfirmAtLocationEntryForm.
+
+The form's job is to validate Location + Reference + Number of items
+before the user is sent to the multi-page scan grid. The scan grid
+itself paginates the entered count into pages of SCAN_GRID_PAGE_SIZE
+inputs each (handled by the view, not the form).
+
+Key invariants tested here:
+- number_of_items must be >= 1 (IntegerField).
+- number_of_items must NOT exceed unconfirmed items on the manifest.
+- Entering exactly the unconfirmed count is valid (scan workflow then
+  paginates).
+- unconfirmed_items == 0 rejects.
+- Invalid stock_transfer_identifier rejects.
+
+DB interaction with StockTransfer is mocked — the form's role is
+validation, not DB plumbing.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from edc_pharmacy.forms.stock import (
+    SCAN_GRID_PAGE_SIZE,
+    ConfirmAtLocationEntryForm,
+)
+
+
+def _make_form(**overrides):
+    """Build a bound form with mocked location ModelChoiceField.
+
+    Short-circuits the ModelChoiceField queryset lookup so the test
+    doesn't need a Location row in the DB.
+    """
+    location = MagicMock()
+    location.id = "00000000-0000-0000-0000-000000000001"
+    location.__str__ = lambda self: "central"  # noqa: ARG005
+
+    data = {
+        "location": str(location.id),
+        "stock_transfer_identifier": "TX0001",
+        "number_of_items": 3,
+    }
+    data.update(overrides)
+
+    form = ConfirmAtLocationEntryForm(data)
+    form.fields["location"].to_python = lambda v: location if v else None
+    form.fields["location"].validate = lambda v: None
+    form.fields["location"].run_validators = lambda v: None
+    return form, location
+
+
+def _mock_transfer(*, unconfirmed: int) -> MagicMock:
+    transfer = MagicMock()
+    transfer.unconfirmed_items = unconfirmed
+    transfer.transfer_identifier = "TX0001"
+    return transfer
+
+
+class ConfirmAtLocationEntryFormTests(SimpleTestCase):
+
+    @patch("edc_pharmacy.forms.stock.confirm_at_location_entry_form.StockTransfer.objects.get")
+    def test_valid_well_under_unconfirmed(self, mock_get):
+        mock_get.return_value = _mock_transfer(unconfirmed=8)
+        form, _ = _make_form(number_of_items=3)
+        self.assertTrue(form.is_valid(), msg=form.errors)
+        self.assertEqual(form.cleaned_data["max_allowed"], 8)
+        self.assertEqual(form.cleaned_data["number_of_items"], 3)
+
+    @patch("edc_pharmacy.forms.stock.confirm_at_location_entry_form.StockTransfer.objects.get")
+    def test_valid_at_unconfirmed_within_page_size(self, mock_get):
+        # Unconfirmed == 5, well below SCAN_GRID_PAGE_SIZE — single
+        # grid page will suffice.
+        mock_get.return_value = _mock_transfer(unconfirmed=5)
+        form, _ = _make_form(number_of_items=5)
+        self.assertTrue(form.is_valid(), msg=form.errors)
+        self.assertEqual(form.cleaned_data["max_allowed"], 5)
+
+    @patch("edc_pharmacy.forms.stock.confirm_at_location_entry_form.StockTransfer.objects.get")
+    def test_valid_at_unconfirmed_above_page_size(self, mock_get):
+        # 53 unconfirmed, user wants to scan all 53 — valid; the scan
+        # workflow paginates into 6 pages (10+10+10+10+10+3).
+        mock_get.return_value = _mock_transfer(unconfirmed=53)
+        form, _ = _make_form(number_of_items=53)
+        self.assertTrue(form.is_valid(), msg=form.errors)
+        self.assertEqual(form.cleaned_data["max_allowed"], 53)
+
+    @patch("edc_pharmacy.forms.stock.confirm_at_location_entry_form.StockTransfer.objects.get")
+    def test_valid_below_unconfirmed_above_page_size(self, mock_get):
+        # User has only some of the bottles in hand; can ask for a
+        # smaller batch than the unconfirmed total.
+        mock_get.return_value = _mock_transfer(unconfirmed=53)
+        form, _ = _make_form(number_of_items=15)
+        self.assertTrue(form.is_valid(), msg=form.errors)
+        self.assertEqual(form.cleaned_data["max_allowed"], 53)
+
+    @patch("edc_pharmacy.forms.stock.confirm_at_location_entry_form.StockTransfer.objects.get")
+    def test_rejects_number_over_unconfirmed(self, mock_get):
+        mock_get.return_value = _mock_transfer(unconfirmed=4)
+        form, _ = _make_form(number_of_items=5)
+        self.assertFalse(form.is_valid())
+        self.assertIn("number_of_items", form.errors)
+        msg = " ".join(form.errors["number_of_items"])
+        self.assertIn("4", msg)
+
+    @patch("edc_pharmacy.forms.stock.confirm_at_location_entry_form.StockTransfer.objects.get")
+    def test_rejects_when_nothing_unconfirmed(self, mock_get):
+        mock_get.return_value = _mock_transfer(unconfirmed=0)
+        form, _ = _make_form(number_of_items=1)
+        self.assertFalse(form.is_valid())
+        self.assertIn("stock_transfer_identifier", form.errors)
+
+    def test_field_rejects_zero(self):
+        form, _ = _make_form(number_of_items=0)
+        self.assertFalse(form.is_valid())
+        self.assertIn("number_of_items", form.errors)
+
+    def test_field_rejects_negative(self):
+        form, _ = _make_form(number_of_items=-3)
+        self.assertFalse(form.is_valid())
+        self.assertIn("number_of_items", form.errors)
+
+    @patch("edc_pharmacy.forms.stock.confirm_at_location_entry_form.StockTransfer.objects.get")
+    def test_rejects_unknown_identifier(self, mock_get):
+        from edc_pharmacy.models import StockTransfer
+
+        mock_get.side_effect = StockTransfer.DoesNotExist
+        form, _ = _make_form(stock_transfer_identifier="DOES_NOT_EXIST")
+        self.assertFalse(form.is_valid())
+        self.assertIn("stock_transfer_identifier", form.errors)
+
+    def test_scan_grid_page_size_value(self):
+        """Guardrail — changing this is a deliberate UX decision."""
+        self.assertEqual(SCAN_GRID_PAGE_SIZE, 10)

--- a/src/edc_pharmacy/views/confirm_at_location_view.py
+++ b/src/edc_pharmacy/views/confirm_at_location_view.py
@@ -21,6 +21,7 @@ from edc_navbar import NavbarViewMixin
 from edc_protocol.view_mixins import EdcProtocolViewMixin
 
 from ..constants import ALREADY_CONFIRMED, CENTRAL_LOCATION, INVALID
+from ..forms.stock import SCAN_GRID_PAGE_SIZE, ConfirmAtLocationEntryForm
 from ..models import ConfirmationAtLocation, Location, StockTransfer
 from ..utils import confirm_stock_at_location
 
@@ -37,57 +38,83 @@ class ConfirmaAtLocationView(
         self.session_uuid: str | None = None
         super().__init__(**kwargs)
 
+    # ------------------------------------------------------------------
+    # Context
+    # ------------------------------------------------------------------
     def get_context_data(self, **kwargs):
-        extra_opts = {}
+        extra_opts: dict = {}
         stock_transfer = self.get_stock_transfer(self.kwargs.get("stock_transfer_identifier"))
+
         if not self.kwargs.get("session_uuid"):
             self.session_uuid = str(uuid4())
             session_obj = None
         else:
             self.session_uuid = str(self.kwargs.get("session_uuid"))
             session_obj = self.request.session[self.session_uuid]
+
         if stock_transfer:
-            unconfirmed_count = self.get_unconfirmed_count(stock_transfer)
+            # On the scan page, ``items_to_scan`` (URL kwarg) is the
+            # number of physical bottles the user still has to scan in
+            # this workflow. The grid renders min(items_to_scan,
+            # SCAN_GRID_PAGE_SIZE) rows; after submit the view decrements
+            # items_to_scan and redirects until it reaches 0.
+            items_to_scan = self.kwargs.get("items_to_scan")
+            try:
+                items_to_scan = int(items_to_scan) if items_to_scan else 0
+            except (TypeError, ValueError):
+                items_to_scan = 0
+            items_to_scan = max(items_to_scan, 0)
+            grid_size = min(items_to_scan, SCAN_GRID_PAGE_SIZE)
             extra_opts = dict(
-                unconfirmed_count=unconfirmed_count,
-                item_count=list(
-                    range(1, self.get_adjusted_unconfirmed_count(stock_transfer) + 1)
-                ),
+                unconfirmed_count=stock_transfer.unconfirmed_items,
+                items_to_scan=items_to_scan,
+                grid_size=grid_size,
+                item_count=list(range(1, grid_size + 1)),
                 last_codes=[],
             )
+
         if session_obj:
-            last_codes = [(x, "confirmed") for x in session_obj.get("confirmed") or []]
-            last_codes.extend(
-                [(x, "already confirmed") for x in session_obj.get("already_confirmed") or []]
-            )
-            last_codes.extend([(x, "invalid") for x in session_obj.get("invalid") or []])
-            unconfirmed_count = self.get_unconfirmed_count(stock_transfer)
+            # last_codes is stored in SCAN ORDER (the order the pharmacist
+            # filled the input grid), tagged with bucket label. Built in
+            # _handle_scan_submission below.
             extra_opts.update(
-                item_count=list(
-                    range(1, self.get_adjusted_unconfirmed_count(stock_transfer) + 1)
-                ),
-                unconfirmed_count=unconfirmed_count,
-                last_codes=last_codes,
+                last_codes=session_obj.get("last_codes") or [],
+                last_scanned_count=session_obj.get("last_scanned_count") or 0,
             )
-        if self.kwargs.get("location_name") == CENTRAL_LOCATION:
-            locations = Location.objects.filter(name=CENTRAL_LOCATION)
-        else:
-            locations = Location.objects.filter(
-                site__in=self.request.user.userprofile.sites.all()
-            )
+
+        location_qs = self._location_queryset()
+
+        # Entry form lives on the initial page only (no stock_transfer in
+        # context). Once the user is on the scan page we don't need it.
+        entry_form = kwargs.pop("entry_form", None)
+        if entry_form is None and not stock_transfer:
+            entry_form = ConfirmAtLocationEntryForm(location_queryset=location_qs)
+
         kwargs.update(
-            locations=locations,
+            entry_form=entry_form,
+            locations=location_qs,
             location=self.location,
             location_id=self.location_id,
             stock_transfer=stock_transfer,
             stock_transfers=self.stock_transfers,
             session_uuid=str(self.session_uuid),
+            SCAN_GRID_PAGE_SIZE=SCAN_GRID_PAGE_SIZE,
             CONFIRMED=CONFIRMED,
             ALREADY_CONFIRMED=ALREADY_CONFIRMED,
             INVALID=INVALID,
             **extra_opts,
         )
         return super().get_context_data(**kwargs)
+
+    # ------------------------------------------------------------------
+    # Queryset helpers
+    # ------------------------------------------------------------------
+    def _location_queryset(self):
+        if self.kwargs.get("location_name") == CENTRAL_LOCATION:
+            return Location.objects.filter(name=CENTRAL_LOCATION)
+        return Location.objects.filter(
+            site__in=self.request.user.userprofile.sites.all()
+        )
 
     @property
     def stock_transfers(self):
@@ -96,10 +123,6 @@ class ConfirmaAtLocationView(
             stocktransferitem__confirmationatlocationitem__isnull=True,
         )
         return qs.annotate(count=Count("transfer_identifier")).order_by("-transfer_datetime")
-
-    def get_adjusted_unconfirmed_count(self, stock_transfer):
-        unconfirmed_count = self.get_unconfirmed_count(stock_transfer)
-        return min(unconfirmed_count, 12)
 
     def get_stock_codes(self, stock_transfer):
         return [
@@ -113,15 +136,6 @@ class ConfirmaAtLocationView(
         return stock_transfer.stocktransferitem_set.filter(
             confirmationatlocationitem__isnull=True
         ).count()
-        # return (
-        #     Stock.objects.values("code")
-        #     .filter(
-        #         code__in=self.get_stock_codes(stock_transfer),
-        #         location_id=self.location_id,
-        #         stocktransferitem__confirmationatlocationitem__isnull=True,
-        #     )
-        #     .count()
-        # )
 
     @property
     def site(self) -> Site | None:
@@ -182,14 +196,22 @@ class ConfirmaAtLocationView(
         stock_transfer_identifier: str,
         suppress_msg: bool | None = None,
     ) -> StockTransfer | None:
+        """Lookup helper used only for the scan-page context.
+
+        The entry form has its own validation; this helper is for URLs
+        that already carry a stock_transfer_identifier kwarg (i.e. we're
+        on the scan page already) and just need to look it up.
+        """
         stock_transfer = None
+        if stock_transfer_identifier is None:
+            return None
         try:
             stock_transfer = StockTransfer.objects.get(
                 transfer_identifier=stock_transfer_identifier or None,
                 to_location_id=self.location_id or None,
             )
         except ObjectDoesNotExist:
-            if stock_transfer_identifier and not suppress_msg:
+            if not suppress_msg:
                 location = Location.objects.get(pk=self.location_id or None)
                 messages.add_message(
                     self.request,
@@ -202,84 +224,137 @@ class ConfirmaAtLocationView(
                 )
         return stock_transfer
 
+    # ------------------------------------------------------------------
+    # POST
+    # ------------------------------------------------------------------
     def post(self, request, *args, **kwargs) -> HttpResponseRedirect:  # noqa: ARG002
-        # cancel
-        if request.POST.get("cancel") and request.POST.get("cancel") == "cancel":
-            url = reverse("edc_pharmacy:home_url")
-            return HttpResponseRedirect(url)
+        # Cancel goes home.
+        if request.POST.get("cancel") == "cancel":
+            return HttpResponseRedirect(reverse("edc_pharmacy:home_url"))
 
+        # If scanned codes are present, this is a scan-page submission.
+        # Process them and redirect back to the scan page.
+        if request.POST.getlist("stock_codes"):
+            return self._handle_scan_submission(request)
+
+        # Otherwise treat this as the entry-form submission.
+        return self._handle_entry_submission(request)
+
+    def _handle_entry_submission(self, request) -> HttpResponseRedirect:
+        location_qs = self._location_queryset()
+        form = ConfirmAtLocationEntryForm(request.POST, location_queryset=location_qs)
+        if not form.is_valid():
+            # Re-render the entry page with the bound form (errors and all).
+            context = self.get_context_data(entry_form=form)
+            return self.render_to_response(context)
+
+        stock_transfer = form.cleaned_data["stock_transfer"]
+        number_of_items = form.cleaned_data["number_of_items"]
+        url = reverse(
+            "edc_pharmacy:confirm_at_location_url",
+            kwargs={
+                "stock_transfer_identifier": stock_transfer.transfer_identifier,
+                "location_id": form.cleaned_data["location"].id,
+                "items_to_scan": number_of_items,
+            },
+        )
+        return HttpResponseRedirect(url)
+
+    def _handle_scan_submission(self, request) -> HttpResponseRedirect:
         stock_transfer_identifier = request.POST.get("stock_transfer_identifier")
         stock_transfer = self.get_stock_transfer(stock_transfer_identifier, suppress_msg=True)
         location_id = request.POST.get("location_id")
         if not stock_transfer or not location_id:
-            # nothing selected
-            url = reverse("edc_pharmacy:confirm_at_location_url", kwargs={})
-            return HttpResponseRedirect(url)
+            return HttpResponseRedirect(reverse("edc_pharmacy:confirm_at_location_url"))
 
         session_uuid = request.POST.get("session_uuid")
-        stock_codes = (
-            request.POST.getlist("stock_codes") if request.POST.get("stock_codes") else []
+        stock_codes = request.POST.getlist("stock_codes")
+
+        # Carry through the user's intended total for the multi-page scan
+        # workflow. Decrement by the number of inputs the user submitted
+        # this page — every physical bottle they scanned counts toward
+        # their target, regardless of confirmation outcome (already-
+        # confirmed and invalid bottles still passed through their hands).
+        try:
+            prev_items_to_scan = int(request.POST.get("items_to_scan") or 0)
+        except (TypeError, ValueError):
+            prev_items_to_scan = 0
+
+        confirmed, already_confirmed, invalid = confirm_stock_at_location(
+            stock_transfer, stock_codes, location_id, request=request
         )
 
-        # you have unconfirmed items, so go to the scan page
-        if not stock_codes and stock_transfer.unconfirmed_items > 0:
-            url = reverse(
-                "edc_pharmacy:confirm_at_location_url",
-                kwargs={
-                    "stock_transfer_identifier": stock_transfer_identifier,
-                    "location_id": location_id,
-                    "items_to_scan": stock_transfer.unconfirmed_items,
-                },
-            )
-            return HttpResponseRedirect(url)
+        # Build last_codes in scan order — the order codes appeared in
+        # request.POST.getlist("stock_codes") is the order the pharmacist
+        # filled the input grid (form preserves input order). Tag each
+        # code with its bucket so the sidebar can colour it.
+        confirmed_set = {c.strip().upper() for c in confirmed}
+        already_set = {c.strip().upper() for c in already_confirmed}
+        invalid_set = {c.strip().upper() for c in invalid}
+        last_codes: list[tuple[str, str]] = []
+        for raw_code in stock_codes:
+            code = raw_code.strip().upper()
+            if code in confirmed_set:
+                label = "confirmed"
+            elif code in already_set:
+                label = "already confirmed"
+            elif code in invalid_set:
+                label = "invalid"
+            else:
+                # Shouldn't happen — every submitted code lands in exactly
+                # one of the three buckets. Fall through defensively.
+                label = "invalid"
+            last_codes.append((code, label))
 
-        if stock_codes:
-            # you have scanned codes, process them
-            confirmed, already_confirmed, invalid = confirm_stock_at_location(
-                stock_transfer, stock_codes, location_id, request=request
+        if confirmed:
+            messages.add_message(
+                request,
+                messages.SUCCESS,
+                f"Successfully confirmed {len(confirmed)} stock items. ",
             )
-            # message for confirmed
-            if confirmed:
-                messages.add_message(
-                    request,
-                    messages.SUCCESS,
-                    f"Successfully confirmed {len(confirmed)} stock items. ",
-                )
-            # message for already confirmed
-            if already_confirmed:
-                messages.add_message(
-                    request,
-                    messages.WARNING,
-                    (
-                        f"Skipped {len(already_confirmed)} items. Stock items are "
-                        "already confirmed."
-                    ),
-                )
-            # message for invalid codes
-            if invalid:
-                messages.add_message(
-                    request,
-                    messages.ERROR,
-                    f"Invalid codes submitted! Got {', '.join(invalid)} .",
-                )
+        if already_confirmed:
+            # NOTE: a physical bottle cannot be in two pharmacists' hands at
+            # once, so seeing items in this bucket means another session
+            # received the same code between this user opening the scan
+            # page and submitting. Bucketing it as already_confirmed is the
+            # intentional behaviour — see DESIGN_transaction_log.md.
+            messages.add_message(
+                request,
+                messages.WARNING,
+                f"Skipped {len(already_confirmed)} items. Stock items are already confirmed.",
+            )
+        if invalid:
+            messages.add_message(
+                request,
+                messages.ERROR,
+                f"Invalid codes submitted! Got {', '.join(invalid)} .",
+            )
 
-            self.request.session[session_uuid] = dict(
-                confirmed=confirmed,
-                already_confirmed=already_confirmed,
-                invalid=invalid,
-                stock_transfer_pk=str(stock_transfer.pk),
-            )
-            # return to page with any unconfirmed codes for this stock_transfer document
-            # might be 0 items
-            url = reverse(
-                "edc_pharmacy:confirm_at_location_url",
-                kwargs={
-                    "session_uuid": str(request.POST.get("session_uuid")),
-                    "stock_transfer_identifier": stock_transfer_identifier,
-                    "location_id": location_id,
-                    "items_to_scan": stock_transfer.unconfirmed_items,
-                },
-            )
-            return HttpResponseRedirect(url)
-        # can you get here??
-        return HttpResponseRedirect(self.confirm_at_location_changelist_url)
+        self.request.session[session_uuid] = dict(
+            confirmed=confirmed,
+            already_confirmed=already_confirmed,
+            invalid=invalid,
+            last_codes=last_codes,
+            last_scanned_count=len(stock_codes),
+            stock_transfer_pk=str(stock_transfer.pk),
+        )
+
+        # Multi-page scan loop: decrement the target by however many
+        # inputs the user submitted this page (typically
+        # SCAN_GRID_PAGE_SIZE, or fewer on the final page). Floor at 0
+        # and additionally clamp against unconfirmed_items so that if
+        # someone else confirmed bottles concurrently the user isn't
+        # asked to scan more than physically remain.
+        scanned_this_page = len(stock_codes)
+        next_items_to_scan = max(0, prev_items_to_scan - scanned_this_page)
+        next_items_to_scan = min(next_items_to_scan, stock_transfer.unconfirmed_items)
+        url = reverse(
+            "edc_pharmacy:confirm_at_location_url",
+            kwargs={
+                "session_uuid": str(session_uuid),
+                "stock_transfer_identifier": stock_transfer_identifier,
+                "location_id": location_id,
+                "items_to_scan": next_items_to_scan,
+            },
+        )
+        return HttpResponseRedirect(url)

--- a/src/edc_pharmacy/views/get_stock_transfers_view.py
+++ b/src/edc_pharmacy/views/get_stock_transfers_view.py
@@ -1,19 +1,41 @@
 # views.py
-from django.db.models import Count
+from django.db.models import Count, Q
 from django.http import JsonResponse
 
 from ..models import StockTransfer
 
 
 def get_stock_transfers_view(request):
+    """Return the list of stock transfers with unconfirmed items.
+
+    Each row includes ``unconfirmed_items`` so the
+    /confirm-at-location/ entry form can compute the max for the
+    "Number of items" input on reference change without a round-trip.
+    """
     location_id = request.GET.get("location_id", None)
     stock_transfers = (
         StockTransfer.objects.filter(
             to_location_id=location_id,
             stocktransferitem__confirmationatlocationitem__isnull=True,
         )
-        .annotate(count=Count("transfer_identifier"))
-        .values("id", "transfer_identifier", "item_count")
+        .annotate(
+            count=Count("transfer_identifier"),
+            unconfirmed_items_count=Count(
+                "stocktransferitem",
+                filter=Q(stocktransferitem__confirmationatlocationitem__isnull=True),
+            ),
+        )
+        .values("id", "transfer_identifier", "item_count", "unconfirmed_items_count")
         .order_by("-transfer_identifier")
     )
-    return JsonResponse(list(stock_transfers), safe=False)
+    # Rename the annotation to a stable JSON key for the template's JS.
+    payload = [
+        {
+            "id": row["id"],
+            "transfer_identifier": row["transfer_identifier"],
+            "item_count": row["item_count"],
+            "unconfirmed_items": row["unconfirmed_items_count"],
+        }
+        for row in stock_transfers
+    ]
+    return JsonResponse(payload, safe=False)


### PR DESCRIPTION
## Summary

Reworks the **Confirm transferred stock** workflow to ask the pharmacist up-front how many physical bottles they intend to scan, then drives a multi-page scan grid with seamless barcode-scanner UX.

## Entry page

New **Number of items** field next to Location + Reference.

- Min 1; max = number of items still unconfirmed on the selected manifest (manifest total minus already-received).
- Live "max" hint populated by JS on Reference change (existing AJAX endpoint extended).
- Server-side validation rejects overshoot.

## Scan workflow (the main UX change)

The scan grid renders at most `SCAN_GRID_PAGE_SIZE` (10) inputs per page. **Number of items** is NOT capped at 10 — entering 53 produces 6 consecutive pages of 10 + 10 + 10 + 10 + 10 + 3 inputs.

Barcode flow per page:

| Step | What happens |
|---|---|
| Page loads | First input has `autofocus`; other inputs do not |
| Scanner reads code | Code appears in the focused input; scanner emits `Enter` |
| `Enter` on inputs 1–9 | JS catches it, advances focus to the next input |
| `Enter` on input 10 (last) | JS auto-submits the form |
| Server processes | Decrements items-remaining by the number of inputs submitted, redirects to next page |
| New page loads | First input autofocuses, ready for the next bottle |

## Sidebar ("Last scanned (N)")

- Shows the results of the **most recent submit only** (one page's codes), in **scan order** (the order the pharmacist filled the grid), tagged confirmed / already confirmed / invalid.
- Empty-state placeholder *"No scans yet"* before the first submit.

## Implementation

- New `ConfirmAtLocationEntryForm` (`forms/stock/confirm_at_location_entry_form.py`) — clean validation, scoped Location queryset.
- New constant `SCAN_GRID_PAGE_SIZE = 10` exported alongside the form.
- `ConfirmaAtLocationView` refactored to use the form; `_handle_entry_submission` / `_handle_scan_submission` split out from `post()` for clarity.
- `_handle_scan_submission` builds `last_codes` in submitted order with bucket labels, persists in session.
- `get_stock_transfers_view` now also returns `unconfirmed_items` per transfer so the JS can compute the max client-side.
- 10 new form-level tests covering valid ranges and rejection paths.

## Test plan

- [x] `python runtests.py edc_pharmacy` — 1625 passed, 37 skipped, 0 failures.
- [ ] Manual: enter Reference, watch the max hint populate; try to overshoot, see server reject.
- [ ] Manual with barcode scanner: enter 30 items; verify 3 successive pages flow without manual focus management; verify auto-submit between pages.
- [ ] Manual: scan all the way to 0 remaining; verify "All done!" page.
- [ ] Manual: confirm the sidebar shows the last page's codes in scan order, with the correct bucket labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)