### PR TITLE
Docs and tests for the metadata review screen

### DIFF
--- a/docs/clinicedc_modules/edc_metadata.rst
+++ b/docs/clinicedc_modules/edc_metadata.rst
@@ -30,6 +30,78 @@ By default the ``entry_status`` field attribute is set to ``REQUIRED``. You can 
     The same applies to REQUISITIONS.
 
 
+Reviewing outstanding forms (data manager review screen)
+--------------------------------------------------------
+
+``edc_metadata`` provides a proactive review screen for data managers that aggregates
+**outstanding** forms — those with ``entry_status == REQUIRED`` ("New", not yet ``KEYED``) —
+across subjects and visits. It answers "which subjects, at which visits, have outstanding CRFs
+and requisitions, and which form types are most behind".
+
+* URL name: ``edc_metadata:review_grid_url`` (``/edc_metadata/review/``).
+* View: ``views/review_grid_view.py`` — ``MetadataReviewGridView`` (a ``TemplateView``).
+* Permission: gated by the existing ``edc_metadata.view_crfmetadata`` codename. No new
+  navbar item — it is reached from the **Data Management** home page link and from the
+  **"Outstanding CRFs"** link in the subject dashboard "Collection status" sidebar.
+
+Two lenses
+++++++++++
+
+Switch lenses with the ``?lens=`` parameter (default ``leaderboard``):
+
+* **Leaderboard** (``lens=leaderboard``) — rows are CRF types, columns are visit codes, and
+  each cell is the number of **distinct subjects** with that CRF outstanding at that visit.
+  Rows are ordered by priority tier then outstanding count; tier-1 CRFs are highlighted.
+  Clicking a cell hands off to the grid filtered to that CRF and visit.
+* **Subjects-by-visit grid** (``lens=grid``) — rows are subjects (ordered by
+  ``subject_identifier``, paginated), columns are the schedule's visit codes, and each cell
+  shows ``CRF / requisition`` outstanding counts. Row and column totals are included.
+  Clicking a cell opens the subject dashboard at that appointment.
+
+Filters
++++++++
+
+* **Subject** — case-insensitive ``subject_identifier`` search (``q``).
+* **Schedule** — one ``visit_schedule_name`` / ``schedule_name`` at a time (counts never
+  span schedules, because ``visit_code`` collides across them).
+* **Site** — a single site or **All sites** across the user's allowed set (see below).
+* **Visit** — restrict to a single ``visit_code``.
+* **CRFs (override priority)** — a multiselect of CRF model labels.
+* **Priority only** — restrict CRF counts to the configured priority set (see below).
+
+Priority CRFs
++++++++++++++
+
+The ``CrfPriority`` model (``models/crf_priority.py``, admin-maintained by data managers)
+flags CRF types as priority per schedule, with a ``tier`` and ``active`` flag. Resolution
+order for which CRFs are counted:
+
+1. an explicit **CRFs multiselect** selection wins; otherwise
+2. if **Priority only** is checked and priority rows exist, the active priority set for the
+   schedule is used; otherwise
+3. all CRFs (with a banner when priority-only is on but nothing is configured).
+
+When a CRF set is active (priority or multiselect), the grid becomes **CRF-focused**:
+requisitions are excluded from the subject set, cells and totals so the filter is not muddied
+by unrelated requisitions (requisition prioritisation is deferred).
+
+Site scoping
+++++++++++++
+
+Queries use the default ``objects`` manager (not ``on_site``) and scope explicitly with
+``site_id__in``. ``allowed_site_ids()`` returns, for users with the ``DATA_MANAGER_ROLE``,
+every site on their user profile (including the current site); other users get
+``edc_sites.sites.get_site_ids_for_user()`` (current + view-only).
+
+.. important::
+
+   The screen counts **persisted** metadata. It does not recompute rules on render (that
+   would be far too expensive across many subjects), so counts can lag reality until metadata
+   is refreshed — e.g. by visiting a subject dashboard (which recomputes that timepoint) or by
+   running ``python manage.py update_metadata``. The subject-grid aggregation is served by the
+   ``a10idx`` composite index and the leaderboard by ``a11idx`` (see the model ``Meta``).
+
+
 ``metadata_rules`` manipulate ``metadata`` model instances
 ----------------------------------------------------------
 

