### PR TITLE
fix(migrate): set atomic=False so RunPython can issue ALTER on MySQL

### DIFF
--- a/src/edc_pharmacy/migrations/0158_allocation_mysql_active_uniqueness.py
+++ b/src/edc_pharmacy/migrations/0158_allocation_mysql_active_uniqueness.py
@@ -56,6 +56,12 @@ def reverse(apps, schema_editor):  # noqa: ARG001
 
 class Migration(migrations.Migration):
 
+    # MySQL can't roll back DDL, so Django forbids ALTER inside the
+    # transaction RunPython is otherwise wrapped in. Disable the wrapping
+    # transaction at the Migration level — the SQL is one ALTER statement
+    # so atomicity at the migration boundary is sufficient.
+    atomic = False
+
     dependencies = [
         ("edc_pharmacy", "0157_backfill_allocation_stock_backpointer"),
     ]


### PR DESCRIPTION
MySQL has no rollback for DDL; Django therefore refuses to execute
schema-altering SQL inside the transaction it would normally wrap a
RunPython operation in:

  django.db.transaction.TransactionManagementError:
      Executing DDL statements while in a transaction on databases that
      can't perform a rollback is prohibited.

Standard fix: declare atomic = False on the Migration class so the
RunPython runs outside any transaction. The ALTER itself is a single
statement so migration-boundary atomicity is sufficient.

Follow-up to #107 which shipped without this guard.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
