### PR TITLE
Stock take discrepancy report: site filter + richer PDF columns

### DIFF
--- a/src/edc_pharmacy/choices.py
+++ b/src/edc_pharmacy/choices.py
@@ -96,3 +96,31 @@ STOCK_TRANSACTION_CHOICES = (
     # Corrections
     (TXN_REVERSAL, "Reversal"),
 )
+
+# Three-letter, all-caps abbreviations for transaction_type, used in compact
+# report columns (e.g. the stock take discrepancy report "TXN" column).
+STOCK_TRANSACTION_ABBR = {
+    TXN_ALLOCATED: "ALC",
+    TXN_BIN_MOVED: "MVD",
+    TXN_DISPENSED: "DSP",
+    TXN_RECEIVED: "RCV",
+    TXN_REPACK_CONSUMED: "RPK",
+    TXN_STORED: "STR",
+    TXN_TRANSFER_DISPATCHED: "TRD",
+    TXN_TRANSFER_RECEIVED: "TRR",
+    # Remaining types — abbreviations not yet confirmed by the user.
+    TXN_ALLOCATION_ENDED: "ALE",
+    TXN_REPACK_PRODUCED: "RPP",
+    TXN_RETURN_REQUESTED: "RRQ",
+    TXN_RETURN_DISPATCHED: "RRD",
+    TXN_RETURN_RECEIVED: "RRR",
+    TXN_RETURN_DISPOSITION_REPOOLED: "RDP",
+    TXN_RETURN_DISPOSITION_QUARANTINED: "RDQ",
+    TXN_RETURN_DISPOSITION_DESTROYED: "RDD",
+    TXN_ADJUSTED: "ADJ",
+    TXN_DAMAGED: "DMG",
+    TXN_LOST: "LST",
+    TXN_EXPIRED: "EXP",
+    TXN_VOIDED: "VOD",
+    TXN_REVERSAL: "REV",
+}

--- a/src/edc_pharmacy/pdf_reports/stock_take_discrepancy_pdf_report.py
+++ b/src/edc_pharmacy/pdf_reports/stock_take_discrepancy_pdf_report.py
@@ -13,8 +13,13 @@ from edc_pdf_reports import NumberedCanvas as BaseNumberedCanvas
 from edc_pdf_reports import Report
 from edc_protocol.research_protocol_config import ResearchProtocolConfig
 
-from ..models import MISSING, UNEXPECTED, StockTake, StorageBin
+from ..choices import STOCK_TRANSACTION_ABBR, STOCK_TRANSACTION_CHOICES
+from ..constants import TXN_BIN_MOVED
+from ..models import MISSING, UNEXPECTED, StockTake, StockTransaction, StorageBin
 from ..utils import get_related_or_none
+
+# Compact action labels for the report (override the verbose choice display).
+_ACTION_LABELS = {TXN_BIN_MOVED: "Moved"}
 
 
 class NumberedCanvas(BaseNumberedCanvas):
