### PR TITLE
Fix radio options hidden on mobile (iOS)

### DIFF
--- a/src/edc_model_admin/templates/edc_model_admin/admin/change_form.html
+++ b/src/edc_model_admin/templates/edc_model_admin/admin/change_form.html
@@ -16,12 +16,6 @@
 {%  for css in edc_model_admin_css_theme_path %}
 <link rel='stylesheet' type="text/css" href='{% static css %}'>
 {% endfor %}
-<!-- hack to fix wrapping radiolists -->
-<style>
-  form div.radiolist label {
-    width: 600px;
-}
-</style>
 {% endblock %}
 
 {% block dark-mode-vars %}


### PR DESCRIPTION
## Summary

Remove the inline `width: 600px` CSS hack on radio label elements in the admin `change_form.html` template. This fixed wrapping on desktop but caused radio options to be clipped/hidden on narrow iOS screens (portrait iPhone ~375px).

Only the last option(s) in each radio group were visible; earlier options were hidden behind the `<fieldset>` `<legend>` element that Django 5+ adds for accessibility.

Django's native admin CSS handles radio label widths correctly at all viewport sizes without this override.

## Test plan

- [ ] Verify radio buttons render all options on iOS Safari/Firefox in portrait (~375px)
- [ ] Verify radio buttons still render correctly on desktop at full width
- [ ] Verify radio labels don't wrap badly on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)