### PR TITLE
Export the CRF leaderboard to Excel

### DIFF
--- a/docs/clinicedc_modules/edc_metadata.rst
+++ b/docs/clinicedc_modules/edc_metadata.rst
@@ -52,7 +52,9 @@ Switch lenses with the ``?lens=`` parameter (default ``leaderboard``):
 * **Leaderboard** (``lens=leaderboard``) — rows are CRF types, columns are visit codes, and
   each cell is the number of **distinct subjects** with that CRF outstanding at that visit.
   Rows are ordered by descending outstanding count.
-  Clicking a cell hands off to the grid filtered to that CRF and visit.
+  Clicking a cell hands off to the grid filtered to that CRF and visit. The leaderboard can be
+  exported to ``.xlsx`` (respecting the current filters) via the **Export** button
+  (``ExportLeaderboardView``; requires ``openpyxl``).
 * **Subjects-by-visit grid** (``lens=grid``) — rows are subjects (ordered by
   ``subject_identifier``, paginated), columns are the schedule's visit codes, and each cell
   shows ``CRF / requisition`` outstanding counts. Row and column totals are included.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dependencies = [
     "inflect>=7.5.0",
     "mempass>=0.1.2",
     "mysqlclient>=2.2.7",
+    "openpyxl>=3.1.5",
     "psycopg2>=2.9.10",
     "pycups>=2.0.4",
     "pypdf>=5.9.0",

--- a/src/edc_metadata/templates/edc_metadata/review_outstanding_grid.html
+++ b/src/edc_metadata/templates/edc_metadata/review_outstanding_grid.html
@@ -187,6 +187,11 @@
         class="btn {% if lens == 'grid' %}btn-primary{% else %}btn-default{% endif %}">
         Subjects by visit grid</a>
      </div>
+          {% if lens == 'leaderboard' %}
+              <a href="{% url 'edc_metadata:export_leaderboard_url' %}?{{ filter_querystring }}" class="btn btn-default pull-right" style="margin-left:6px;" title="Export the leaderboard to Excel">
+                  <i class="fas fa-file-excel" aria-hidden="true"></i> Export
+              </a>
+          {% endif %}
           {% if unavailable_count %}
               <a href="{% url 'edc_metadata:unavailable_report_url' %}" class="btn btn-default pull-right" title="Review all forms flagged as data unavailable">
                   Review flagged: {{ unavailable_count }}

--- a/src/edc_metadata/tests/tests/test_export_leaderboard.py
+++ b/src/edc_metadata/tests/tests/test_export_leaderboard.py
@@ -1,0 +1,70 @@
+from datetime import datetime
+from io import BytesIO
+from zoneinfo import ZoneInfo
+
+import time_machine
+from clinicedc_tests.consents import consent_v1
+from clinicedc_tests.helper import Helper
+from clinicedc_tests.visit_schedules.visit_schedule_metadata.visit_schedule import (
+    get_visit_schedule,
+)
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings, tag
+from django.test.client import RequestFactory
+
+from edc_consent import site_consents
+from edc_facility.import_holidays import import_holidays
+from edc_lab.models.panel import Panel
+from edc_metadata.views.export_leaderboard_view import ExportLeaderboardView
+from edc_visit_schedule.site_visit_schedules import site_visit_schedules
+
+utc_tz = ZoneInfo("UTC")
+
+
+@tag("metadata")
+@override_settings(SITE_ID=10)
+@time_machine.travel(datetime(2019, 8, 11, 8, 00, tzinfo=utc_tz))
+class TestExportLeaderboard(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        import_holidays()
+
+    def setUp(self):
+        self.user = User.objects.create(username="erik")
+        for name in ["one", "two", "three", "four", "five", "six", "seven", "eight", "nine"]:
+            Panel.objects.create(name=name)
+        site_consents.registry = {}
+        site_consents.register(consent_v1)
+        site_visit_schedules._registry = {}
+        site_visit_schedules.loaded = False
+        visit_schedule = get_visit_schedule(consent_v1)
+        site_visit_schedules.register(visit_schedule)
+
+        helper = Helper()
+        self.subject_visit = helper.enroll_to_baseline(
+            visit_schedule_name=visit_schedule.name, schedule_name="schedule"
+        )
+        self.appointment = self.subject_visit.appointment
+        self.vsn = self.appointment.visit_schedule_name
+        self.sn = self.appointment.schedule_name
+
+    def test_export_returns_xlsx_workbook(self):
+        view = ExportLeaderboardView()
+        view.request = RequestFactory().get(
+            f"/export/?schedule={self.vsn}::{self.sn}&site=10"
+        )
+        view.request.user = self.user
+        view.allowed_site_ids = lambda: [10]
+        response = view.get(view.request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("spreadsheetml.sheet", response["Content-Type"])
+        self.assertIn("attachment;", response["Content-Disposition"])
+
+        from openpyxl import load_workbook  # noqa: PLC0415
+
+        ws = load_workbook(BytesIO(response.content)).active
+        self.assertEqual(ws.cell(row=1, column=1).value, "CRF")
+        self.assertEqual(ws.cell(row=1, column=ws.max_column).value, "Total")
+        # one header row + at least one CRF row
+        self.assertGreater(ws.max_row, 1)

--- a/src/edc_metadata/urls.py
+++ b/src/edc_metadata/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from .admin_site import edc_metadata_admin
 from .views import (
     DeleteReviewFilterView,
+    ExportLeaderboardView,
     HomeView,
     ReviewOutstandingDetailView,
     ReviewOutstandingFlaggedView,
@@ -35,6 +36,11 @@ urlpatterns = [
         "review-outstanding/filters/delete/",
         DeleteReviewFilterView.as_view(),
         name="delete_filter_url",
+    ),
+    path(
+        "review-outstanding/leaderboard-export/",
+        ExportLeaderboardView.as_view(),
+        name="export_leaderboard_url",
     ),
     path("", HomeView.as_view(), name="home_url"),
 ]

--- a/src/edc_metadata/views/__init__.py
+++ b/src/edc_metadata/views/__init__.py
@@ -1,3 +1,4 @@
+from .export_leaderboard_view import ExportLeaderboardView
 from .home_view import HomeView
 from .refresh_metadata_actions_view import RefreshMetadataActionsView
 from .review_filter_views import DeleteReviewFilterView, SaveReviewFilterView

--- a/src/edc_metadata/views/export_leaderboard_view.py
+++ b/src/edc_metadata/views/export_leaderboard_view.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+from django.http import HttpResponse, HttpResponseRedirect
+from django.urls import reverse
+from django.utils import timezone
+
+from ..models import CrfMetadata, CrfMetadataUnavailable
+from .review_outstanding_grid_view import ReviewOutstandingGridView, visit_columns
+
+XLSX_CONTENT_TYPE = (
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+)
+
+
+class ExportLeaderboardView(ReviewOutstandingGridView):
+    """Export the CRF leaderboard, respecting the current filters, as .xlsx.
+
+    Subclasses the board so all filter parsing and ``leaderboard()`` are reused.
+    """
+
+    def get(self, request, *args, **kwargs):  # noqa: ARG002
+        visit_schedule_name, schedule_name = self.selected_schedule()
+        if not visit_schedule_name:
+            return HttpResponseRedirect(reverse("edc_metadata:review_grid_url"))
+        site_ids = self.selected_site_ids()
+        columns = visit_columns(visit_schedule_name, schedule_name)
+        models = self.selected_models()
+        subject_q = self.request.GET.get("q", "").strip()
+        crf_base = self.base_filter(
+            site_ids,
+            visit_schedule_name,
+            schedule_name,
+            self.request.GET.get("visit_code") or None,
+            subject_q,
+        )
+        if models:
+            crf_base["model__in"] = models
+        crf_exclude = self._flagged_ids(CrfMetadata, CrfMetadataUnavailable, crf_base)
+        leaderboard = self.leaderboard(
+            site_ids,
+            visit_schedule_name,
+            schedule_name,
+            models,
+            columns,
+            subject_q,
+            crf_exclude,
+        )
+        return self._xlsx(leaderboard, columns, schedule_name)
+
+    @staticmethod
+    def _xlsx(leaderboard, columns, schedule_name) -> HttpResponse:
+        from openpyxl import Workbook  # noqa: PLC0415
+        from openpyxl.styles import Font  # noqa: PLC0415
+
+        wb = Workbook()
+        ws = wb.active
+        ws.title = "Leaderboard"
+        ws.append(["CRF", *[code for code, _ in columns], "Total"])
+        for cell in ws[1]:
+            cell.font = Font(bold=True)
+        for row in leaderboard:
+            ws.append(
+                [row["verbose_name"], *[c["count"] for c in row["cells"]], row["total"]]
+            )
+        stream = BytesIO()
+        wb.save(stream)
+        response = HttpResponse(stream.getvalue(), content_type=XLSX_CONTENT_TYPE)
+        stamp = timezone.now().strftime("%Y%m%d")
+        response["Content-Disposition"] = (
+            f'attachment; filename="leaderboard_{schedule_name}_{stamp}.xlsx"'
+        )
+        return response

--- a/uv.lock
+++ b/uv.lock
@@ -702,6 +702,7 @@ dependencies = [
     { name = "inflect" },
     { name = "mempass" },
     { name = "mysqlclient" },
+    { name = "openpyxl" },
     { name = "parse-trial-labs" },
     { name = "psycopg2" },
     { name = "pycups" },
@@ -778,6 +779,7 @@ requires-dist = [
     { name = "inflect", specifier = ">=7.5.0" },
     { name = "mempass", specifier = ">=0.1.2" },
     { name = "mysqlclient", specifier = ">=2.2.7" },
+    { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "parse-trial-labs", specifier = ">=0.4.0" },
     { name = "psycopg2", specifier = ">=2.9.10" },
     { name = "pycups", specifier = ">=2.0.4" },
@@ -1454,6 +1456,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
 ]
 
 [[package]]
@@ -2891,6 +2902,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/46/52fc0d2a68d7643f0f149eeea5a5d8ea2a3507056ac8afa83c9212606e8b/numpy-2.5.0-cp314-cp314t-win32.whl", hash = "sha256:edadfbd4794b1086c0d822f81863e8a68fc129d132fd0bb9e31e955d7fbbbdb7", size = 6253168, upload-time = "2026-06-21T20:57:45.101Z" },
     { url = "https://files.pythonhosted.org/packages/2a/be/6c8d1118b5f13b2881dc095d5b345de19c6638b8959c17409b6eff84c8aa/numpy-2.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f7e5fa4382967ae6548bd2f174219afb908e294b0d5f625af01166edd5f7d9aa", size = 12736286, upload-time = "2026-06-21T20:57:46.935Z" },
     { url = "https://files.pythonhosted.org/packages/fd/6a/d3a169aaf8536cf228d56a09e04bcb713a2fe4410d4e2105b9419b5a9c89/numpy-2.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:016623417bb330d719d579daf2d6b9a01ddc52e41a9ed61a47f39fde46dcd865", size = 10686451, upload-time = "2026-06-21T20:57:49.313Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds an **Export** button on the review board's **leaderboard** lens that downloads the leaderboard as an `.xlsx`, respecting the current filters (site, schedule, visit, CRFs, subject search).

## What's added
- **`ExportLeaderboardView`** (`export_leaderboard_url`) — subclasses `ReviewOutstandingGridView` so it reuses the filter parsing and `leaderboard()` aggregation, then streams an Excel workbook via **openpyxl**: one *Leaderboard* sheet with a bold header (`CRF` · each visit code · `Total`) and one row per CRF. Filename `leaderboard_<schedule>_<YYYYMMDD>.xlsx`. Gated by the existing `view_crfmetadata` permission.
- **Export button** on the leaderboard lens (top-right, Excel icon), carrying the current `filter_querystring` so the file matches the screen.
- **`openpyxl>=3.1.5`** added to `pyproject.toml` dependencies.
- `test_export_leaderboard.py` (asserts xlsx content-type, attachment, valid workbook with `CRF`/`Total` header) + a docs note.

No migration — read-only over existing data. Builds on #118 (already merged): uses `selected_models()` and the trimmed `leaderboard()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)