### PR TITLE
Add PrnModelManager with natural key support

### DIFF
--- a/src/edc_prn/prn_model_manager.py
+++ b/src/edc_prn/prn_model_manager.py
@@ -1,0 +1,10 @@
+from django.db import models
+
+
+class PrnModelManager(models.Manager):
+    """A manager class for PRN models"""
+
+    use_in_migrations = True
+
+    def get_by_natural_key(self, subject_identifier):
+        return self.get(subject_identifier=subject_identifier)


### PR DESCRIPTION
## Summary
- Add `PrnModelManager` to `edc_prn` with `get_by_natural_key` support for subject_identifier lookups
- Sets `use_in_migrations = True` for migration compatibility

## Test plan
- [ ] Verify `edc_prn` imports resolve correctly
- [ ] Confirm downstream packages (edc-retinopathy) can reference `edc_prn.prn_model_manager`

🤖 Generated with [Claude Code](https://claude.com/claude-code)