### PR TITLE
confirm-at-location: prefill Reference on form-error + fix select_for_update FieldError

### DIFF
--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/confirm_at_location.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/confirm_at_location.html
@@ -31,7 +31,17 @@
                     </div>
                     <div class="form-group">
                       <label class="control-label" for="id_stock_transfer_identifier">Reference</label>
-                      {{ entry_form.stock_transfer_identifier }}
+                      {# Render server-side so options survive a form-error redisplay.   #}
+                      {# JS in extra-scripts-bottom still repopulates on Location change. #}
+                      <select class="form-control" id="id_stock_transfer_identifier" name="stock_transfer_identifier">
+                        <option value="" {% if not entry_form.stock_transfer_identifier.value %}selected{% endif %}>---</option>
+                        {% for t in prefilled_transfers %}
+                          <option value="{{ t.transfer_identifier }}" {% if t.transfer_identifier == entry_form.stock_transfer_identifier.value %}selected{% endif %}>
+                            {{ t.transfer_identifier }} -- {{ t.item_count }} items
+                          </option>
+                        {% endfor %}
+                      </select>
+                      {{ prefilled_transfers|json_script:"prefilled-transfers-data" }}
                       {% if entry_form.stock_transfer_identifier.errors %}
                         <div class="text-danger">{{ entry_form.stock_transfer_identifier.errors }}</div>
                       {% endif %}
@@ -172,22 +182,23 @@
       }
     }
 
