### PR TITLE
fix: strip tz from tz-aware datetime columns when remove_timezone=True

### DIFF
--- a/src/edc_model_to_dataframe/model_to_dataframe.py
+++ b/src/edc_model_to_dataframe/model_to_dataframe.py
@@ -163,9 +163,13 @@ class ModelToDataframe:
 
             df = df.rename(columns=self.columns)
 
-            # remove timezone if asked
+            # remove timezone if asked. Note: tz-aware columns
+            # (datetime64[ns, UTC]) are selected with "datetimetz", not
+            # "datetime" (which only matches tz-naive datetime64). With
+            # USE_TZ=True Django datetimes are tz-aware, so selecting on
+            # "datetime" alone stripped nothing.
             if self.remove_timezone:
-                for column in df.select_dtypes(include="datetime").columns:
+                for column in df.select_dtypes(include="datetimetz").columns:
                     df[column] = df[column].dt.tz_localize(None)
 
             # convert bool to int64

--- a/src/edc_model_to_dataframe/tests/tests/test_to_df.py
+++ b/src/edc_model_to_dataframe/tests/tests/test_to_df.py
@@ -120,6 +120,30 @@ class TestExport(TestCase):
                 ),
             )
 
+    def test_remove_timezone(self):
+        model = "clinicedc_tests.crffour"
+
+        # remove_timezone=True (default) must strip tz from datetime columns
+        df = ModelToDataframe(model=model).dataframe
+        self.assertGreater(
+            len(df.select_dtypes(include="datetime").columns),
+            0,
+            msg="expected at least one tz-naive datetime column",
+        )
+        self.assertEqual(
+            list(df.select_dtypes(include="datetimetz").columns),
+            [],
+            msg="tz-aware datetime columns were not stripped",
+        )
+
+        # remove_timezone=False must keep datetime columns tz-aware
+        df = ModelToDataframe(model=model, remove_timezone=False).dataframe
+        self.assertGreater(
+            len(df.select_dtypes(include="datetimetz").columns),
+            0,
+            msg="expected tz-aware datetime columns to be retained",
+        )
+
     def test_encrypted_none(self):
         model = "clinicedc_tests.crfencrypted"
         m = ModelToDataframe(model=model)


### PR DESCRIPTION
## Summary

`ModelToDataframe.remove_timezone` was effectively a no-op for normal Django data.

The strip loop selected columns with `select_dtypes(include="datetime")`, which only matches **tz-naive** `datetime64` columns. With `USE_TZ=True`, Django datetimes come through as **tz-aware** `datetime64[ns, UTC]`, which that selector never matches — so `remove_timezone=True` stripped nothing.

This switches the selector to `include="datetimetz"`, so tz-aware columns are actually localized to naive. `tz_localize(None)` is only valid on tz-aware columns, so selecting on `datetimetz` is also the correct dtype to call it on.

## Why it matters

Downstream STATA export (`edc_export`) passes `remove_timezone=True` expecting naive datetimes, because `to_stata` cannot write tz-aware datetimes (`datetime64[..., UTC]`). With the flag silently doing nothing, those exports failed with `NotImplementedError: Data type datetime64[us, UTC] not supported`.

## Test

Adds `test_remove_timezone` to `edc_model_to_dataframe`:
- `remove_timezone=True` (default) → no `datetimetz` columns remain (and tz-naive datetime columns are present)
- `remove_timezone=False` → tz-aware datetime columns are retained

`uv run --dev python runtests.py --tag=model_to_dataframe` → 9 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)