@@ -35,8 +40,12 @@ _LOC_STYLE = ParagraphStyle(
 class StockTakeDiscrepancyReport(Report):
     """PDF report of stock take discrepancies, grouped by location."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, site_id=None, **kwargs):
         self.protocol_name = ResearchProtocolConfig().protocol_title
+        try:
+            self.site_id = int(site_id) if site_id else None
+        except (TypeError, ValueError):
+            self.site_id = None
         super().__init__(**kwargs)
 
     def draw_header(self, canvas, doc):  # noqa: ARG002
@@ -79,13 +88,42 @@ class StockTakeDiscrepancyReport(Report):
             story.append(HRFlowable(width="100%", thickness=0.5, color=colors.grey))
             story.append(Spacer(0.1 * cm, 0.3 * cm))
 
+        story.extend(self._legend_flowables())
         return story
 
+    @staticmethod
+    def _legend_flowables() -> list:
+        """Legend mapping each TXN abbreviation to its full transaction type."""
+        entries = [
+            f"<b>{STOCK_TRANSACTION_ABBR[txn_type]}</b>&nbsp;&nbsp;{display}"
+            for txn_type, display in STOCK_TRANSACTION_CHOICES
+            if txn_type in STOCK_TRANSACTION_ABBR
+        ]
+        ncols = 3
+        grid = [entries[i : i + ncols] for i in range(0, len(entries), ncols)]
+        for grid_row in grid:
+            grid_row.extend([""] * (ncols - len(grid_row)))
+        data = [[Paragraph(cell, _CELL_STYLE) for cell in grid_row] for grid_row in grid]
+        table = Table(data, colWidths=[9 * cm, 9 * cm, 9 * cm])
+        table.setStyle(TableStyle([
+            ("FONTSIZE", (0, 0), (-1, -1), 7),
+            ("VALIGN", (0, 0), (-1, -1), "TOP"),
+            ("LEFTPADDING", (0, 0), (-1, -1), 0),
+            ("TOPPADDING", (0, 0), (-1, -1), 1),
+            ("BOTTOMPADDING", (0, 0), (-1, -1), 1),
+        ]))
+        return [
+            Paragraph(_("TXN — last transaction codes").upper(), _LOC_STYLE),
+            Spacer(0.1 * cm, 0.15 * cm),
+            table,
+        ]
+
     def _build_rows(self) -> dict[str, tuple]:
-        bins = (
-            StorageBin.objects.filter(in_use=True)
-            .select_related("container", "location")
-            .order_by("location__display_name", "bin_identifier")
+        bins = StorageBin.objects.filter(in_use=True)
+        if self.site_id:
+            bins = bins.filter(location__site_id=self.site_id)
+        bins = bins.select_related("container", "location").order_by(
+            "location__display_name", "bin_identifier"
         )
         rows_by_location: dict[str, tuple] = {}
         for b in bins:
@@ -101,6 +139,7 @@ class StockTakeDiscrepancyReport(Report):
                 .select_related(
                     "stock__product__formulation",
                     "stock__allocation__registered_subject",
+                    "stock_transaction",
                 )
                 .order_by("status", "code")
             )
@@ -120,24 +159,68 @@ class StockTakeDiscrepancyReport(Report):
             ])
         return rows_by_location
 
+    @staticmethod
+    def _action_and_note(item) -> tuple[str, str]:
+        """The correction applied to a discrepancy and its audit note.
+
+        Returns ("", "") when the discrepancy is still open.
+        """
+        if item.resolved:
+            txn = item.stock_transaction
+            label = _ACTION_LABELS.get(txn.transaction_type) or (
+                txn.get_transaction_type_display()
+            )
+            return label, txn.reason
+        if item.acknowledged:
+            return _("Acknowledged"), item.acknowledged_note
+        return "", ""
+
+    @staticmethod
+    def _last_txn_abbr_by_stock(rows: list[dict]) -> dict:
+        """Map stock_id -> abbreviation of its most recent transaction_type.
+
+        One query for the whole table; the first row seen per stock (ordered by
+        descending datetime) is the latest. Stocks not in the ledger are omitted.
+        """
+        stock_ids = {row["item"].stock_id for row in rows if row["item"].stock_id}
+        last_type: dict = {}
+        for stock_id, txn_type in (
+            StockTransaction.objects.filter(stock_id__in=stock_ids)
+            .order_by("stock_id", "-transaction_datetime")
+            .values_list("stock_id", "transaction_type")
+        ):
+            last_type.setdefault(stock_id, txn_type)
+        return {
+            stock_id: STOCK_TRANSACTION_ABBR.get(txn_type, "")
+            for stock_id, txn_type in last_type.items()
+        }
+
     def _location_table(self, rows: list[dict]) -> Table:
-        col_widths = [2.5 * cm, 2.5 * cm, 3.5 * cm, 3.5 * cm, 5 * cm, 3 * cm, 3 * cm, 4 * cm]
+        col_widths = [
+            2.0 * cm, 3.5 * cm, 2.8 * cm, 3.6 * cm, 2.2 * cm,
+            2.0 * cm, 2.4 * cm, 4.0 * cm, 1.4 * cm,
+        ]
         data = [[
             Paragraph(_("BIN"), _HEADER_STYLE),
             Paragraph(_("CODE"), _HEADER_STYLE),
-            Paragraph(_("BARCODE"), _HEADER_STYLE),
             Paragraph(_("SUBJECT"), _HEADER_STYLE),
             Paragraph(_("PRODUCT"), _HEADER_STYLE),
-            Paragraph(_("DISCREPANCY"), _HEADER_STYLE),
+            Paragraph(_("ISSUE"), _HEADER_STYLE),
             Paragraph(_("STOCK TAKE DATE"), _HEADER_STYLE),
             Paragraph(_("ACTION"), _HEADER_STYLE),
+            Paragraph(_("AUDIT NOTE"), _HEADER_STYLE),
+            Paragraph(_("TXN"), _HEADER_STYLE),
         ]]
+
+        txn_abbr_by_stock = self._last_txn_abbr_by_stock(rows)
 
         for row in rows:
             item = row["item"]
             stock = item.stock
 
+            # Barcode with the human-readable code centered below it, one cell.
             barcode = code128.Code128(item.code, barHeight=5 * mm, barWidth=0.7, gap=1.7)
+            code_cell = [barcode, Paragraph(item.code, _CELL_CENTER)]
 
             subject_identifier = ""
             if stock and get_related_or_none(stock, "allocation"):
@@ -152,18 +235,21 @@ class StockTakeDiscrepancyReport(Report):
                 except AttributeError:
                     product_name = str(stock.product) if stock.product else ""
 
-            discrepancy = item.get_status_display()
-            take_date = localtime(row["stock_take_datetime"]).strftime("%d-%b-%Y %H:%M")
+            issue = item.get_status_display()
+            take_date = localtime(row["stock_take_datetime"]).strftime("%d-%b-%Y")
+            txn_abbr = txn_abbr_by_stock.get(item.stock_id, "")
+            action, audit_note = self._action_and_note(item)
 
             data.append([
                 Paragraph(row["bin"], _CELL_CENTER),
-                Paragraph(item.code, _CELL_CENTER),
-                barcode,
+                code_cell,
                 Paragraph(subject_identifier, _CELL_STYLE),
                 Paragraph(product_name, _CELL_STYLE),
-                Paragraph(discrepancy, _CELL_CENTER),
+                Paragraph(issue, _CELL_CENTER),
                 Paragraph(take_date, _CELL_CENTER),
-                Paragraph("", _CELL_STYLE),
+                Paragraph(action, _CELL_CENTER),
+                Paragraph(audit_note, _CELL_STYLE),
+                Paragraph(txn_abbr, _CELL_CENTER),
             ])
 
         table = Table(data, colWidths=col_widths, repeatRows=1)

--- a/src/edc_pharmacy/pdf_reports/stock_take_discrepancy_pdf_report.py
+++ b/src/edc_pharmacy/pdf_reports/stock_take_discrepancy_pdf_report.py
@@ -94,11 +94,15 @@ class StockTakeDiscrepancyReport(Report):
     @staticmethod
     def _legend_flowables() -> list:
         """Legend mapping each TXN abbreviation to its full transaction type."""
-        entries = [
-            f"<b>{STOCK_TRANSACTION_ABBR[txn_type]}</b>&nbsp;&nbsp;{display}"
-            for txn_type, display in STOCK_TRANSACTION_CHOICES
-            if txn_type in STOCK_TRANSACTION_ABBR
-        ]
+        pairs = sorted(
+            (
+                (STOCK_TRANSACTION_ABBR[txn_type], display)
+                for txn_type, display in STOCK_TRANSACTION_CHOICES
+                if txn_type in STOCK_TRANSACTION_ABBR
+            ),
+            key=lambda pair: pair[0],
+        )
+        entries = [f"<b>{abbr}</b>&nbsp;&nbsp;{display}" for abbr, display in pairs]
         ncols = 3
         grid = [entries[i : i + ncols] for i in range(0, len(entries), ncols)]
         for grid_row in grid:

--- a/src/edc_pharmacy/pdf_reports/stock_take_discrepancy_pdf_report.py
+++ b/src/edc_pharmacy/pdf_reports/stock_take_discrepancy_pdf_report.py
@@ -103,10 +103,13 @@ class StockTakeDiscrepancyReport(Report):
             key=lambda pair: pair[0],
         )
         entries = [f"<b>{abbr}</b>&nbsp;&nbsp;{display}" for abbr, display in pairs]
+        # Fill column-major so each column reads alphabetically top-to-bottom.
         ncols = 3
-        grid = [entries[i : i + ncols] for i in range(0, len(entries), ncols)]
-        for grid_row in grid:
-            grid_row.extend([""] * (ncols - len(grid_row)))
+        nrows = -(-len(entries) // ncols)
+        columns = [entries[c * nrows : (c + 1) * nrows] for c in range(ncols)]
+        grid = [
+            [col[r] if r < len(col) else "" for col in columns] for r in range(nrows)
+        ]
         data = [[Paragraph(cell, _CELL_STYLE) for cell in grid_row] for grid_row in grid]
         table = Table(data, colWidths=[9 * cm, 9 * cm, 9 * cm])
         table.setStyle(TableStyle([

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_take_discrepancy_report.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_take_discrepancy_report.html
@@ -32,6 +32,11 @@
                         var node = rows.nodes()[0];
                         var $td = $('<td colspan="4"/>');
                         $td.append($('<strong/>').text('Bin ' + $(node).data('bin-label')));
+                        var takeDate = $(node).data('take-date');
+                        if (takeDate) {
+                            $td.append($('<span class="text-muted"/>')
+                                .text(' — last stock take ' + takeDate));
+                        }
                         $td.append(' &middot; ' + rows.count() + ' to resolve &nbsp;');
                         $td.append($('<a class="btn btn-primary btn-xs"/>')
                             .attr('href', $(node).data('redo-url')).text('Redo stock take'));
@@ -55,15 +60,29 @@
             <div style="padding:10px;display:flex;align-items:center;justify-content:space-between;">
                 <span>
                     <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
-                    <a href="{% url "edc_pharmacy:stock_take_home_url" %}">Stock Take</a> &rsaquo;
+                    <a href="{% url "edc_pharmacy:stock_take_home_url" %}{% if selected_site_id %}?site={{ selected_site_id }}{% endif %}">Stock Take</a> &rsaquo;
                     Discrepancy Report
                 </span>
-                {% if items %}
-                <a href="{% url "edc_pharmacy:print_stock_take_discrepancy_report_url" %}"
-                   class="btn btn-default btn-sm">
-                    <i class="fa fa-print"></i> Print PDF
-                </a>
-                {% endif %}
+                <span style="display:flex;align-items:center;gap:8px;">
+                    {% if site_choices %}
+                    <form method="get" style="margin:0;">
+                        <label class="text-muted small" style="margin:0 4px 0 0;">Site</label>
+                        <select name="site" class="form-control input-sm" style="width:auto;display:inline-block;"
+                                onchange="this.form.submit()">
+                            <option value="">All sites</option>
+                            {% for site in site_choices %}
+                            <option value="{{ site.id }}"{% if site.id == selected_site_id %} selected{% endif %}>{{ site.display_name }}</option>
+                            {% endfor %}
+                        </select>
+                    </form>
+                    {% endif %}
+                    {% if items %}
+                    <a href="{% url "edc_pharmacy:print_stock_take_discrepancy_report_url" %}{% if selected_site_id %}?site={{ selected_site_id }}{% endif %}"
+                       class="btn btn-default btn-sm">
+                        <i class="fa fa-print"></i> Print PDF
+                    </a>
+                    {% endif %}
+                </span>
             </div>
 
             {% if not items %}
@@ -84,6 +103,7 @@
                 <tbody>
                     {% for item in items %}
                     <tr data-bin-label="{{ item.stock_take.storage_bin.bin_identifier }}"
+                        data-take-date="{{ item.stock_take.stock_take_datetime|date:'d M Y' }}"
                         data-redo-url="{% url 'edc_pharmacy:stock_take_scan_url' storage_bin=item.stock_take.storage_bin.pk %}"
                         data-results-url="{% url 'edc_pharmacy:stock_take_results_url' stock_take=item.stock_take.pk %}">
                         <td>{{ item.stock_take.storage_bin.bin_identifier }}</td>
@@ -113,7 +133,7 @@
             {% endif %}
 
             <p style="margin-top:10px;">
-                <a href="{% url "edc_pharmacy:stock_take_home_url" %}" class="btn btn-default btn-sm">All bins</a>
+                <a href="{% url "edc_pharmacy:stock_take_home_url" %}{% if selected_site_id %}?site={{ selected_site_id }}{% endif %}" class="btn btn-default btn-sm">All bins</a>
             </p>
 
         </div>

--- a/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_take_home.html
+++ b/src/edc_pharmacy/templates/edc_pharmacy/stock/stock_take_home.html
@@ -35,8 +35,22 @@
                     <a href="{% url "edc_pharmacy:home_url" %}">Edc Pharmacy</a> &rsaquo;
                     Stock Take
                 </span>
-                <a href="{% url "edc_pharmacy:stock_take_discrepancy_report_url" %}"
-                   class="btn btn-default btn-sm">Discrepancy report</a>
+                <span style="display:flex;align-items:center;gap:8px;">
+                    {% if site_choices %}
+                    <form method="get" style="margin:0;">
+                        <label class="text-muted small" style="margin:0 4px 0 0;">Site</label>
+                        <select name="site" class="form-control input-sm" style="width:auto;display:inline-block;"
+                                onchange="this.form.submit()">
+                            <option value="">All sites</option>
+                            {% for site in site_choices %}
+                            <option value="{{ site.id }}"{% if site.id == selected_site_id %} selected{% endif %}>{{ site.display_name }}</option>
+                            {% endfor %}
+                        </select>
+                    </form>
+                    {% endif %}
+                    <a href="{% url "edc_pharmacy:stock_take_discrepancy_report_url" %}{% if selected_site_id %}?site={{ selected_site_id }}{% endif %}"
+                       class="btn btn-default btn-sm">Discrepancy report</a>
+                </span>
             </div>
 
             {% if rows %}

--- a/src/edc_pharmacy/views/print_stock_take_discrepancy_report_view.py
+++ b/src/edc_pharmacy/views/print_stock_take_discrepancy_report_view.py
@@ -24,6 +24,7 @@ def print_stock_take_discrepancy_report_view(request):
     )
     report = StockTakeDiscrepancyReport(
         request=request,
+        site_id=request.GET.get("site"),
         footer_row_height=20,
         page=page,
         numbered_canvas=NumberedCanvas,

--- a/src/edc_pharmacy/views/stock_take_discrepancy_report_view.py
+++ b/src/edc_pharmacy/views/stock_take_discrepancy_report_view.py
@@ -21,6 +21,7 @@ from edc_protocol.view_mixins import EdcProtocolViewMixin
 
 from ..models import MISSING, UNEXPECTED, StockTake, StockTakeItem, StorageBin
 from .stock_take_conflicts import annotate_conflicts
+from .stock_take_site_filter import get_selected_site_id, stock_take_site_choices
 
 
 @method_decorator(login_required, name="dispatch")
@@ -32,11 +33,17 @@ class StockTakeDiscrepancyReportView(
     navbar_selected_item = "pharmacy"
 
     def get_context_data(self, **kwargs):
-        bins = (
-            StorageBin.objects.filter(in_use=True)
-            .select_related("container", "location")
-            .order_by("location__display_name", "bin_identifier")
-        )
+        base = StorageBin.objects.filter(in_use=True)
+
+        # Sites the user can choose from: only those with in-use bins. The
+        # default ("All sites") leaves the report unfiltered.
+        site_choices = stock_take_site_choices(base)
+        selected_site_id = get_selected_site_id(self.request, site_choices)
+
+        bins = base.select_related("container", "location")
+        if selected_site_id:
+            bins = bins.filter(location__site_id=selected_site_id)
+        bins = bins.order_by("location__display_name", "bin_identifier")
 
         # One flat, bin-ordered list of discrepancies (missing then unexpected
         # within each bin) for a single grouped DataTable.
@@ -64,4 +71,9 @@ class StockTakeDiscrepancyReportView(
             items.extend(bin_items)
 
         annotate_conflicts(items)
-        return super().get_context_data(items=items, **kwargs)
+        return super().get_context_data(
+            items=items,
+            site_choices=site_choices,
+            selected_site_id=selected_site_id,
+            **kwargs,
+        )

--- a/src/edc_pharmacy/views/stock_take_home_view.py
+++ b/src/edc_pharmacy/views/stock_take_home_view.py
@@ -17,6 +17,7 @@ from edc_navbar import NavbarViewMixin
 from edc_protocol.view_mixins import EdcProtocolViewMixin
 
 from ..models import StockTake, StorageBin, StorageBinItem
+from .stock_take_site_filter import get_selected_site_id, stock_take_site_choices
 
 
 @method_decorator(login_required, name="dispatch")
@@ -37,12 +38,19 @@ class StockTakeHomeView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Tem
             .values("c")
         )
 
-        bins = (
-            StorageBin.objects.filter(in_use=True)
-            .select_related("container", "location")
-            .annotate(item_count=Subquery(item_count_sq, output_field=IntegerField()))
-            .order_by("location__display_name", "bin_identifier")
+        base = StorageBin.objects.filter(in_use=True)
+
+        # Shared with the discrepancy report: "All sites" (no selection) leaves
+        # the bin list unfiltered.
+        site_choices = stock_take_site_choices(base)
+        selected_site_id = get_selected_site_id(self.request, site_choices)
+
+        bins = base.select_related("container", "location").annotate(
+            item_count=Subquery(item_count_sq, output_field=IntegerField())
         )
+        if selected_site_id:
+            bins = bins.filter(location__site_id=selected_site_id)
+        bins = bins.order_by("location__display_name", "bin_identifier")
 
         rows = []
         for b in bins:
@@ -56,4 +64,9 @@ class StockTakeHomeView(EdcViewMixin, NavbarViewMixin, EdcProtocolViewMixin, Tem
                 "last_take": last,
             })
 
-        return super().get_context_data(rows=rows, **kwargs)
+        return super().get_context_data(
+            rows=rows,
+            site_choices=site_choices,
+            selected_site_id=selected_site_id,
+            **kwargs,
+        )

--- a/src/edc_pharmacy/views/stock_take_site_filter.py
+++ b/src/edc_pharmacy/views/stock_take_site_filter.py
@@ -1,0 +1,62 @@
+"""Shared site filter for the stock-take pages.
+
+The stock-take home page and the discrepancy report share one ``?site=``
+selection. "All sites" (no selection) leaves the bin list unfiltered.
+
+Selector labels use the site *display name* from the ``edc_sites`` global
+registry (``sites.get(site_id).description``), not the raw Site.name.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from django.core.handlers.wsgi import WSGIRequest
+from django.db.models import QuerySet
+
+from edc_sites.site import SiteNotRegistered, sites
+
+
+@dataclass(frozen=True)
+class SiteChoice:
+    """A selectable site for the stock-take filter."""
+
+    id: int
+    display_name: str
+
+
+def _display_name(site_id: int) -> str:
+    """Display name from the edc_sites global, falling back to the id."""
+    try:
+        return sites.get(site_id).description
+    except SiteNotRegistered:
+        return str(site_id)
+
+
+def stock_take_site_choices(bin_qs: QuerySet) -> list[SiteChoice]:
+    """Sites that have at least one bin in ``bin_qs``, ordered by display name."""
+    site_ids = (
+        bin_qs.exclude(location__site__isnull=True)
+        .values_list("location__site_id", flat=True)
+        .distinct()
+    )
+    choices = [
+        SiteChoice(id=site_id, display_name=_display_name(site_id)) for site_id in site_ids
+    ]
+    return sorted(choices, key=lambda choice: choice.display_name)
+
+
+def get_selected_site_id(request: WSGIRequest, site_choices: list[SiteChoice]) -> int | None:
+    """Return the chosen site id from ``?site=``, or None for "All sites".
+
+    Anything that is not one of the offered sites is ignored.
+    """
+    raw = request.GET.get("site")
+    if not raw:
+        return None
+    try:
+        candidate = int(raw)
+    except (TypeError, ValueError):
+        return None
+    valid_ids = {choice.id for choice in site_choices}
+    return candidate if candidate in valid_ids else None


### PR DESCRIPTION
## Summary

Enhancements to the **stock take** pages in `edc_pharmacy`. The "most recent stock take per bin" rule is unchanged; this adds a site filter and richer reporting columns.

### Site filter (both stock-take pages)
- Shared `?site=` filter on the stock-take **home** page and the **discrepancy report**, via new `views/stock_take_site_filter.py`.
- Default option is **All sites**; selecting a site narrows bins by `location__site`.
- Selector labels use the `edc_sites` **display name** (`sites.get(site_id).description`), guarded against `SiteNotRegistered`.
- Selection is carried across the **[Discrepancy report]** button, the **Stock Take** breadcrumb, the **All bins** button, and the **Print PDF** link.

### Discrepancy report (HTML)
- Show the **last stock take date** next to the bin in the DataTables group header.

### Discrepancy report (PDF)
- **ACTION** + **AUDIT NOTE**: show the correction applied (e.g. *Moved*, *Lost*, *Acknowledged*) and its note for handled rows; blank when still open.
- **TXN** column (last column): 3-letter abbreviation of the stock's most recent `transaction_type`, with a **legend** at the foot of the report. Map `STOCK_TRANSACTION_ABBR` added to `choices.py`.
- **CODE + BARCODE merged** into one column (human-readable code centered below the barcode).
- **DISCREPANCY → ISSUE**; stock take date is now date-only.
- Honors the same `?site=` filter as the screen.

## Notes
- No migration required (no model changes).
- `ruff` passes on all changed files (pre-existing E501s in the PDF module left untouched).

## Test plan
- [ ] Render the PDF from the discrepancy report **Print PDF** button; verify the merged barcode/code cell, TXN column, and legend.
- [ ] Switch the site selector on both pages; confirm the filter and that the selection carries across navigation.
- [ ] Automated coverage for the site filter is **not yet added** — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)