--- a/src/edc_metadata/tests/tests/test_crf_priority.py
+++ b/src/edc_metadata/tests/tests/test_crf_priority.py
@@ -1,0 +1,56 @@
+from django.db import IntegrityError, transaction
+from django.test import TestCase, override_settings, tag
+
+from edc_metadata.admin.crf_priority import CrfPriorityForm
+from edc_metadata.constants import CRF
+from edc_metadata.models import CrfPriority
+
+
+@tag("metadata")
+@override_settings(SITE_ID=10)
+class TestCrfPriority(TestCase):
+    def test_create_and_defaults(self):
+        obj = CrfPriority.objects.create(
+            model="clinicedc_tests.crfone",
+            visit_schedule_name="visit_schedule",
+            schedule_name="schedule",
+        )
+        self.assertEqual(obj.tier, 2)
+        self.assertTrue(obj.active)
+        self.assertEqual(obj.metadata_kind, CRF)
+        self.assertIn("clinicedc_tests.crfone", str(obj))
+
+    def test_unique_per_model_schedule_kind(self):
+        opts = dict(
+            model="clinicedc_tests.crfone",
+            visit_schedule_name="visit_schedule",
+            schedule_name="schedule",
+        )
+        CrfPriority.objects.create(**opts)
+        with transaction.atomic(), self.assertRaises(IntegrityError):
+            CrfPriority.objects.create(**opts)
+
+    def test_admin_form_uses_explicit_fields_without_audit_fields(self):
+        # audit fields are system columns and must never be exposed on a
+        # user-facing ModelForm.
+        fields = set(CrfPriorityForm.base_fields)
+        self.assertEqual(
+            fields,
+            {
+                "model",
+                "visit_schedule_name",
+                "schedule_name",
+                "metadata_kind",
+                "tier",
+                "active",
+            },
+        )
+        for audit_field in (
+            "created",
+            "modified",
+            "user_created",
+            "user_modified",
+            "hostname_created",
+            "device_created",
+        ):
+            self.assertNotIn(audit_field, fields)

--- a/src/edc_metadata/tests/tests/test_home_redirect.py
+++ b/src/edc_metadata/tests/tests/test_home_redirect.py
@@ -1,29 +1,20 @@
-"""Prove that `edc_metadata:home_url` redirects to the CrfMetadata
-changelist with `?entry_status__exact=REQUIRED` prefilled.
+"""`edc_metadata:home_url` renders the edc_metadata ``HomeView`` (login required).
 
