### PR TITLE
fix(edc_lab_results): use a registered panel in visit-link test

### DIFF
--- a/src/edc_lab_results/tests/tests/test_link_order_to_visit.py
+++ b/src/edc_lab_results/tests/tests/test_link_order_to_visit.py
@@ -96,9 +96,9 @@ class TestLinkOrderToVisit(TestCase):
         self.assertEqual(result.requisition_match_category, NO_MATCH)
 
     def test_no_link_when_requisition_panel_differs(self):
-        # a requisition exists at the visit, but for a different panel
-        other_panel = Panel.objects.exclude(name="fbc").first()
-        self._create_requisition(panel_name=other_panel.name)
+        # a requisition exists at the visit, but for a different panel that is
+        # registered in this lab_profile (blood_glucose, not fbc)
+        self._create_requisition(panel_name="blood_glucose")
         self._create_result(utest_id="haemoglobin")  # haemoglobin is only on fbc
 
         self.assertEqual(self._link(), 0)


### PR DESCRIPTION
test_no_link_when_requisition_panel_differs grabbed an arbitrary non-fbc
Panel via Panel.objects.exclude(name="fbc").first(), which could return a
panel (e.g. CD4) not registered in the test lab_profile — saving a
SubjectRequisition with it raised PanelModelError. Use blood_glucose, a
panel registered in the test lab_profile whose utest_ids exclude haemoglobin.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
