### PR TITLE
fix(edc_metadata): keep flagged items excluded from manage-missing overview across visit_code filter

### DIFF
--- a/src/edc_metadata/tests/tests/test_manage_missing_excludes_flagged.py
+++ b/src/edc_metadata/tests/tests/test_manage_missing_excludes_flagged.py
@@ -8,6 +8,7 @@ from clinicedc_tests.visit_schedules.visit_schedule_metadata.visit_schedule impo
     get_visit_schedule,
 )
 from django.test import TestCase, override_settings, tag
+from django.test.client import RequestFactory
 
 from edc_consent import site_consents
 from edc_facility.import_holidays import import_holidays
@@ -19,6 +20,7 @@ from edc_metadata.models import (
     DataMissingReason,
 )
 from edc_metadata.views import ManageMissingView
+from edc_metadata.views.manage_missing import visit_columns
 from edc_visit_schedule.site_visit_schedules import site_visit_schedules
 
 utc_tz = ZoneInfo("UTC")
@@ -97,3 +99,56 @@ class TestManageMissingExcludesFlagged(TestCase):
             self.baseline
         ]
         self.assertEqual(cols_after, cols_before - 1)
+
+    def test_flagged_ids_scoped_to_other_visit_code_misses_the_flag(self):
+        """Documents the trap: a visit_code-scoped base misses flags at other
+        visits, which is why the all-visits overview must not scope by it."""
+        flagged_crf = self._flag_one()
+        other_base = ManageMissingView.base_filter(
+            [10], self.vsn, self.sn, "not_the_flagged_visit", None
+        )
+        # scoped to a different visit_code -> the flag is not resolved
+        self.assertEqual(
+            ManageMissingView._flagged_ids(CrfMetadata, CrfMetadataMissing, other_base),
+            set(),
+        )
+        # dropping visit_code (as the overview lens now does) resolves it again
+        unscoped = {k: v for k, v in other_base.items() if k != "visit_code"}
+        flagged = ManageMissingView._flagged_ids(CrfMetadata, CrfMetadataMissing, unscoped)
+        self.assertEqual(flagged, {flagged_crf.id})
+
+    def test_overview_hides_flagged_despite_differing_visit_code_filter(self):
+        """Regression: with a visit_code filter that differs from the flag's
+        visit, the flagged CRF must still drop out of the overview totals."""
+        flagged_crf = self._flag_one()
+        model_label = flagged_crf.model
+        columns = visit_columns(self.vsn, self.sn)
+        visit_index = [code for code, _ in columns].index(self.baseline)
+
+        view = ManageMissingView()
+        # empty `site` param -> selected_site_value() returns "" without needing
+        # request.site, which RequestFactory does not populate.
+        view.request = RequestFactory().get("/review/?site=")
+
+        def _cell_count(exclude_ids):
+            overview = view.overview(
+                [10], self.vsn, self.sn, [model_label], columns, exclude_ids=exclude_ids
+            )
+            row = next((r for r in overview if r["model"] == model_label), None)
+            return 0 if row is None else row["cells"][visit_index]["count"]
+
+        # buggy scope (visit_code carried into the exclude) leaves it visible ...
+        scoped_base = ManageMissingView.base_filter(
+            [10], self.vsn, self.sn, "not_the_flagged_visit", None
+        )
+        scoped_exclude = ManageMissingView._flagged_ids(
+            CrfMetadata, CrfMetadataMissing, scoped_base
+        )
+        self.assertEqual(_cell_count(scoped_exclude), 1)
+
+        # ... the fixed scope (no visit_code) hides it
+        unscoped = {k: v for k, v in scoped_base.items() if k != "visit_code"}
+        fixed_exclude = ManageMissingView._flagged_ids(
+            CrfMetadata, CrfMetadataMissing, unscoped
+        )
+        self.assertEqual(_cell_count(fixed_exclude), 0)

--- a/src/edc_metadata/views/manage_missing/manage_missing_view.py
+++ b/src/edc_metadata/views/manage_missing/manage_missing_view.py
@@ -168,13 +168,27 @@ class ManageMissingView(
         # muddied by unrelated requisitions.
         crf_only = bool(models)
 
-        # items flagged "data unavailable" drop out of the outstanding counts
-        crf_exclude = self._flagged_ids(CrfMetadata, CrfMetadataMissing, crf_base)
+        # items flagged "data unavailable" drop out of the outstanding counts.
+        # The overview lens is an all-visits leaderboard and ignores visit_code in
+        # its counts, so its exclude set must ignore visit_code too. Otherwise a
+        # visit_code filter that differs from a flag's visit narrows the exclude
+        # set away from the flagged rows and they reappear in the overview totals.
+        # The grid lens narrows counts by visit_code, so it keeps it.
+        if self.lens() == "overview":
+            crf_exclude_base = {k: v for k, v in crf_base.items() if k != "visit_code"}
+            req_exclude_base = {k: v for k, v in req_base.items() if k != "visit_code"}
+        else:
+            crf_exclude_base = crf_base
+            req_exclude_base = req_base
+        crf_exclude = self._flagged_ids(CrfMetadata, CrfMetadataMissing, crf_exclude_base)
         req_exclude = (
             set()
             if crf_only
             else self._flagged_ids(
-                RequisitionMetadata, RequisitionMetadataMissing, req_base, panel=True
+                RequisitionMetadata,
+                RequisitionMetadataMissing,
+                req_exclude_base,
+                panel=True,
             )
         )
 


### PR DESCRIPTION
## Problem

In the manage-missing **Overview** lens, CRFs/requisitions flagged "data unavailable" (with a reason) reappear in the totals when a `visit_code` filter is applied whose value differs from the flag's visit.

**Repro:** flag 4 CRFs at visit 1000 with a reason → filter `CRFs=[Next appointment]`, `visit_code` blank → the 4 are correctly hidden. Change `visit_code` to 1005 → the 4 reappear under 1000. Drilling into that cell shows the grid (correctly) empty.

## Root cause

The Overview lens is an all-visits leaderboard: its counts intentionally ignore `visit_code`. But the flagged-exclusion set (`crf_exclude`/`req_exclude`) was computed from `crf_base`, which *does* carry `visit_code`. `_flagged_ids` narrows both the flag lookup and the final match by that `visit_code`, so with `visit_code=1005` the flags at 1000 fall outside the exclude set and the Overview (counting all visits) has nothing to subtract. `visit_code` was the only filter present in `crf_base` but absent from `overview()`'s scope — that asymmetry is the bug.

## Fix

Compute the Overview's exclude set without `visit_code` so its scope matches the counts it applies to. The **grid** lens keeps `visit_code`, since its counts do narrow by it.

## Tests

- `test_flagged_ids_scoped_to_other_visit_code_misses_the_flag` — documents the scoping trap.
- `test_overview_hides_flagged_despite_differing_visit_code_filter` — the exact repro: asserts the old scoped exclude leaves the cell at 1 and the fixed unscoped exclude drops it to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)