-This is the entry point the `administration.html` section uses for
-"Data Collection Status" (via `AdministrationViewMixin.get_section`,
-which resolves `edc_metadata:home_url` when `AppConfig.home_url_name`
-is not set — and it isn't).
+Previously this url redirected to the CrfMetadata changelist via a
+``HomeRedirectView``; it now resolves to a login-protected ``HomeView``.
 """
 
 from django.test import TestCase, override_settings, tag
 from django.urls import reverse
 
-from edc_metadata.constants import REQUIRED
-
 
 @tag("metadata")
 @override_settings(SITE_ID=10)
-class TestHomeRedirect(TestCase):
+class TestHomeView(TestCase):
     def test_home_url_resolves(self):
         self.assertEqual(reverse("edc_metadata:home_url"), "/edc_metadata/")
 
-    def test_home_url_redirects_to_crfmetadata_with_required_filter(self):
+    def test_home_url_requires_login(self):
         response = self.client.get(reverse("edc_metadata:home_url"), follow=False)
         self.assertEqual(response.status_code, 302)
-        expected_path = reverse("edc_metadata_admin:edc_metadata_crfmetadata_changelist")
-        self.assertEqual(
-            response["Location"],
-            f"{expected_path}?entry_status__exact={REQUIRED}",
-        )
+        self.assertIn("/accounts/login/", response["Location"])

--- a/src/edc_metadata/tests/tests/test_leaderboard.py
+++ b/src/edc_metadata/tests/tests/test_leaderboard.py
@@ -1,0 +1,97 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import time_machine
+from clinicedc_tests.consents import consent_v1
+from clinicedc_tests.helper import Helper
+from clinicedc_tests.visit_schedules.visit_schedule_metadata.visit_schedule import (
+    get_visit_schedule,
+)
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings, tag
+from django.test.client import RequestFactory
+
+from edc_consent import site_consents
+from edc_facility.import_holidays import import_holidays
+from edc_lab.models.panel import Panel
+from edc_metadata.constants import REQUIRED
+from edc_metadata.models import CrfMetadata
+from edc_metadata.views.review_grid_view import MetadataReviewGridView, visit_columns
+from edc_visit_schedule.site_visit_schedules import site_visit_schedules
+
+utc_tz = ZoneInfo("UTC")
+
+
+@tag("metadata")
+@override_settings(SITE_ID=10)
+@time_machine.travel(datetime(2019, 8, 11, 8, 00, tzinfo=utc_tz))
+class TestLeaderboard(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        import_holidays()
+
+    def setUp(self):
+        self.user = User.objects.create(username="erik")
+        for name in ["one", "two", "three", "four", "five", "six", "seven", "eight", "nine"]:
+            Panel.objects.create(name=name)
+        site_consents.registry = {}
+        site_consents.register(consent_v1)
+        site_visit_schedules._registry = {}
+        site_visit_schedules.loaded = False
+        visit_schedule = get_visit_schedule(consent_v1)
+        site_visit_schedules.register(visit_schedule)
+
+        helper = Helper()
+        self.subject_visit = helper.enroll_to_baseline(
+            visit_schedule_name=visit_schedule.name, schedule_name="schedule"
+        )
+        self.appointment = self.subject_visit.appointment
+        self.subject_identifier = self.subject_visit.subject_identifier
+        self.vsn = self.appointment.visit_schedule_name
+        self.sn = self.appointment.schedule_name
+        self.baseline = self.appointment.visit_code
+
+    def _view(self):
+        view = MetadataReviewGridView()
+        view.request = RequestFactory().get("/review/?site=")
+        view.request.user = self.user
+        return view
+
+    def _leaderboard(self, tier_map=None):
+        view = self._view()
+        return view.leaderboard(
+            [10],
+            self.vsn,
+            self.sn,
+            None,
+            visit_columns(self.vsn, self.sn),
+            tier_map or {},
+        )
+
+    def test_one_row_per_required_crf_model_with_distinct_subjects(self):
+        expected_models = set(
+            CrfMetadata.objects.filter(
+                entry_status=REQUIRED, site_id=10, visit_code=self.baseline
+            ).values_list("model", flat=True)
+        )
+        rows = self._leaderboard()
+        self.assertEqual({r["model"] for r in rows}, expected_models)
+        for row in rows:
+            # one enrolled subject -> distinct subject count of 1
+            self.assertEqual(row["total"], 1)
+
+    def test_cell_handoff_url_carries_model_and_visit(self):
+        rows = self._leaderboard()
+        row = rows[0]
+        cell = next(c for c in row["cells"] if c["count"])
+        self.assertIn("lens=grid", cell["url"])
+        self.assertIn("visit_code=", cell["url"])
+        self.assertIn("models=", cell["url"])
+
+    def test_tier_one_rows_sort_first(self):
+        rows = self._leaderboard()
+        models = sorted(r["model"] for r in rows)
+        promoted = models[-1]  # last alphabetically; tier would otherwise not float it up
+        rows = self._leaderboard(tier_map={promoted: 1})
+        self.assertEqual(rows[0]["model"], promoted)
+        self.assertEqual(rows[0]["tier"], 1)

--- a/src/edc_metadata/tests/tests/test_review_grid.py
+++ b/src/edc_metadata/tests/tests/test_review_grid.py
@@ -1,0 +1,175 @@
+from datetime import datetime
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+import time_machine
+from clinicedc_tests.consents import consent_v1
+from clinicedc_tests.helper import Helper
+from clinicedc_tests.visit_schedules.visit_schedule_metadata.visit_schedule import (
+    get_visit_schedule,
+)
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings, tag
+from django.test.client import RequestFactory
+
+from edc_consent import site_consents
+from edc_dashboard.url_names import url_names
+from edc_facility.import_holidays import import_holidays
+from edc_lab.models.panel import Panel
+from edc_metadata.constants import KEYED, REQUIRED
+from edc_metadata.models import CrfMetadata, RequisitionMetadata
+from edc_metadata.views.review_grid_view import MetadataReviewGridView, visit_columns
+from edc_visit_schedule.site_visit_schedules import site_visit_schedules
+
+utc_tz = ZoneInfo("UTC")
+
+
+@tag("metadata")
+@override_settings(SITE_ID=10)
+@time_machine.travel(datetime(2019, 8, 11, 8, 00, tzinfo=utc_tz))
+class TestReviewGrid(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        import_holidays()
+
+    def setUp(self):
+        self.user = User.objects.create(username="erik")
+        for name in ["one", "two", "three", "four", "five", "six", "seven", "eight", "nine"]:
+            Panel.objects.create(name=name)
+        site_consents.registry = {}
+        site_consents.register(consent_v1)
+        site_visit_schedules._registry = {}
+        site_visit_schedules.loaded = False
+        visit_schedule = get_visit_schedule(consent_v1)
+        site_visit_schedules.register(visit_schedule)
+
+        helper = Helper()
+        self.subject_visit = helper.enroll_to_baseline(
+            visit_schedule_name=visit_schedule.name, schedule_name="schedule"
+        )
+        self.appointment = self.subject_visit.appointment
+        self.subject_identifier = self.subject_visit.subject_identifier
+        self.vsn = self.appointment.visit_schedule_name
+        self.sn = self.appointment.schedule_name
+        self.baseline = self.appointment.visit_code
+
+    def base(self, **extra):
+        opts = MetadataReviewGridView.base_filter(
+            [10], self.vsn, self.sn, extra.pop("visit_code", None), extra.pop("q", None)
+        )
+        opts.update(extra)
+        return opts
+
+    # -------------------------------------------------------------- base_filter
+    def test_base_filter_minimal(self):
+        opts = MetadataReviewGridView.base_filter([10], self.vsn, self.sn, None, None)
+        self.assertEqual(
+            opts,
+            dict(
+                entry_status=REQUIRED,
+                site_id__in=[10],
+                visit_schedule_name=self.vsn,
+                schedule_name=self.sn,
+            ),
+        )
+
+    def test_base_filter_with_visit_and_subject(self):
+        opts = MetadataReviewGridView.base_filter(
+            [10], self.vsn, self.sn, self.baseline, "105"
+        )
+        self.assertEqual(opts["visit_code"], self.baseline)
+        self.assertEqual(opts["subject_identifier__icontains"], "105")
+
+    # ----------------------------------------------------------- count helpers
+    def test_subject_totals_count_required_only(self):
+        expected = CrfMetadata.objects.filter(
+            entry_status=REQUIRED, site_id=10, subject_identifier=self.subject_identifier
+        ).count()
+        self.assertGreater(expected, 0)
+        totals = MetadataReviewGridView._subject_totals(CrfMetadata, self.base())
+        self.assertEqual(totals[self.subject_identifier], expected)
+
+    def test_keyed_metadata_excluded_from_required_count(self):
+        # The aggregation counts REQUIRED only. Flip one record to KEYED
+        # directly (a plain save bypasses metadata rules) and confirm the
+        # count drops by exactly one.
+        sid = self.subject_identifier
+        base = self.base()
+        before = MetadataReviewGridView._subject_totals(CrfMetadata, base)[sid]
+        pk = (
+            CrfMetadata.objects.filter(
+                entry_status=REQUIRED, site_id=10, subject_identifier=sid
+            )
+            .values_list("pk", flat=True)
+            .first()
+        )
+        CrfMetadata.objects.filter(pk=pk).update(entry_status=KEYED)
+        after = MetadataReviewGridView._subject_totals(CrfMetadata, base)[sid]
+        self.assertEqual(after, before - 1)
+
+    def test_cell_counts_keyed_by_subject_and_visit(self):
+        expected = CrfMetadata.objects.filter(
+            entry_status=REQUIRED,
+            site_id=10,
+            subject_identifier=self.subject_identifier,
+            visit_code=self.baseline,
+        ).count()
+        cells = MetadataReviewGridView._cell_counts(
+            CrfMetadata, self.base(), [self.subject_identifier]
+        )
+        self.assertEqual(cells[(self.subject_identifier, self.baseline)], expected)
+
+    def test_model_filter_narrows_count(self):
+        one = CrfMetadata.objects.filter(
+            entry_status=REQUIRED, subject_identifier=self.subject_identifier
+        ).values_list("model", flat=True)[0]
+        totals = MetadataReviewGridView._subject_totals(
+            CrfMetadata, self.base(model__in=[one])
+        )
+        self.assertEqual(totals[self.subject_identifier], 1)
+
+    def test_appointment_map_built_in_one_query(self):
+        with self.assertNumQueries(1):
+            appt_map = MetadataReviewGridView._appointment_map(
+                [self.subject_identifier], self.vsn, self.sn, [10]
+            )
+        self.assertIn((self.subject_identifier, self.baseline), appt_map)
+
+    # ------------------------------------------------------------------- grid()
+    def _grid(self, crf_only):
+        view = MetadataReviewGridView()
+        view.request = RequestFactory().get("/review/")
+        view.request.user = self.user
+        columns = visit_columns(self.vsn, self.sn)
+        with (
+            patch.object(url_names, "get", return_value="subject_dashboard_url"),
+            patch(
+                "edc_metadata.views.review_grid_view.reverse", return_value="/dash/"
+            ),
+        ):
+            return view.grid(
+                self.base(), self.base(), columns, self.vsn, self.sn, [10], crf_only
+            ), columns
+
+    def test_grid_totals_include_requisitions(self):
+        crf_n = CrfMetadata.objects.filter(entry_status=REQUIRED, site_id=10).count()
+        req_n = RequisitionMetadata.objects.filter(entry_status=REQUIRED, site_id=10).count()
+        self.assertGreater(req_n, 0)
+        ctx, _ = self._grid(crf_only=False)
+        self.assertEqual(ctx["grand_total"], crf_n + req_n)
+        self.assertEqual(ctx["subject_count"], 1)
+
+    def test_grid_crf_only_excludes_requisitions(self):
+        crf_n = CrfMetadata.objects.filter(entry_status=REQUIRED, site_id=10).count()
+        ctx, _ = self._grid(crf_only=True)
+        self.assertEqual(ctx["grand_total"], crf_n)
+
+    def test_grid_cell_links_to_dashboard(self):
+        ctx, columns = self._grid(crf_only=False)
+        row = next(
+            r for r in ctx["grid"] if r["subject_identifier"] == self.subject_identifier
+        )
+        baseline_index = [code for code, _ in columns].index(self.baseline)
+        cell = row["cells"][baseline_index]
+        self.assertEqual(cell["url"], "/dash/")
+        self.assertGreater(cell["crf"], 0)

--- a/src/edc_pdutils/utils/convert_visit_code_to_float.py
+++ b/src/edc_pdutils/utils/convert_visit_code_to_float.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:


### PR DESCRIPTION
Follow-up to #115 (metadata review screen): adds documentation and test coverage.

## Docs
New section in `docs/clinicedc_modules/edc_metadata.rst` describing the data-manager **Outstanding CRFs and Requisitions** review screen — the two lenses (leaderboard / subjects-by-visit grid), filters, `CrfPriority` and priority resolution order, the `crf_only` behavior, site scoping, and the metadata-freshness caveat.

## Tests (`src/edc_metadata/tests/tests/`)
- `test_crf_priority.py` — defaults, unique constraint, and that the admin form exposes only the explicit fields (no audit/system columns).
- `test_review_grid.py` — `base_filter` shape, REQUIRED-only counting, KEYED excluded, cell/column grouping, `model__in` filter, `crf_only` excluding requisitions, the appointment map built in a single query (`assertNumQueries(1)`), and cell→dashboard links.
- `test_leaderboard.py` — distinct-subject counts, tier-1 ordering, and the handoff URL carrying `model` + `visit_code`.
- `test_home_redirect.py` — updated for the `HomeView` (login-required) url change from #115; the old "redirects to changelist" assertion was obsolete.

Tests reuse the `clinicedc_tests` fixtures and derive expected counts from the DB. Full `--tag=metadata` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)