### PR TITLE
fix: make STATA export tolerant of uuid pk/fk and all-null columns

### DIFF
--- a/src/edc_export/models_to_file.py
+++ b/src/edc_export/models_to_file.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shutil
 import sys
+import uuid
 from pathlib import Path
 from tempfile import mkdtemp
 from typing import TYPE_CHECKING
@@ -157,6 +158,7 @@ class ModelsToFile:
                     )
                 elif self.export_format in [STATA_14, STATA_15]:
                     path = self.export_folder / self.sub_folder / f"{fname}.dta"
+                    dataframe = self.make_stata_safe(dataframe)
                     dataframe.to_stata(
                         path,
                         data_label=str(path),
@@ -184,6 +186,37 @@ class ModelsToFile:
             root_dir=self.export_folder,
             base_dir=self.sub_folder,
         )
+
+    @staticmethod
+    def make_stata_safe(dataframe: pd.DataFrame) -> pd.DataFrame:
+        """Coerce columns that pandas `to_stata` cannot write.
+
+        Handles two things `to_stata` cannot write but are valid in a plain
+        dataframe (and fine for `to_csv`):
+        - object columns holding uuid.UUID values (the pk `id` and FK `*_id`
+          columns, which arrive from `.values()` as uuid.UUID objects)
+        - object/string columns that are entirely null (e.g. a nullable
+          text/date field with no values for this queryset)
+
+        Applied only for the STATA export. Null text values are written as
+        empty strings, matching how STATA represents missing strings.
+
+        Note: tz-aware datetime columns are also unsupported by `to_stata`,
+        but those are stripped upstream by
+        ModelToDataframe(remove_timezone=True), which is how this exporter
+        always builds the frame.
+        """
+        for column in dataframe.select_dtypes(include="object").columns:
+            dataframe[column] = dataframe[column].map(
+                lambda v: str(v) if isinstance(v, uuid.UUID) else v
+            )
+        for column in dataframe.columns:
+            is_text = dataframe[column].dtype == object or isinstance(
+                dataframe[column].dtype, pd.StringDtype
+            )
+            if is_text and dataframe[column].isna().all():
+                dataframe[column] = ""
+        return dataframe
 
     def stata_variable_labels(self, dataframe: pd.DataFrame, model: str) -> dict[str, str]:
         variable_labels = dict(id="primary key")

--- a/src/edc_export/tests/tests/test_models_to_file.py
+++ b/src/edc_export/tests/tests/test_models_to_file.py
@@ -2,13 +2,14 @@ import shutil
 from pathlib import Path
 from tempfile import mkdtemp
 
+import pandas as pd
 from clinicedc_tests.sites import all_sites
 from clinicedc_tests.utils import get_user_for_tests
 from django.contrib.sites.models import Site
 from django.test import TestCase
 from django.test.utils import override_settings, tag
 
-from edc_export.constants import CSV
+from edc_export.constants import CSV, STATA_14
 from edc_export.models_to_file import ModelsToFile, ModelsToFileNothingExportedError
 from edc_facility.import_holidays import import_holidays
 from edc_registration.models import RegisteredSubject
@@ -51,6 +52,34 @@ class TestArchiveExporter(TestCase):
         filename = Path(exporter.archive_filename)
         self.assertIsNotNone(filename)
         self.assertTrue(filename.exists(), msg=f"file '{filename}' does not exist")
+
+    def test_request_archive_stata(self):
+        """A STATA export must not raise on UUID pk/fk columns.
+
+        Regression: the 'id' and '*_id' columns arrive as uuid.UUID objects
+        (object dtype) and 'last_login' (auth.user) is all-null. to_stata
+        rejects object columns that are not all strings/None, so without
+        coercion this raised "ValueError: Column `id` cannot be exported".
+        """
+        exporter = ModelsToFile(
+            models=self.models,
+            user=self.user,
+            archive_to_single_file=True,
+            export_format=STATA_14,
+        )
+        folder = Path(mkdtemp())
+        shutil.unpack_archive(exporter.archive_filename, folder, "zip")
+        dta_files = list(folder.rglob("*.dta"))
+        self.assertGreater(len(dta_files), 0, msg="no .dta files were exported")
+        # the exported file must be readable back and carry the uuid pk as string
+        registeredsubject_dta = next(
+            f for f in dta_files if "registeredsubject" in f.name.lower()
+        )
+        df = pd.read_stata(registeredsubject_dta)
+        self.assertIn("id", df.columns)
+        # the uuid pk must round-trip as a non-null string, not a uuid object
+        self.assertTrue(df["id"].notna().all())
+        self.assertIsInstance(df["id"].iloc[0], str)
 
     def test_requested_with_invalid_table(self):
         models = ["auth.blah", "edc_registration.registeredsubject"]


### PR DESCRIPTION
## Summary

`export_models` (STATA format) crashed with `ValueError: Column \`id\` cannot be exported`.

pandas `to_stata` rejects object columns that are not all strings/None. Two kinds of column hit this:
- the pk `id` and FK `*_id` columns come from `.values()` as `uuid.UUID` objects (object dtype)
- nullable text/date fields with no values for the queryset are all-null object columns (e.g. `auth.user.last_login`)

`to_csv` tolerates both (it `str()`s values), which is why only STATA export failed.

## Change

Adds `ModelsToFile.make_stata_safe()`, applied **only on the STATA branch**, which:
- coerces `uuid.UUID` values → `str`
- coerces all-null text (object/`string` dtype) columns → empty string (how STATA represents missing strings)

`ModelToDataframe` is deliberately left untouched — it keeps producing a faithful dataframe (real uuid objects, real `NA`s) for CSV and other consumers. The export-format-specific massaging lives in the exporter.

tz-aware datetime columns (another `to_stata` limitation) are handled upstream by `ModelToDataframe(remove_timezone=True)`, fixed in #128.

## Test

Adds `test_request_archive_stata` to `edc_export`, exporting `auth.user` + `edc_registration.registeredsubject` as STATA and reading the `.dta` back. Covers both failure modes (uuid pk + all-null `last_login`).

`uv run --dev python runtests.py --tag=export` → 30 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)