### PR TITLE
feat(edc_metadata): add "due on or before" filter to manage-missing

### DIFF
--- a/src/edc_metadata/templates/edc_metadata/manage_missing.html
+++ b/src/edc_metadata/templates/edc_metadata/manage_missing.html
@@ -129,6 +129,21 @@
             </div>
           </div>
         </div>
+
+        <div class="row">
+          <div class="col-sm-3">
+            <div class="form-group">
+              <label class="control-label">Due on or before</label>
+              <input type="date" name="due_to" class="form-control input-sm" value="{{ selected_due_to }}">
+            </div>
+          </div>
+          <div class="col-sm-9">
+            <p class="help-block" style="margin-top:26px;">
+              Filter to CRFs/requisitions due on or before this date. Leave blank to ignore
+              the due date. Forms with no due date are excluded when a date is set.
+            </p>
+          </div>
+        </div>
       </form>
 
       {# ---- saved filters (above Apply) ---- #}
@@ -179,8 +194,8 @@
         }
         function clearFilters() {
           var ff = document.getElementById('filter-form');
-          // text inputs -> empty
-          Array.prototype.forEach.call(ff.querySelectorAll('input[type="text"]'), function (el) {
+          // text and date inputs -> empty
+          Array.prototype.forEach.call(ff.querySelectorAll('input[type="text"], input[type="date"]'), function (el) {
             el.value = '';
           });
           // single selects -> first option; multi-select -> deselect all
@@ -206,7 +221,7 @@
           var ff = document.getElementById('filter-form');
           var p = new URLSearchParams();
           p.set('site', ff.elements['site'] ? ff.elements['site'].value : '');
-          ['schedule', 'visit_code', 'visit_type', 'q'].forEach(function (n) {
+          ['schedule', 'visit_code', 'visit_type', 'due_to', 'q'].forEach(function (n) {
             var el = ff.elements[n];
             if (el && el.value) { p.set(n, el.value); }
           });

--- a/src/edc_metadata/tests/tests/test_manage_missing.py
+++ b/src/edc_metadata/tests/tests/test_manage_missing.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 from zoneinfo import ZoneInfo
 
 import time_machine
@@ -17,6 +17,7 @@ from edc_lab.models.panel import Panel
 from edc_metadata.constants import KEYED, REQUIRED
 from edc_metadata.models import CrfMetadata, RequisitionMetadata
 from edc_metadata.views.manage_missing import ManageMissingView, visit_columns
+from edc_metadata.views.manage_missing.manage_missing_view import due_datetime_filter
 from edc_visit_schedule.site_visit_schedules import site_visit_schedules
 
 utc_tz = ZoneInfo("UTC")
@@ -75,6 +76,60 @@ class TestManageMissing(TestCase):
         opts = ManageMissingView.base_filter([10], self.vsn, self.sn, self.baseline, "105")
         self.assertEqual(opts["visit_code"], self.baseline)
         self.assertEqual(opts["subject_identifier__icontains"], "105")
+
+    # -------------------------------------------------------- due_datetime_filter
+    def test_due_datetime_filter_blank_is_excluded(self):
+        # empty/None -> field not filtered at all
+        self.assertEqual(due_datetime_filter(""), {})
+        self.assertEqual(due_datetime_filter(None), {})
+
+    def test_due_datetime_filter_ignores_unparsable(self):
+        self.assertEqual(due_datetime_filter("not-a-date"), {})
+
+    def test_due_datetime_filter_bound_is_inclusive(self):
+        opts = due_datetime_filter("2019-08-31")
+        # upper bound is exclusive next-day-midnight so the whole to-date is kept
+        self.assertEqual(list(opts), ["due_datetime__lt"])
+        self.assertEqual(opts["due_datetime__lt"].date(), date(2019, 9, 1))
+        self.assertEqual(
+            (opts["due_datetime__lt"].hour, opts["due_datetime__lt"].minute), (0, 0)
+        )
+
+    def test_base_filter_includes_due_bound(self):
+        opts = ManageMissingView.base_filter(
+            [10], self.vsn, self.sn, None, None, due_to="2019-08-31"
+        )
+        self.assertIn("due_datetime__lt", opts)
+
+    def test_due_bound_narrows_and_excludes_nulls(self):
+        # give a couple of records an in-range due date, leave the rest NULL
+        sid = self.subject_identifier
+        qs = CrfMetadata.objects.filter(
+            entry_status=REQUIRED, site_id=10, subject_identifier=sid
+        )
+        pks = list(qs.values_list("pk", flat=True))
+        self.assertGreater(len(pks), 2)
+        in_range = datetime(2019, 8, 15, 12, 0, tzinfo=utc_tz)
+        CrfMetadata.objects.filter(pk__in=pks[:2]).update(due_datetime=in_range)
+        CrfMetadata.objects.filter(pk__in=pks[2:]).update(due_datetime=None)
+
+        base = ManageMissingView.base_filter(
+            [10], self.vsn, self.sn, None, sid, due_to="2019-08-31"
+        )
+        totals = ManageMissingView._subject_totals(CrfMetadata, base)
+        # only the two due-on-or-before (non-null) records survive; nulls excluded
+        self.assertEqual(totals[sid], 2)
+
+    def test_due_bound_before_window_returns_nothing(self):
+        sid = self.subject_identifier
+        CrfMetadata.objects.filter(
+            entry_status=REQUIRED, site_id=10, subject_identifier=sid
+        ).update(due_datetime=datetime(2019, 8, 15, 12, 0, tzinfo=utc_tz))
+        base = ManageMissingView.base_filter(
+            [10], self.vsn, self.sn, None, sid, due_to="2019-08-01"
+        )
+        totals = ManageMissingView._subject_totals(CrfMetadata, base)
+        self.assertNotIn(sid, totals)
 
     # ----------------------------------------------------------- count helpers
     def test_subject_totals_count_required_only(self):

--- a/src/edc_metadata/views/manage_missing/export_overview_view.py
+++ b/src/edc_metadata/views/manage_missing/export_overview_view.py
@@ -26,12 +26,14 @@ class ExportOverviewView(ManageMissingView):
         columns = visit_columns(visit_schedule_name, schedule_name)
         models = self.selected_models()
         subject_identifier = self.request.GET.get("q", "").strip()
+        due_to = self.selected_due_to()
         crf_base = self.base_filter(
             site_ids,
             visit_schedule_name,
             schedule_name,
             self.request.GET.get("visit_code") or None,
             subject_identifier,
+            due_to=due_to,
         )
         if models:
             crf_base["model__in"] = models
@@ -44,6 +46,7 @@ class ExportOverviewView(ManageMissingView):
             columns,
             subject_identifier,
             crf_exclude,
+            due_to=due_to,
         )
         return self._xlsx(overview, columns, schedule_name)
 

--- a/src/edc_metadata/views/manage_missing/manage_missing_view.py
+++ b/src/edc_metadata/views/manage_missing/manage_missing_view.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, time, timedelta
 from urllib.parse import parse_qsl, urlencode
 
 from django.apps import apps as django_apps
@@ -9,6 +10,8 @@ from django.contrib.sites.models import Site
 from django.core.paginator import Paginator
 from django.db.models import Count, Q
 from django.urls import reverse
+from django.utils import timezone
+from django.utils.dateparse import parse_date
 from django.views.generic.base import TemplateView
 
 from edc_dashboard.view_mixins import EdcViewMixin
@@ -97,6 +100,29 @@ def visit_type_filter(visit_type: str | None) -> dict:
     return {}
 
 
+def _aware_start_of_day(d) -> datetime:
+    """Midnight of `d` as an aware datetime in the current timezone."""
+    return timezone.make_aware(
+        datetime.combine(d, time.min), timezone.get_current_timezone()
+    )
+
+
+def due_datetime_filter(due_to: str | None) -> dict:
+    """Queryset fragment narrowing to items due on or before ``due_to``.
+
+    ``due_to`` is a ``YYYY-MM-DD`` string (or empty). The bound is expressed as
+    an aware datetime so the ``due_datetime`` index is used (no ``__date`` wrap),
+    inclusive of the whole day via ``__lt`` next-day-midnight.
+
+    An active bound compares against ``due_datetime`` and so excludes rows where
+    it is NULL. An empty/unparsable value excludes the field from the filter.
+    """
+    d = parse_date(due_to) if due_to else None
+    if not d:
+        return {}
+    return {"due_datetime__lt": _aware_start_of_day(d + timedelta(days=1))}
+
+
 class ManageMissingView(
     PermissionRequiredMixin,
     AllowedSitesViewMixin,
@@ -141,6 +167,7 @@ class ManageMissingView(
         visit_code = self.request.GET.get("visit_code") or None
         subject_identifier = self.request.GET.get("subject_identifier", "").strip()
         visit_type = self.selected_visit_type()
+        due_to = self.selected_due_to()
 
         crf_base = self.base_filter(
             site_ids,
@@ -149,6 +176,7 @@ class ManageMissingView(
             visit_code,
             subject_identifier,
             visit_type,
+            due_to,
         )
         if models:
             crf_base["model__in"] = models
@@ -161,6 +189,7 @@ class ManageMissingView(
             visit_code,
             subject_identifier,
             visit_type,
+            due_to,
         )
 
         # When CRFs are selected the view is CRF-focused: requisitions are
@@ -200,6 +229,7 @@ class ManageMissingView(
             selected_models=models or [],
             selected_visit_code=visit_code or "",
             selected_visit_type=visit_type,
+            selected_due_to=due_to,
             subject_identifier=subject_identifier,
             crf_only=crf_only,
             unavailable_count=len(crf_exclude) + len(req_exclude),
@@ -232,6 +262,7 @@ class ManageMissingView(
                     subject_identifier,
                     crf_exclude,
                     visit_type,
+                    due_to,
                 )
             )
         return kwargs
@@ -253,6 +284,21 @@ class ManageMissingView(
         """"scheduled"/"unscheduled", or "" (all)."""
         value = self.request.GET.get("visit_type")
         return value if value in ("scheduled", "unscheduled") else ""
+
+    def _selected_date(self, key: str) -> str:
+        """Normalised ISO ``YYYY-MM-DD`` for a date param, or "" (excluded).
+
+        Round-tripping through ``parse_date`` drops unparsable input so a bad
+        value clears the field rather than propagating into the filter or the
+        saved-filter querystring.
+        """
+        raw = self.request.GET.get(key, "").strip()
+        d = parse_date(raw) if raw else None
+        return d.isoformat() if d else ""
+
+    def selected_due_to(self) -> str:
+        """Inclusive upper bound (ISO date) for ``due_datetime``, or "" (all)."""
+        return self._selected_date("due_to")
 
     def selected_schedule(self) -> tuple[str | None, str | None]:
         choices = schedule_choices()
@@ -295,6 +341,7 @@ class ManageMissingView(
         visit_code,
         subject_identifier=None,
         visit_type=None,
+        due_to=None,
     ) -> dict:
         opts = dict(
             entry_status=REQUIRED,
@@ -307,6 +354,7 @@ class ManageMissingView(
         if subject_identifier:
             opts["subject_identifier__icontains"] = subject_identifier
         opts.update(visit_type_filter(visit_type))
+        opts.update(due_datetime_filter(due_to))
         return opts
 
     # ------------------------------------------------------------------ queries
@@ -479,6 +527,7 @@ class ManageMissingView(
         subject_identifier=None,
         exclude_ids=None,
         visit_type=None,
+        due_to=None,
     ) -> list[dict]:
         opts = dict(
             entry_status=REQUIRED,
@@ -491,6 +540,7 @@ class ManageMissingView(
         if subject_identifier:
             opts["subject_identifier__icontains"] = subject_identifier
         opts.update(visit_type_filter(visit_type))
+        opts.update(due_datetime_filter(due_to))
         qs = CrfMetadata.objects.filter(**opts)
         if exclude_ids:
             qs = qs.exclude(id__in=exclude_ids)
@@ -528,6 +578,8 @@ class ManageMissingView(
                     handoff_params.append(("subject_identifier", subject_identifier))
                 if visit_type:
                     handoff_params.append(("visit_type", visit_type))
+                if due_to:
+                    handoff_params.append(("due_to", due_to))
                 handoff = "?" + urlencode(handoff_params)
                 cells.append(dict(count=count, url=handoff if count else None))
             overview.append(
@@ -553,5 +605,9 @@ class ManageMissingView(
             for key in ("schedule", "visit_code", "visit_type", "q")
             if get.get(key)
         ]
+        # normalise the date bound (drop unparsable values) so links and saved
+        # filters carry only a valid date.
+        if self.selected_due_to():
+            params.append(("due_to", self.selected_due_to()))
         params += [("models", model) for model in get.getlist("models") if model]
         return urlencode(params)


### PR DESCRIPTION
## Summary

Adds an optional **due date** filter ("Due on or before") to the manage-missing review board, applied to both `CrfMetadata` and `RequisitionMetadata`.

- **Blank = excluded** (no due-date narrowing), matching the existing `visit_type` filter pattern.
- The bound is **inclusive of the whole selected day** and expressed as an aware datetime (`due_datetime__lt` next-day-midnight) so the existing `due_datetime` index is used — no `__date` wrap (MySQL-friendly).
- Rows with a **NULL `due_datetime` are excluded** when a date is set (a date comparison can't match NULL).
- Carried through the grid and overview lenses, the xlsx export, saved filters (`clearFilters`/`syncSaveQuery`), and drill-down handoff links.

No model changes, so no migration required.

## UI

A single `Due on or before` date input in the Filters panel.

## Tests

`test_manage_missing.py`: blank/unparsable → excluded; inclusive next-day bound; `base_filter` inclusion; plus queryset tests for due-bound narrowing that excludes NULLs and a before-window case returning nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)