### PR TITLE
fix: make STATA export handle DateField and any leftover object dtype

### DIFF
--- a/src/edc_export/models_to_file.py
+++ b/src/edc_export/models_to_file.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import shutil
 import sys
 import uuid
+from datetime import date
 from pathlib import Path
 from tempfile import mkdtemp
 from typing import TYPE_CHECKING
@@ -191,31 +192,52 @@ class ModelsToFile:
     def make_stata_safe(dataframe: pd.DataFrame) -> pd.DataFrame:
         """Coerce columns that pandas `to_stata` cannot write.
 
-        Handles two things `to_stata` cannot write but are valid in a plain
-        dataframe (and fine for `to_csv`):
-        - object columns holding uuid.UUID values (the pk `id` and FK `*_id`
-          columns, which arrive from `.values()` as uuid.UUID objects)
-        - object/string columns that are entirely null (e.g. a nullable
-          text/date field with no values for this queryset)
+        `to_stata` only writes object columns that are all strings/None;
+        everything else must be a recognised dtype. Several column kinds are
+        valid in a plain dataframe (and fine for `to_csv`) but trip this up.
+        Handled here, in order:
 
-        Applied only for the STATA export. Null text values are written as
-        empty strings, matching how STATA represents missing strings.
+        1. uuid.UUID values (the pk `id` and FK `*_id` columns, which arrive
+           from `.values()` as uuid.UUID objects) -> str
+        2. DateField values, which arrive as datetime.date objects (object
+           dtype) -> datetime64 so STATA writes them as dates
+        3. object/string columns that are entirely null (e.g. a nullable
+           field with no values for this queryset) -> "" (how STATA
+           represents a missing string); to_stata prohibits all-null object
+           columns
+        4. anything still left as object dtype (e.g. datetime.time from a
+           TimeField, Decimal, mixed) -> string, so to_stata never sees a raw
+           python object
 
-        Note: tz-aware datetime columns are also unsupported by `to_stata`,
-        but those are stripped upstream by
+        Applied only for the STATA export. tz-aware datetime columns are also
+        unsupported by `to_stata`, but those are stripped upstream by
         ModelToDataframe(remove_timezone=True), which is how this exporter
         always builds the frame.
         """
+        # 1. uuid.UUID -> str
         for column in dataframe.select_dtypes(include="object").columns:
             dataframe[column] = dataframe[column].map(
                 lambda v: str(v) if isinstance(v, uuid.UUID) else v
             )
+        # 2. datetime.date (DateField) -> datetime64. datetime.datetime is a
+        #    date subclass but comes through as datetime64, not object, so it
+        #    is not matched here.
+        for column in dataframe.select_dtypes(include="object").columns:
+            non_null = dataframe[column].dropna()
+            if not non_null.empty and non_null.map(
+                lambda v: isinstance(v, date)
+            ).all():
+                dataframe[column] = pd.to_datetime(dataframe[column])
+        # 3. all-null object/string columns -> ""
         for column in dataframe.columns:
             is_text = dataframe[column].dtype == object or isinstance(
                 dataframe[column].dtype, pd.StringDtype
             )
             if is_text and dataframe[column].isna().all():
                 dataframe[column] = ""
+        # 4. any remaining object column -> string
+        for column in dataframe.select_dtypes(include="object").columns:
+            dataframe[column] = dataframe[column].astype("string")
         return dataframe
 
     def stata_variable_labels(self, dataframe: pd.DataFrame, model: str) -> dict[str, str]:

--- a/src/edc_export/tests/tests/test_models_to_file.py
+++ b/src/edc_export/tests/tests/test_models_to_file.py
@@ -1,4 +1,5 @@
 import shutil
+from datetime import date
 from pathlib import Path
 from tempfile import mkdtemp
 
@@ -33,7 +34,11 @@ class TestArchiveExporter(TestCase):
     def setUp(self):
         self.user = get_user_for_tests(username="erikvw")
         Site.objects.get_current()
-        RegisteredSubject.objects.create(subject_identifier="12345")
+        # dob is a populated DateField (datetime.date object); leaving other
+        # nullable fields unset also exercises the all-null column path
+        RegisteredSubject.objects.create(
+            subject_identifier="12345", dob=date(1990, 6, 15)
+        )
         self.models = ["auth.user", "edc_registration.registeredsubject"]
 
     def test_request_archive(self):
@@ -54,12 +59,13 @@ class TestArchiveExporter(TestCase):
         self.assertTrue(filename.exists(), msg=f"file '{filename}' does not exist")
 
     def test_request_archive_stata(self):
-        """A STATA export must not raise on UUID pk/fk columns.
+        """A STATA export must not raise on object columns to_stata can't write.
 
-        Regression: the 'id' and '*_id' columns arrive as uuid.UUID objects
-        (object dtype) and 'last_login' (auth.user) is all-null. to_stata
-        rejects object columns that are not all strings/None, so without
-        coercion this raised "ValueError: Column `id` cannot be exported".
+        Regression cases, all object dtype in the dataframe but rejected by
+        to_stata ("Column `x` cannot be exported"):
+        - 'id'/'*_id' arrive as uuid.UUID objects
+        - 'last_login' (auth.user) is all-null
+        - 'dob' (DateField) arrives as datetime.date objects
         """
         exporter = ModelsToFile(
             models=self.models,
@@ -80,6 +86,9 @@ class TestArchiveExporter(TestCase):
         # the uuid pk must round-trip as a non-null string, not a uuid object
         self.assertTrue(df["id"].notna().all())
         self.assertIsInstance(df["id"].iloc[0], str)
+        # a populated DateField round-trips as a datetime, not a raw date object
+        self.assertIn("dob", df.columns)
+        self.assertEqual(pd.Timestamp(df["dob"].iloc[0]).date(), date(1990, 6, 15))
 
     def test_requested_with_invalid_table(self):
         models = ["auth.blah", "edc_registration.registeredsubject"]


### PR DESCRIPTION
## Summary

Follow-up to #129. After the uuid/all-null fix, `export_models` (STATA) still crashed on a populated date field:

```
ValueError: Column `dob` cannot be exported.
```

A `DateField` comes back from `.values()` as `datetime.date` objects (object dtype). Since `dob` is populated, neither the uuid branch nor the all-null branch in `make_stata_safe` touched it, so raw `datetime.date` objects reached `to_stata`, which can't write them.

## Change

Extends `ModelsToFile.make_stata_safe()` with two more steps:
- **DateField** (`datetime.date`, object dtype) → `datetime64` via `pd.to_datetime`, so STATA writes proper dates. (`datetime.datetime` is a `date` subclass but arrives as `datetime64`, not object, so it isn't matched.)
- **Final fallback**: any column still `object` dtype → `string`. This catches the next would-be offenders (e.g. `datetime.time` from a `TimeField`, `Decimal`, mixed) so the export stops failing one model at a time.

Ordering: uuid → date → all-null→`""` → object-fallback→string. The all-null step still runs before the fallback so all-null columns become `""` (not all-`NA` string, which `to_stata` also rejects).

`ModelToDataframe` remains untouched — faithful dataframe for CSV/other consumers.

## Test

`test_request_archive_stata` now creates the subject with a populated `dob` and asserts it round-trips as a date. Verified the helper round-trips uuid + populated date + partial-null date + all-null date + `TimeField` + string via `to_stata`/`read_stata`.

`uv run --dev python runtests.py --tag=export` → 30 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)