### PR TITLE
feat(edc-pharmacy): enforce one active Allocation per Stock on MySQL

### DIFF
--- a/src/edc_pharmacy/migrations/0158_allocation_mysql_active_uniqueness.py
+++ b/src/edc_pharmacy/migrations/0158_allocation_mysql_active_uniqueness.py
@@ -1,0 +1,65 @@
+"""MySQL-only enforcement of one active Allocation per Stock.
+
+The Meta ``UniqueConstraint(condition=Q(ended_datetime__isnull=True))``
+becomes a partial unique index on PostgreSQL / SQLite but is silently
+skipped on MySQL — partial indexes don't exist there. This migration
+reproduces the invariant on MySQL with the canonical workaround:
+
+  * A STORED generated column ``active_stock_id`` equal to ``stock_id``
+    when ``ended_datetime IS NULL`` and ``NULL`` otherwise.
+  * A plain unique index on that column.
+
+Why it works: MySQL unique indexes treat ``NULL`` values as distinct, so
+ended Allocation rows (active_stock_id = NULL) coexist freely with
+others for the same stock; only the active row (active_stock_id =
+stock_id) is uniqueness-checked.
+
+No-op on every non-MySQL backend so the partial index that Django emits
+from the Meta constraint stays intact there.
+
+Requirements:
+  * MySQL >= 5.7.6 for STORED generated columns.
+  * InnoDB engine (Django's default).
+
+Reversible. ``unmigrate`` drops the index and the column on MySQL only.
+"""
+
+from django.db import migrations
+
+MYSQL_FORWARD_SQL = """
+    ALTER TABLE edc_pharmacy_allocation
+        ADD COLUMN active_stock_id CHAR(32)
+            GENERATED ALWAYS AS (
+                CASE WHEN ended_datetime IS NULL THEN stock_id ELSE NULL END
+            ) STORED,
+        ADD UNIQUE INDEX one_active_allocation_per_stock_mysql (active_stock_id);
+"""
+
+MYSQL_REVERSE_SQL = """
+    ALTER TABLE edc_pharmacy_allocation
+        DROP INDEX one_active_allocation_per_stock_mysql,
+        DROP COLUMN active_stock_id;
+"""
+
+
+def forward(apps, schema_editor):  # noqa: ARG001
+    if schema_editor.connection.vendor != "mysql":
+        return
+    schema_editor.execute(MYSQL_FORWARD_SQL)
+
+
+def reverse(apps, schema_editor):  # noqa: ARG001
+    if schema_editor.connection.vendor != "mysql":
+        return
+    schema_editor.execute(MYSQL_REVERSE_SQL)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("edc_pharmacy", "0157_backfill_allocation_stock_backpointer"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, reverse),
+    ]


### PR DESCRIPTION
## Summary

Companion to **#106** (application-level guard). Adds the matching **database-level** enforcement specifically for MySQL — which silently no-ops the \`Meta.UniqueConstraint(condition=…)\` that PostgreSQL and SQLite honour as a partial unique index.

## How

Migration **0158** is a single \`RunPython\` op that runs only when \`schema_editor.connection.vendor == \"mysql\"\`:

\`\`\`sql
ALTER TABLE edc_pharmacy_allocation
    ADD COLUMN active_stock_id CHAR(32)
        GENERATED ALWAYS AS (
            CASE WHEN ended_datetime IS NULL THEN stock_id ELSE NULL END
        ) STORED,
    ADD UNIQUE INDEX one_active_allocation_per_stock_mysql (active_stock_id);
\`\`\`

MySQL unique indexes treat \`NULL\` as distinct, so:
- An *ended* Allocation has \`active_stock_id = NULL\` — multiple per stock allowed.
- An *active* Allocation has \`active_stock_id = stock_id\` — uniqueness enforced.

## Requirements

- MySQL >= 5.7.6 (STORED generated columns)
- InnoDB (Django's default)

## What it does on other backends

- **PostgreSQL / SQLite** — no-op. The partial unique index Django generates from the Meta constraint already enforces the invariant.
- **Anything else** — no-op.

## Reversible

\`unmigrate edc_pharmacy 0157_backfill_allocation_stock_backpointer\` drops the index and the column on MySQL only.

## Test plan

- [ ] \`makemigrations --check\` reports no missing migrations
- [ ] \`migrate\` on MySQL adds \`active_stock_id\` (visible in \`DESCRIBE edc_pharmacy_allocation\`) and the unique index (visible in \`SHOW INDEX FROM edc_pharmacy_allocation\`)
- [ ] Inserting two active Allocations for the same Stock on MySQL raises \`IntegrityError\` from the DB (not just from the save() guard)
- [ ] \`migrate\` on SQLite / PostgreSQL is a clean no-op (no schema diff)
- [ ] \`migrate edc_pharmacy 0157_backfill_allocation_stock_backpointer\` rolls back cleanly on MySQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)