-    // Replace the bare-select reference dropdown rendered by Django form
-    // ({{ entry_form.stock_transfer_identifier }} is a CharField) with a
-    // populated <select> driven by the location_id AJAX endpoint.
-    function buildReferenceSelect() {
-      if (!referenceEl) { return; }
-      if (referenceEl.tagName !== 'SELECT') {
-        // The Django widget rendered a text input; swap it out for a select
-        // of the same id/name so reverse-form posts still work.
-        const select = document.createElement('select');
-        select.id = referenceEl.id;
-        select.name = referenceEl.name;
-        select.className = referenceEl.className || 'form-control';
-        referenceEl.parentNode.replaceChild(select, referenceEl);
+    // On initial render the Reference <select> is built server-side (so
+    // its options survive a form-error redisplay). Seed
+    // unconfirmedByIdentifier from the JSON payload the server embedded
+    // so the "max:" hint works on first paint.
+    (function primeFromPrefilled() {
+      const dataEl = document.getElementById('prefilled-transfers-data');
+      if (!dataEl) { return; }
+      try {
+        const data = JSON.parse(dataEl.textContent);
+        data.forEach(function(item) {
+          unconfirmedByIdentifier[item.transfer_identifier] = item.unconfirmed_items;
+        });
+        updateNumberOfItemsHint();
+      } catch (e) {
+        console.error('Failed to parse prefilled-transfers-data:', e);
       }
-    }
-    buildReferenceSelect();
+    })();
 
     if (locationEl) {
       locationEl.addEventListener('change', function() {

--- a/src/edc_pharmacy/utils/confirm_stock_at_location.py
+++ b/src/edc_pharmacy/utils/confirm_stock_at_location.py
@@ -61,8 +61,15 @@ def confirm_stock_at_location(
     for stock_code in stock_codes:
         with transaction.atomic():
             try:
+                # of=("self",) only: locking "stock" via of= would require
+                # an explicit select_related("stock") to expose it as a
+                # known alias for select_for_update (Django raises
+                # FieldError on MySQL otherwise). The Stock row is locked
+                # anyway by apply_transaction(...) inside compute_delta's
+                # caller, so the outer lock on just the StockTransferItem
+                # is sufficient.
                 stock_transfer_item = stock_transfer_item_model_cls.objects.select_for_update(
-                    of=("self", "stock")
+                    of=("self",)
                 ).get(stock__code=stock_code, stock_transfer=stock_transfer)
             except ObjectDoesNotExist:
                 if request:

--- a/src/edc_pharmacy/views/confirm_at_location_view.py
+++ b/src/edc_pharmacy/views/confirm_at_location_view.py
@@ -90,8 +90,17 @@ class ConfirmaAtLocationView(
         if entry_form is None and not stock_transfer:
             entry_form = ConfirmAtLocationEntryForm(location_queryset=location_qs)
 
+        # When the entry form is being re-rendered after a validation
+        # failure, the user already chose a Location and a Reference. The
+        # Reference <select> is normally populated by JS via the
+        # get-stock-transfers endpoint on Location change — but that JS
+        # hasn't fired on form redisplay, so we'd lose the options. Pre-
+        # render them server-side based on the bound Location.
+        prefilled_transfers = self._prefilled_transfers(entry_form)
+
         kwargs.update(
             entry_form=entry_form,
+            prefilled_transfers=prefilled_transfers,
             locations=location_qs,
             location=self.location,
             location_id=self.location_id,
@@ -105,6 +114,35 @@ class ConfirmaAtLocationView(
             **extra_opts,
         )
         return super().get_context_data(**kwargs)
+
+    def _prefilled_transfers(self, entry_form) -> list[dict]:
+        """Return server-side data for the Reference <select> on
+        validation-error redisplay. Mirrors the JSON shape produced by
+        ``get_stock_transfers_view`` so the JS can read it identically.
+        """
+        if entry_form is None or not entry_form.is_bound:
+            return []
+        # Use raw data (not cleaned_data) — cleaned_data may be missing
+        # if the bound location failed its own validation.
+        raw_location_id = entry_form.data.get("location") or None
+        if not raw_location_id:
+            return []
+        transfers = (
+            StockTransfer.objects.filter(
+                to_location_id=raw_location_id,
+                stocktransferitem__confirmationatlocationitem__isnull=True,
+            )
+            .distinct()
+            .order_by("-transfer_identifier")
+        )
+        return [
+            {
+                "transfer_identifier": t.transfer_identifier,
+                "item_count": t.item_count,
+                "unconfirmed_items": t.unconfirmed_items,
+            }
+            for t in transfers
+        ]
 
     # ------------------------------------------------------------------
     # Queryset helpers


### PR DESCRIPTION
## Summary

Two bugs surfaced during UAT of the new entry-form / multi-page scan flow (PR #98).

### 1. Reference dropdown wiped on form-error redisplay

When the entry form failed validation (e.g. *"Number of items (36) exceeds the 35 items still unconfirmed on the manifest"*), the **Reference** `<select>` showed only its empty placeholder. The user couldn't resubmit because the JS that normally populates the dropdown fires only on **Location** change — and that hadn't happened on redisplay.

**Fix:** render the Reference `<select>` options server-side from the bound Location, with the previously-submitted choice marked `selected`. The same transfers are also embedded as `<script type="application/json">` so the JS can prime `unconfirmedByIdentifier` immediately and the "Number of items" max hint works on first paint. The existing AJAX endpoint still drives dynamic updates when the user changes Location.

### 2. `FieldError: Invalid field name(s) given in select_for_update(of=(...)): stock`

On scan submit, `confirm_stock_at_location` raised:

```
FieldError at /edc_pharmacy/confirm-at-location/000091/2/9/
Invalid field name(s) given in select_for_update(of=(...)): stock.
Only relational fields followed in the query are allowed. Choices are: self.
```

The query was `.select_for_update(of=("self", "stock")).get(stock__code=..., stock_transfer=...)`. `stock` was only joined in via the lookup, not exposed as a known alias via `select_related` — so Django rejects it for `of=`. This is a pre-existing bug in PR #85 (the original audit) that wasn't exercised by any test path.

**Fix:** drop `"stock"` from `of=`. The Stock row is locked anyway by `apply_transaction(...)` further down (it does its own `select_for_update`), so the outer lock on just the `StockTransferItem` is sufficient. Same shape that `transfer_stock_to_location` and `allocate_stock` already use.

## Test plan

- [x] `python runtests.py edc_pharmacy` — 1625 passed, 37 skipped, 0 failures.
- [ ] Manual: submit the entry form with a number > unconfirmed. Verify error message appears AND the Reference `<select>` still has the right options with the previous Reference still selected.
- [ ] Manual: complete a scan page. Verify no `FieldError`; the transactions are written; the redirect to the next page works.
- [ ] Manual: change Location after a form-error redisplay. Verify the Reference dropdown reloads via AJAX (no stale options from previous Location).

## Related

- PR #98 — original entry-form + multi-page scan flow (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)